### PR TITLE
Make sure clicking on the Activity Load more link does not load duplicates

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-activity.php
+++ b/src/bp-activity/classes/class-bp-activity-activity.php
@@ -1922,6 +1922,8 @@ class BP_Activity_Activity {
 	 *                                          'secondary_item_id' column in the database.
 	 *     @type int              $offset       Return only those items with an ID greater
 	 *                                          than the offset value.
+	 *     @type int              $offset_lower Return only those items with an ID lower
+	 *                                          than the offset value.
 	 *     @type string           $since        Return only those items that have a
 	 *                                          date_recorded value greater than a
 	 *                                          given MySQL-formatted date.
@@ -1965,6 +1967,11 @@ class BP_Activity_Activity {
 		if ( ! empty( $filter_array['offset'] ) ) {
 			$sid_sql = absint( $filter_array['offset'] );
 			$filter_sql[] = "a.id >= {$sid_sql}";
+		}
+
+		if ( ! empty( $filter_array['offset_lower'] ) ) {
+			$sid_sql = absint( $filter_array['offset_lower'] );
+			$filter_sql[] = "a.id < {$sid_sql}";
 		}
 
 		if ( ! empty( $filter_array['since'] ) ) {

--- a/src/bp-templates/bp-legacy/buddypress-functions.php
+++ b/src/bp-templates/bp-legacy/buddypress-functions.php
@@ -765,6 +765,10 @@ function bp_legacy_theme_ajax_querystring( $query_string, $object ) {
 		$qs[] = 'offset=' . intval( $_POST['offset'] );
 	}
 
+	if ( ! empty( $_POST['offset_lower'] ) ) {
+		$qs[] = 'offset_lower=' . intval( $_POST['offset_lower'] );
+	}
+
 	$object_search_text = bp_get_search_default_text( $object );
 	if ( ! empty( $_POST['search_terms'] ) && is_string( $_POST['search_terms'] ) && $object_search_text != $_POST['search_terms'] && 'false' != $_POST['search_terms'] && 'undefined' != $_POST['search_terms'] )
 		$qs[] = 'search_terms=' . urlencode( $_POST['search_terms'] );

--- a/src/bp-templates/bp-legacy/js/buddypress.js
+++ b/src/bp-templates/bp-legacy/js/buddypress.js
@@ -431,6 +431,9 @@ jq( function() {
 
 		/* Load more updates at the end of the page */
 		if ( target.parent().hasClass('load-more') ) {
+			var loadMoreLink = new URL( jq( target ).prop( 'href' ) ),
+				offsetLower = parseInt( loadMoreLink.searchParams.get( 'offset_lower' ), 10 ) || 0;
+
 			if ( bp_ajax_request ) {
 				bp_ajax_request.abort();
 			}
@@ -448,6 +451,7 @@ jq( function() {
 				action: 'activity_get_older_updates',
 				'cookie': bp_get_cookies(),
 				'page': oldest_page,
+				'offset_lower': offsetLower,
 				'exclude_just_posted': just_posted.join(',')
 			};
 

--- a/src/bp-templates/bp-nouveau/includes/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/functions.php
@@ -117,6 +117,10 @@ function bp_nouveau_ajax_querystring( $query_string, $object ) {
 		$qs[] = 'offset=' . intval( $post_query['offset'] );
 	}
 
+	if ( ! empty( $post_query['offset_lower'] ) ) {
+		$qs[] = 'offset_lower=' . intval( $post_query['offset_lower'] );
+	}
+
 	$object_search_text = bp_get_search_default_text( $object );
 	if ( ! empty( $post_query['search_terms'] ) && $object_search_text != $post_query['search_terms'] && 'false' != $post_query['search_terms'] && 'undefined' != $post_query['search_terms'] ) {
 		$qs[] = 'search_terms=' . urlencode( $_POST['search_terms'] );

--- a/src/bp-templates/bp-nouveau/js/buddypress-activity.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-activity.js
@@ -273,12 +273,14 @@ window.bp = window.bp || {};
 
 			// Load more activities
 			} else if ( $( event.currentTarget ).hasClass( 'load-more' ) ) {
-				var next_page = ( Number( this.current_page ) * 1 ) + 1, self = this, search_terms = '';
+				var next_page = ( Number( this.current_page ) * 1 ) + 1, self = this, search_terms = '',
+				    loadMoreLink = $( event.currentTarget ).children().first(),
+				    offsetLower  = loadMoreLink ? bp.Nouveau.getLinkParams( loadMoreLink.prop( 'href' ), 'offset_lower' ) : 0;
 
 				// Stop event propagation
 				event.preventDefault();
 
-				$( event.currentTarget ).find( 'a' ).first().addClass( 'loading' );
+				loadMoreLink.addClass( 'loading' );
 
 				// reset the just posted
 				this.just_posted = [];
@@ -300,6 +302,7 @@ window.bp = window.bp || {};
 					page                : next_page,
 					method              : 'append',
 					exclude_just_posted : this.just_posted.join( ',' ),
+					offset_lower        : offsetLower,
 					target              : '#buddypress [data-bp-list] ul.bp-list'
 				} ).done( function( response ) {
 					if ( true === response.success ) {


### PR DESCRIPTION
Introduces a new `offset_lower` parameter to only load activities having an ID lower than the provided `offset_lower` value. Using this parameter when clicking on the Load More link avoids loading possible duplicates if some activity were published by another user although the one clicking on the Load More link haven't refreshed the page yet.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/4535

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
