### PR TITLE
Fix wrong LIMIT offset value

### DIFF
--- a/src/bp-notifications/classes/class-bp-notifications-notification.php
+++ b/src/bp-notifications/classes/class-bp-notifications-notification.php
@@ -482,7 +482,7 @@ class BP_Notifications_Notification {
 		if ( ! empty( $args['page'] ) && ! empty( $args['per_page'] ) ) {
 			$page     = absint( $args['page']     );
 			$per_page = absint( $args['per_page'] );
-			$offset   = $per_page * ( $page - 1 );
+			$offset   = $per_page * ( $page - 1 ) + 1;
 			$retval   = $wpdb->prepare( "LIMIT %d, %d", $offset, $per_page );
 		}
 


### PR DESCRIPTION
The current LIMIT offset calculator is wrong resulting in duplicate acitivty cards.
Possible related to https://buddypress.trac.wordpress.org/ticket/4535

<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Fix the correct formula to calculate the 'offset' value.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/4535
---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
