### PR TITLE
Added the missing erase data section in Export Data page - BP Legacy …

### DIFF
--- a/src/bp-templates/bp-legacy/buddypress/members/single/settings/data.php
+++ b/src/bp-templates/bp-legacy/buddypress/members/single/settings/data.php
@@ -83,6 +83,14 @@ do_action( 'bp_before_member_settings_template' ); ?>
 	</form>
 -->
 
+<p><?php esc_html_e( 'To erase all data associated with your account, your user account must be completely deleted.', 'buddypress' ); ?> 
+	<?php if ( bp_disable_account_deletion() ) : ?>
+		<?php esc_html_e( 'Please contact the site administrator to request account deletion.', 'buddypress' ); ?>
+	<?php else : ?>
+		<?php printf( esc_html__( 'You may delete your account by visiting the %s page.', 'buddypress' ), sprintf( '<a href="%s">%s</a>', bp_displayed_user_domain() . bp_get_settings_slug() . '/delete-account', esc_html__( 'Delete Account', 'buddypress' ) ) ); ?>
+	<?php endif; ?>
+</p>
+
 <?php
 
 /** This action is documented in bp-templates/bp-legacy/buddypress/members/single/settings/profile.php */


### PR DESCRIPTION
The legacy template for Data Export page was missing the erase data section at the bottom. Added the missing section from the Nouveau template

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8021

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
