### PR TITLE
fix: unread count not set for message threads (#8750)

### DIFF
--- a/tests/phpunit/testcases/messages/template.php
+++ b/tests/phpunit/testcases/messages/template.php
@@ -423,5 +423,21 @@ class BP_Tests_Messages_Template extends BP_UnitTestCase {
 		$this->assertCount( 2, $messages_template->threads[0]->messages );
 		$this->assertNotCount( 2, $messages_template->threads[0]->recipients );
 		$this->assertCount( 1, $messages_template->threads[0]->recipients );
+
+		// mark thread read by user 2
+		BP_Messages_Thread::mark_as_read( $message_1->thread_id, $u2 );
+
+		// test unread count for user 1
+		$messages_template = new BP_Messages_Box_Template(
+			array(
+				'user_id'             => $u1,
+				'messages_page'       => 1,
+				'messages_per_page'   => 2,
+				'recipients_page'     => 1,
+				'recipients_per_page' => 1,
+			)
+		);
+
+        $this->assertEquals( 2, $messages_template->threads[0]->unread_count );
 	}
 }


### PR DESCRIPTION
This fixes the unread_count property not always being set on message thread object when getting message threads for a user, particularly when 'recipients_per_page' and 'recipients_page' are provided within arguments.

<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

* `BP_Tests_Messages_Template` has been updated to catch potential failure.
* The `user_id` from arguments to `\BP_Messages_Thread::get_current_threads_for_user()` is now passed to `new BP_Messages_Thread()` for use when populating the thread.
* `\BP_Messages_Thread::get_unread_count()` method added and used within `populate()` 

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8750

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
