### PR TITLE
Add required headers in plugin

### DIFF
--- a/src/bp-loader.php
+++ b/src/bp-loader.php
@@ -19,6 +19,8 @@
  * Text Domain: buddypress
  * Domain Path: /bp-languages/
  * License:     GPLv2 or later (license.txt)
+ * Requires at least: 4.8
+ * Requires PHP: 5.6
  */
 
 /**


### PR DESCRIPTION
WordPress core supports these headers now, so a core project, we should add these headers.