### PR TITLE
Update class-bp-members-admin.php

### DIFF
--- a/src/bp-members/classes/class-bp-members-admin.php
+++ b/src/bp-members/classes/class-bp-members-admin.php
@@ -996,6 +996,11 @@ class BP_Members_Admin {
 		if ( ! bp_current_user_can( 'bp_moderate' ) && empty( $this->is_self_profile ) ) {
 			die( '-1' );
 		}
+		
+		// check for WP User Profiles plugin compatibility
+		if ( is_plugin_active( 'wp-user-profiles/wp-user-profiles.php' ) ) {
+			return;
+		} 
 
 		// Get the user ID.
 		$user_id = $this->get_user_id();


### PR DESCRIPTION
Adding this check to see if the WP User Profiles plugin is active allows for creating a new WP User Profile section that adds the BuddyPress Extended Profile tab to the User Profile navigation by using 'bp-profile-edit' for the section/id/slug/name. Happy to explain further if that isn't clear and also happy to hear if what I'm doing is crazy and I should not do it. Thanks! :)