### PR TITLE
Use the right function to find out whether the theme is a block theme or not

### DIFF
--- a/src/bp-core/bp-core-template-loader.php
+++ b/src/bp-core/bp-core-template-loader.php
@@ -464,7 +464,7 @@ function bp_get_query_template( $type, $templates = array() ) {
 	 * The current theme is using the WordPress Full Site Editing feature.
 	 * BuddyPress then needs to use the WordPress template canvas to retrieve the community content.
 	 */
-	if ( current_theme_supports( 'block-templates' ) ) {
+	if ( bp_is_running_wp( '5.9.0', '>=' ) && wp_is_block_theme() ) {
 		$template = ABSPATH . WPINC . '/template-canvas.php';
 	}
 


### PR DESCRIPTION
Instead of checking whether a theme is supporting `block-templates` to find out whether the current theme is a Block (templates) based theme, use the `wp_is_block_theme()`

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8757

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
