### PR TITLE
Use a new constant to force all deprecated code to load

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -4741,8 +4741,15 @@ function bp_delete_optout_by_id( $id = 0 ) {
  */
 function bp_get_deprecated_functions_versions() {
 	$ignore_deprecated = null;
-	if ( defined( 'BP_IGNORE_DEPRECATED' ) ) {
+
+	// Do ignore deprecated => ignore all deprecated code.
+	if ( defined( 'BP_IGNORE_DEPRECATED' ) && BP_IGNORE_DEPRECATED ) {
 		$ignore_deprecated = (bool) BP_IGNORE_DEPRECATED;
+	}
+
+	// Do not ignore deprecated => load all deprecated code.
+	if ( defined( 'BP_LOAD_DEPRECATED' ) && BP_LOAD_DEPRECATED ) {
+		$ignore_deprecated = ! (bool) BP_LOAD_DEPRECATED;
 	}
 
 	/*


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Introduce the `BP_LOAD_DEPRECATED` constant

Setting  this constant to `true` will force all deprecated code to load. This replaces the previous double negation approach where we needed to define `BP_IGNORE_DEPRECATED` to false to load all deprecated code.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8687

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
