### PR TITLE
Remove the post link from `new_blog_post` activity action callback

### DIFF
--- a/src/bp-blogs/bp-blogs-activity.php
+++ b/src/bp-blogs/bp-blogs-activity.php
@@ -353,7 +353,7 @@ function bp_blogs_format_activity_action_new_blog_comment( $action, $activity ) 
 		restore_current_blog();
 
 		if ( ! empty( $comment ) && ! is_wp_error( $comment ) ) {
-			$action = apply_filters( 'bp_blogs_activity_new_comment_action', $action, $comment, $post_url . '#' . $activity->secondary_item_id );
+			$action = apply_filters_deprecated( 'bp_blogs_activity_new_comment_action', array( $action, $comment, $post_url . '#' . $activity->secondary_item_id ), '2.0.0', 'bp_blogs_format_activity_action_new_blog_comment' );
 		}
 	}
 

--- a/src/bp-blogs/bp-blogs-activity.php
+++ b/src/bp-blogs/bp-blogs-activity.php
@@ -115,17 +115,63 @@ function bp_blogs_register_post_tracking_args( $params = null, $post_type = 0 ) 
 add_filter( 'bp_activity_get_post_type_tracking_args', 'bp_blogs_register_post_tracking_args', 10, 2 );
 
 /**
+ * Returns the blog URL and name which relates to a post or comment activity.
+ *
+ * @since 11.0.0
+ *
+ * @param BP_Activity_Activity $activity The activity object.
+ * @return array The blog URL and name which relates to a post or comment activity.
+ */
+function bp_blogs_activity_get_site_link_meta( $activity = null ) {
+	$attributes = array(
+		'blog_url'  => '',
+		'blog_name' => '',
+	);
+
+	if ( ! isset( $activity->item_id, $activity->component ) || ! $activity->item_id || 'blogs' !== $activity->component ) {
+		return $attributes;
+	}
+
+	if ( isset( $activity->blog_url ) ) {
+		$attributes['blog_url'] = $activity->blog_url;
+	} else {
+		$blog_url = bp_blogs_get_blogmeta( $activity->item_id, 'url' );
+
+		if ( ! $blog_url ) {
+			$blog_url = get_home_url( $activity->item_id );
+			bp_blogs_update_blogmeta( $activity->item_id, 'url', $blog_url );
+		} else {
+			$attributes['blog_url'] = $blog_url;
+		}
+	}
+
+	if ( isset( $activity->blog_name ) ) {
+		$attributes['blog_name'] = $activity->blog_name;
+	} else {
+		$blog_name = bp_blogs_get_blogmeta( $activity->item_id, 'name' );
+
+		if ( ! $blog_name ) {
+			$blog_name = get_blog_option( $activity->item_id, 'blogname' );
+			bp_blogs_update_blogmeta( $activity->item_id, 'name', $blog_name );
+		} else {
+			$attributes['blog_name'] = $blog_name;
+		}
+	}
+
+	return $attributes;
+}
+
+/**
  * Format 'new_blog' activity actions.
  *
  * @since 2.0.0
  *
  * @param string $action   Static activity action.
  * @param object $activity Activity data object.
- * @return string
+ * @return string Constructed activity action.
  */
 function bp_blogs_format_activity_action_new_blog( $action, $activity ) {
-	$blog_url  = bp_blogs_get_blogmeta( $activity->item_id, 'url' );
-	$blog_name = bp_blogs_get_blogmeta( $activity->item_id, 'name' );
+	list( $blog_url, $blog_name ) = array_values( bp_blogs_activity_get_site_link_meta( $activity ) );
 
 	$action = sprintf(
 		/* translators: 1: the activity user link. 2: the blog link. */
@@ -142,7 +188,8 @@ function bp_blogs_format_activity_action_new_blog( $action, $activity ) {
 		}
 
 		if ( isset( $recorded_blog ) ) {
-			$action = apply_filters( 'bp_blogs_activity_created_blog_action', $action, $recorded_blog, $blog_name, bp_blogs_get_blogmeta( $activity->item_id, 'description' ) );
+			$blog_description = bp_blogs_get_blogmeta( $activity->item_id, 'description' );
+			$action           = apply_filters_deprecated( 'bp_blogs_activity_created_blog_action', array( $action, $recorded_blog, $blog_name, $blog_description ), '2.0.0', 'bp_blogs_format_activity_action_new_blog' );
 		}
 	}
 
@@ -167,93 +214,23 @@ function bp_blogs_format_activity_action_new_blog( $action, $activity ) {
  * @return string Constructed activity action.
  */
 function bp_blogs_format_activity_action_new_blog_post( $action, $activity ) {
-	$blog_url  = bp_blogs_get_blogmeta( $activity->item_id, 'url' );
-	$blog_name = bp_blogs_get_blogmeta( $activity->item_id, 'name' );
-
-	if ( empty( $blog_url ) || empty( $blog_name ) ) {
-		$blog_url  = get_home_url( $activity->item_id );
-		$blog_name = get_blog_option( $activity->item_id, 'blogname' );
-
-		bp_blogs_update_blogmeta( $activity->item_id, 'url', $blog_url );
-		bp_blogs_update_blogmeta( $activity->item_id, 'name', $blog_name );
-	}
-
-	/**
-	 * When the post is published we are faking an activity object
-	 * to which we add 2 properties :
-	 * - the post url
-	 * - the post title
-	 * This is done to build the 'post link' part of the activity
-	 * action string.
-	 * NB: in this case the activity has not yet been created.
-	 */
-	if ( isset( $activity->post_url ) ) {
-		$post_url = $activity->post_url;
-
-	/**
-	 * The post_url property is not set, we need to build the url
-	 * thanks to the post id which is also saved as the secondary
-	 * item id property of the activity object.
-	 */
-	} else {
-		$post_url = add_query_arg( 'p', $activity->secondary_item_id, trailingslashit( $blog_url ) );
-	}
-
-	// Should be the case when the post has just been published.
-	if ( isset( $activity->post_title ) ) {
-		$post_title = $activity->post_title;
-
-	// If activity already exists try to get the post title from activity meta.
-	} else if ( ! empty( $activity->id ) ) {
-		$post_title = bp_activity_get_meta( $activity->id, 'post_title' );
-	}
-
-	/**
-	 * In case the post was published without a title
-	 * or the activity meta was not found.
-	 */
-	if ( empty( $post_title ) ) {
-		// Defaults to no title.
-		$post_title = __( '(no title)', 'buddypress' );
-
-		switch_to_blog( $activity->item_id );
-
-		$post = get_post( $activity->secondary_item_id );
-		if ( is_a( $post, 'WP_Post' ) ) {
-			// Does the post have a title ?
-			if ( ! empty( $post->post_title ) ) {
-				$post_title = $post->post_title;
-			}
-
-			// Make sure the activity exists before saving the post title in activity meta.
-			if ( ! empty( $activity->id ) ) {
-				bp_activity_update_meta( $activity->id, 'post_title', $post_title );
-			}
-		}
-
-		restore_current_blog();
-	}
-
-	// Build the 'post link' part of the activity action string.
-	$post_link = '<a href="' . esc_url( $post_url ) . '">' . esc_html( $post_title ) . '</a>';
-
 	$user_link = bp_core_get_userlink( $activity->user_id );
 
 	// Build the complete activity action string.
 	if ( is_multisite() ) {
+		list( $blog_url, $blog_name ) = array_values( bp_blogs_activity_get_site_link_meta( $activity ) );
+
 		$action = sprintf(
-			/* translators: 1: the activity user link. 2: the post link. 3: the blog link. */
-			esc_html_x( '%1$s wrote a new post, %2$s, on the site %3$s', '`new_blog_post` activity action', 'buddypress' ),
+			/* translators: 1: the activity user link. 2: the blog link. */
+			esc_html_x( '%1$s wrote a new post on the site %2$s', 'Multisite `new_blog_post` activity action', 'buddypress' ),
 			$user_link,
-			$post_link,
 			'<a href="' . esc_url( $blog_url ) . '">' . esc_html( $blog_name ) . '</a>'
 		);
 	} else {
 		$action = sprintf(
-			/* translators: 1: the activity user link. 2: the post link. */
-			esc_html_x( '%1$s wrote a new post, %2$s', '`new_blog_post` activity action', 'buddypress' ),
-			$user_link,
-			$post_link
+			/* translators: 1: the activity user link. */
+			esc_html_x( '%s wrote a new post', '`new_blog_post` activity action', 'buddypress' ),
+			$user_link
 		);
 	}
 
@@ -264,7 +241,8 @@ function bp_blogs_format_activity_action_new_blog_post( $action, $activity ) {
 		restore_current_blog();
 
 		if ( ! empty( $post ) && ! is_wp_error( $post ) ) {
-			$action = apply_filters( 'bp_blogs_activity_new_post_action', $action, $post, $post_url );
+			$post_url = add_query_arg( 'p', $post->ID, trailingslashit( get_home_url( $activity->item_id ) ) );
+			$action   = apply_filters_deprecated( 'bp_blogs_activity_new_post_action', array( $action, $post, $post_url ), '2.0.0', 'bp_blogs_format_activity_action_new_blog_post' );
 		}
 	}
 
@@ -300,34 +278,8 @@ function bp_blogs_format_activity_action_new_blog_comment( $action, $activity ) 
 	 * action string.
 	 * NB: in this case the activity has not yet been created.
 	 */
-
-	$blog_url = false;
-
-	// Try to get the blog url from the activity object.
-	if ( isset( $activity->blog_url ) ) {
-		$blog_url = $activity->blog_url;
-	} else {
-		$blog_url = bp_blogs_get_blogmeta( $activity->item_id, 'url' );
-	}
-
-	$blog_name = false;
-
-	// Try to get the blog name from the activity object.
-	if ( isset( $activity->blog_name ) ) {
-		$blog_name = $activity->blog_name;
-	} else {
-		$blog_name = bp_blogs_get_blogmeta( $activity->item_id, 'name' );
-	}
-
-	if ( empty( $blog_url ) || empty( $blog_name ) ) {
-		$blog_url  = get_home_url( $activity->item_id );
-		$blog_name = get_blog_option( $activity->item_id, 'blogname' );
-
-		bp_blogs_update_blogmeta( $activity->item_id, 'url', $blog_url );
-		bp_blogs_update_blogmeta( $activity->item_id, 'name', $blog_name );
-	}
-
-	$post_url = false;
+	list( $blog_url, $blog_name ) = array_values( bp_blogs_activity_get_site_link_meta( $activity ) );
+	$post_url                     = false;
 
 	// Try to get the post url from the activity object.
 	if ( isset( $activity->post_url ) ) {

--- a/src/bp-templates/bp-legacy/css/buddypress-rtl.css
+++ b/src/bp-templates/bp-legacy/css/buddypress-rtl.css
@@ -332,6 +332,7 @@ body.activity-permalink #buddypress .activity-list li .activity-header > p {
 }
 
 #buddypress .activity-list li.new_blog_post .activity-content .activity-inner img {
+	max-width: 100%;
 	float: right;
 	margin-left: 0.8em;
 }

--- a/src/bp-templates/bp-legacy/css/buddypress.css
+++ b/src/bp-templates/bp-legacy/css/buddypress.css
@@ -332,6 +332,7 @@ body.activity-permalink #buddypress .activity-list li .activity-header > p {
 }
 
 #buddypress .activity-list li.new_blog_post .activity-content .activity-inner img {
+	max-width: 100%;
 	float: left;
 	margin-right: 0.8em;
 }

--- a/src/bp-templates/bp-nouveau/common-styles/_bp_activity_entries.scss
+++ b/src/bp-templates/bp-nouveau/common-styles/_bp_activity_entries.scss
@@ -100,6 +100,7 @@
 				}
 
 				img {
+					max-width: 100%;
 					float: left;
 					margin-right: 0.8em;
 				}

--- a/src/bp-templates/bp-nouveau/css/buddypress-rtl.css
+++ b/src/bp-templates/bp-nouveau/css/buddypress-rtl.css
@@ -1312,6 +1312,7 @@ body.buddypress article.page > .entry-header:not(.alignwide):not(.alignfull) .en
 }
 
 .activity-list .activity-item.new_blog_post .activity-inner img {
+	max-width: 100%;
 	float: right;
 	margin-left: 0.8em;
 }

--- a/src/bp-templates/bp-nouveau/css/buddypress.css
+++ b/src/bp-templates/bp-nouveau/css/buddypress.css
@@ -1312,6 +1312,7 @@ body.buddypress article.page > .entry-header:not(.alignwide):not(.alignfull) .en
 }
 
 .activity-list .activity-item.new_blog_post .activity-inner img {
+	max-width: 100%;
 	float: left;
 	margin-right: 0.8em;
 }

--- a/tests/phpunit/testcases/blogs/activity.php
+++ b/tests/phpunit/testcases/blogs/activity.php
@@ -103,11 +103,8 @@ class BP_Tests_Blogs_Activity extends BP_UnitTestCase {
 
 		$user_link = bp_core_get_userlink( $u );
 		$blog_url = get_home_url();
-		$post_url = add_query_arg( 'p', $p, trailingslashit( $blog_url ) );
-		$post_title = bp_activity_get_meta( $a, 'post_title' );
-		$post_link = '<a href="' . $post_url . '">' . $post_title . '</a>';
 
-		$expected = sprintf( '%s wrote a new post, %s, on the site %s', $user_link, $post_link, '<a href="' . $blog_url . '">' . bp_blogs_get_blogmeta( $a_obj->item_id, 'name' ) . '</a>' );
+		$expected = sprintf( '%s wrote a new post on the site %s', $user_link, '<a href="' . $blog_url . '">' . bp_blogs_get_blogmeta( $a_obj->item_id, 'name' ) . '</a>' );
 
 		$this->assertSame( $expected, $a_obj->action );
 	}
@@ -143,11 +140,8 @@ class BP_Tests_Blogs_Activity extends BP_UnitTestCase {
 
 		$user_link = bp_core_get_userlink( $u );
 		$blog_url = get_blog_option( $a_obj->item_id, 'home' );
-		$post_url = add_query_arg( 'p', $p, trailingslashit( $blog_url ) );
-		$post_title = $p_obj->post_title;
-		$post_link = '<a href="' . $post_url . '">' . $post_title . '</a>';
 
-		$expected = sprintf( '%s wrote a new post, %s, on the site %s', $user_link, $post_link, '<a href="' . $blog_url . '">' . get_blog_option( $a_obj->item_id, 'blogname' ) . '</a>' );
+		$expected = sprintf( '%s wrote a new post on the site %s', $user_link, '<a href="' . $blog_url . '">' . get_blog_option( $a_obj->item_id, 'blogname' ) . '</a>' );
 
 		$this->assertSame( $expected, $a_obj->action );
 	}
@@ -195,93 +189,6 @@ class BP_Tests_Blogs_Activity extends BP_UnitTestCase {
 		$expected = sprintf( '%s commented on the post, %s, on the site %s', $user_link, $post_link, '<a href="' . $blog_url . '">' . get_blog_option( $a_obj->item_id, 'blogname' ) . '</a>' );
 
 		$this->assertSame( $expected, $a_obj->action );
-	}
-
-	/**
-	 * @group bp_blogs_format_activity_action_new_blog
-	 */
-	public function test_bp_activity_format_activity_action_new_blog_backpat() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped();
-		}
-
-		add_filter( 'bp_blogs_activity_created_blog_action', array( $this, 'created_blog_passthrough' ), 10, 2 );
-
-		$b = self::factory()->blog->create();
-		$u = self::factory()->user->create();
-
-		$recorded_blog          = new BP_Blogs_Blog;
-		$recorded_blog->user_id = $u;
-		$recorded_blog->blog_id = $b;
-		$recorded_blog_id       = $recorded_blog->save();
-
-		$a = self::factory()->activity->create( array(
-			'component' => buddypress()->blogs->id,
-			'type' => 'new_blog',
-			'user_id' => $u,
-			'item_id' => $b,
-		) );
-
-		$this->assertEquals( $this->userblog_id, $recorded_blog_id );
-	}
-
-	/**
-	 * @group bp_blogs_format_activity_action_new_blog_post
-	 */
-	public function test_bp_activity_format_activity_action_new_blog_post_backpat() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped();
-		}
-
-		add_filter( 'bp_blogs_activity_new_post_action', array( $this, 'new_post_passthrough' ), 10, 2 );
-
-		$b = self::factory()->blog->create();
-
-		switch_to_blog( $b );
-		$p = self::factory()->post->create();
-		restore_current_blog();
-
-		$u = self::factory()->user->create();
-		$a = self::factory()->activity->create( array(
-			'component' => buddypress()->blogs->id,
-			'type' => 'new_blog_post',
-			'user_id' => $u,
-			'item_id' => $b,
-			'secondary_item_id' => $p,
-		) );
-
-		$this->assertEquals( $this->post_id, $p );
-	}
-
-	/**
-	 * @group bp_blogs_format_activity_action_new_blog_comment
-	 */
-	public function test_bp_activity_format_activity_action_new_blog_comment_backpat() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped();
-		}
-
-		add_filter( 'bp_blogs_activity_new_comment_action', array( $this, 'new_comment_passthrough' ), 10, 2 );
-
-		$b = self::factory()->blog->create();
-
-		switch_to_blog( $b );
-		$p = self::factory()->post->create();
-		$c = self::factory()->comment->create( array(
-			'comment_post_ID' => $p,
-		) );
-		restore_current_blog();
-
-		$u = self::factory()->user->create();
-		$a = self::factory()->activity->create( array(
-			'component' => buddypress()->blogs->id,
-			'type' => 'new_blog_comment',
-			'user_id' => $u,
-			'item_id' => $b,
-			'secondary_item_id' => $c,
-		) );
-
-		$this->assertEquals( $this->comment_post_id, $p );
 	}
 
 	/**

--- a/tests/phpunit/testcases/blogs/activity.php
+++ b/tests/phpunit/testcases/blogs/activity.php
@@ -73,12 +73,7 @@ class BP_Tests_Blogs_Activity extends BP_UnitTestCase {
 		$a_obj = new BP_Activity_Activity( $a );
 
 		$user_link = bp_core_get_userlink( $u );
-		$blog_url = get_home_url();
-		$post_url = add_query_arg( 'p', $p, trailingslashit( $blog_url ) );
-		$post_title = bp_activity_get_meta( $a, 'post_title' );
-		$post_link = '<a href="' . $post_url . '">' . $post_title . '</a>';
-
-		$expected = sprintf( '%s wrote a new post, %s', $user_link, $post_link );
+		$expected = sprintf( '%s wrote a new post', $user_link );
 
 		$this->assertSame( $expected, $a_obj->action );
 	}
@@ -388,99 +383,6 @@ class BP_Tests_Blogs_Activity extends BP_UnitTestCase {
 
 		$a_obj = new BP_Activity_Activity( $a );
 		$this->assertTrue( ! empty( $a_obj->action ) );
-
-	}
-
-	/**
-	 * @group activity_action
-	 * @group bp_blogs_format_activity_action_new_blog_post
-	 */
-	public function test_bp_blogs_format_activity_action_new_blog_post_no_title() {
-		if ( is_multisite() ) {
-			$this->markTestSkipped();
-		}
-
-		buddypress()->activity->actions = new stdClass();
-
-		$u = self::factory()->user->create();
-		$p = wp_insert_post( array(
-			'post_author' => $u,
-			'post_title'  => '', // no title: the object of the test
-			'post_status' => 'publish',
-			'post_content' => 'foo bar',
-		) );
-
-		$user_link = bp_core_get_userlink( $u );
-		$blog_url = get_home_url();
-		$post_url = add_query_arg( 'p', $p, trailingslashit( $blog_url ) );
-		$post_link = '<a href="' . $post_url . '">(no title)</a>';
-
-		// Set activity actions
-		bp_activity_get_actions();
-
-		$a_obj = bp_activity_get( array(
-			'item_id'           => 1,
-			'secondary_item_id' => $p,
-		) );
-
-		$expected = sprintf( '%s wrote a new post, %s', $user_link, $post_link );
-
-		$this->assertSame( $expected, $a_obj['activities'][0]->action );
-	}
-
-	/**
-	 * @group activity_action
-	 * @group bp_blogs_format_activity_action_new_blog_post
-	 */
-	public function test_bp_blogs_format_activity_action_new_blog_post_updated_without_title() {
-		if ( is_multisite() ) {
-			$this->markTestSkipped();
-		}
-
-		buddypress()->activity->actions = new stdClass();
-
-		$u = self::factory()->user->create();
-		$p = wp_insert_post( array(
-			'post_author' => $u,
-			'post_title'  => 'foo',
-			'post_status' => 'publish',
-			'post_content' => 'foo bar',
-		) );
-
-		$user_link  = bp_core_get_userlink( $u );
-		$blog_url   = get_home_url();
-		$post_url   = add_query_arg( 'p', $p, trailingslashit( $blog_url ) );
-		$post_title = get_the_title( $p );
-		$post_link  = '<a href="' . $post_url . '">' . $post_title . '</a>';
-
-		// Set actions
-		bp_activity_get_actions();
-
-		$a_obj = bp_activity_get( array(
-			'item_id'           => 1,
-			'secondary_item_id' => $p,
-		) );
-
-		$expected = sprintf( '%s wrote a new post, %s', $user_link, $post_link );
-
-		$this->assertSame( $expected, $a_obj['activities'][0]->action );
-
-		// Update the post by removing its title
-		wp_update_post( array(
-			'ID'         => $p,
-			'post_title' => '',
-		) );
-
-		// we now expect the (no title) post link
-		$post_link = '<a href="' . $post_url . '">(no title)</a>';
-		$expected = sprintf( '%s wrote a new post, %s', $user_link, $post_link );
-
-		$a_obj = bp_activity_get( array(
-			'item_id'           => 1,
-			'secondary_item_id' => $p,
-		) );
-
-		$this->assertSame( $expected, $a_obj['activities'][0]->action );
 	}
 
 	/**


### PR DESCRIPTION
Stop using the post link into the `new_blog_post` activity action.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8052

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
