### PR TITLE
Take in account inactive users added to a group by an Admin into the group members count

### DIFF
--- a/src/bp-groups/classes/class-bp-group-member-query.php
+++ b/src/bp-groups/classes/class-bp-group-member-query.php
@@ -547,6 +547,7 @@ class BP_Group_Member_Query extends BP_User_Query {
 	 * If a `count` query is performed, the function is used to validate active users.
 	 *
 	 * @since 10.3.0
+	 * @since 11.0.0 Include inactive users added by a community administrators to the group members count.
 	 */
 	public function populate_extras() {
 		if ( ! $this->query_vars_raw['count'] ) {
@@ -554,9 +555,13 @@ class BP_Group_Member_Query extends BP_User_Query {
 		}
 
 		// Validate active users.
-		$active_users    = array_filter( BP_Core_User::get_last_activity( $this->user_ids ) );
-		$active_user_ids = array_keys( $active_users );
-		$this->results   = array_intersect( $this->user_ids, $active_user_ids );
+		if ( ! bp_current_user_can( 'bp_moderate' ) ) {
+			$active_users    = array_filter( BP_Core_User::get_last_activity( $this->user_ids ) );
+			$active_user_ids = array_keys( $active_users );
+			$this->results   = array_intersect( $this->user_ids, $active_user_ids );
+		} else {
+			$this->results = $this->user_ids;
+		}
 
 		// Set the total active users.
 		$this->total_users = count( $this->results );

--- a/tests/phpunit/testcases/groups/functions.php
+++ b/tests/phpunit/testcases/groups/functions.php
@@ -366,6 +366,33 @@ class BP_Tests_Groups_Functions extends BP_UnitTestCase {
 
 	/**
 	 * @group total_member_count
+	 * @ticket BP7614
+	 */
+	public function test_total_member_count_groups_inactive_user_from_admin() {
+		$current_user = get_current_user_id();
+		$u1           = self::factory()->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		$u2           = wp_insert_user( array(
+			'user_pass'  => 'barfoo',
+			'user_login' => 'barfoo',
+			'user_email' => 'barfoo@buddypress.org',
+		) );
+
+		$this->set_current_user( $u1 );
+		$g1 = self::factory()->group->create();
+
+		groups_join_group( $g1, $u2 );
+
+		$this->assertEquals( 2, groups_get_total_member_count( $g1 ) );
+
+		$this->set_current_user( $current_user );
+	}
+
+	/**
+	 * @group total_member_count
 	 * @ticket BP8688
 	 */
 	public function test_total_member_count_groups_spammed_user() {


### PR DESCRIPTION
Adds a `bp_moderate` capability check before eventually remove inactive users from groups members count.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/7614

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
