### PR TITLE
Use the `blog_public` option to check whether to post an activity on blog creation

### DIFF
--- a/src/bp-blogs/bp-blogs-functions.php
+++ b/src/bp-blogs/bp-blogs-functions.php
@@ -350,12 +350,14 @@ function bp_blogs_is_blog_trackable( $blog_id, $user_id = 0 ) {
  */
 function bp_blogs_record_blog( $blog_id, $user_id, $no_activity = false ) {
 
-	if ( empty( $user_id ) )
+	if ( empty( $user_id ) ) {
 		$user_id = bp_loggedin_user_id();
+	}
 
 	// If blog is not recordable, do not record the activity.
-	if ( !bp_blogs_is_blog_recordable( $blog_id, $user_id ) )
+	if ( ! bp_blogs_is_blog_recordable( $blog_id, $user_id ) ) {
 		return false;
+	}
 
 	$name = get_blog_option( $blog_id, 'blogname' );
 	$url  = get_home_url( $blog_id );
@@ -381,7 +383,7 @@ function bp_blogs_record_blog( $blog_id, $user_id, $no_activity = false ) {
 	$recorded_blog->user_id = $user_id;
 	$recorded_blog->blog_id = $blog_id;
 	$recorded_blog_id       = $recorded_blog->save();
-	$is_recorded            = !empty( $recorded_blog_id ) ? true : false;
+	$is_recorded            = ! empty( $recorded_blog_id ) ? true : false;
 
 	bp_blogs_update_blogmeta( $recorded_blog->blog_id, 'url', $url );
 	bp_blogs_update_blogmeta( $recorded_blog->blog_id, 'name', $name );
@@ -392,8 +394,6 @@ function bp_blogs_record_blog( $blog_id, $user_id, $no_activity = false ) {
 	bp_blogs_update_blogmeta( $recorded_blog->blog_id, 'thread_comments_depth', $thread_depth );
 	bp_blogs_update_blogmeta( $recorded_blog->blog_id, 'comment_moderation', $moderation );
 
-	$is_private = !empty( $_POST['blog_public'] ) && (int) $_POST['blog_public'] ? false : true;
-
 	/**
 	 * Filters whether or not a new blog is public.
 	 *
@@ -401,7 +401,10 @@ function bp_blogs_record_blog( $blog_id, $user_id, $no_activity = false ) {
 	 *
 	 * @param bool $is_private Whether or not blog is public.
 	 */
-	$is_private = !apply_filters( 'bp_is_new_blog_public', !$is_private );
+	$is_private = ! apply_filters(
+		'bp_is_new_blog_public',
+		(bool) get_blog_option( $blog_id, 'blog_public' )
+	);
 
 	/**
 	 * Fires after BuddyPress has been made aware of a new site for activity tracking.

--- a/tests/phpunit/testcases/activity/functions.php
+++ b/tests/phpunit/testcases/activity/functions.php
@@ -855,10 +855,14 @@ Bar!';
 			$this->markTestSkipped();
 		}
 
-		$b = self::factory()->blog->create();
-		$u = self::factory()->user->create();
+		$bp    = buddypress();
+		$b     = self::factory()->blog->create();
+		$u     = self::factory()->user->create();
+		$reset = $bp->activity->track;
 
 		switch_to_blog( $b );
+
+		$bp->activity->track = array();
 
 		register_post_type( 'foo', array(
 			'label'   => 'foo',
@@ -883,12 +887,9 @@ Bar!';
 		);
 
 		_unregister_post_type( 'foo' );
-		bp_activity_get_actions();
-
 		restore_current_blog();
 
-		$a = self::factory()->activity->create( $activity_args );
-
+		$a     = self::factory()->activity->create( $activity_args );
 		$a_obj = new BP_Activity_Activity( $a );
 
 		$user_link = bp_core_get_userlink( $u );
@@ -898,6 +899,7 @@ Bar!';
 		$post_link = '<a href="' . $post_url . '">item</a>';
 
 		$expected = sprintf( '%s wrote a new %s, on the site %s', $user_link, $post_link, '<a href="' . $blog_url . '">' . get_blog_option( $a_obj->item_id, 'blogname' ) . '</a>' );
+		$bp->activity->track = $reset;
 
 		$this->assertSame( $expected, $a_obj->action );
 	}
@@ -967,10 +969,14 @@ Bar!';
 			$this->markTestSkipped();
 		}
 
-		$b = self::factory()->blog->create();
-		$u = self::factory()->user->create();
+		$bp = buddypress();
+		$b  = self::factory()->blog->create();
+		$u  = self::factory()->user->create();
+		$reset = $bp->activity->track;
 
 		switch_to_blog( $b );
+
+		$bp->activity->track = array();
 
 		$labels = array(
 			'name'                    => 'bars',
@@ -1009,10 +1015,11 @@ Bar!';
 		$a_obj = new BP_Activity_Activity( $a );
 
 		$user_link = bp_core_get_userlink( $u );
-		$blog_url = get_blog_option( $a_obj->item_id, 'home' );
-		$post_url = add_query_arg( 'p', $p, trailingslashit( $blog_url ) );
+		$blog_url  = get_blog_option( $a_obj->item_id, 'home' );
+		$post_url  = add_query_arg( 'p', $p, trailingslashit( $blog_url ) );
 
 		$expected = sprintf( '%1$s shared a new <a href="%2$s">bar</a>, on the site %3$s', $user_link, $post_url, '<a href="' . $blog_url . '">' . get_blog_option( $a_obj->item_id, 'blogname' ) . '</a>' );
+		$bp->activity->track = $reset;
 
 		$this->assertSame( $expected, $a_obj->action );
 	}
@@ -1097,9 +1104,15 @@ Bar!';
 	 * @group post_type_comment_activities
 	 */
 	public function test_bp_activity_format_activity_action_custom_post_type_comment() {
+		$bp    = buddypress();
+		$reset = $bp->activity->track;
+
 		if ( is_multisite() ) {
 			$b = self::factory()->blog->create();
+
 			switch_to_blog( $b );
+
+			$bp->activity->track = array();
 			add_filter( 'comment_flood_filter', '__return_false' );
 		} else {
 			$b = get_current_blog_id();
@@ -1159,6 +1172,8 @@ Bar!';
 			remove_filter( 'comment_flood_filter', '__return_false' );
 
 			$expected = sprintf( $labels['bp_activity_new_comment_ms'], $user_link, $comment_url, '<a href="' . $blog_url . '">' . get_blog_option( $a_obj->item_id, 'blogname' ) . '</a>' );
+
+			$bp->activity->track = $reset;
 		} else {
 			$expected = sprintf( $labels['bp_activity_new_comment'], $user_link, $comment_url );
 		}

--- a/tests/phpunit/testcases/blogs/functions.php
+++ b/tests/phpunit/testcases/blogs/functions.php
@@ -885,9 +885,15 @@ class BP_Tests_Blogs_Functions extends BP_UnitTestCase {
 	 * @group post_type_comment_activities
 	 */
 	public function test_bp_blogs_comment_sync_activity_comment_for_custom_post_type() {
+		$bp    = buddypress();
+		$reset = $bp->activity->track;
+
 		if ( is_multisite() ) {
 			$b = self::factory()->blog->create();
+
 			switch_to_blog( $b );
+
+			$bp->activity->track = array();
 			add_filter( 'comment_flood_filter', '__return_false' );
 		} else {
 			$b = get_current_blog_id();
@@ -970,6 +976,8 @@ class BP_Tests_Blogs_Functions extends BP_UnitTestCase {
 
 		if ( is_multisite() ) {
 			restore_current_blog();
+
+			$bp->activity->track = $reset;
 			remove_filter( 'comment_flood_filter', '__return_false' );
 		}
 


### PR DESCRIPTION
This makes sure adding a new "public" blog from the WP Admin will generate a `new_blog` activity. 

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8756

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
