### PR TITLE
Improve Activity & Group Activity post update functions extensibility

### DIFF
--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -2113,7 +2113,8 @@ function bp_activity_post_update( $args = '' ) {
 			'content'    => false,
 			'user_id'    => bp_loggedin_user_id(),
 			'error_type' => 'bool',
-		)
+		),
+		'activity_post_update'
 	);
 
 	if ( empty( $r['content'] ) || ! strlen( trim( $r['content'] ) ) ) {

--- a/src/bp-groups/bp-groups-activity.php
+++ b/src/bp-groups/bp-groups-activity.php
@@ -578,16 +578,27 @@ function groups_post_update( $args = '' ) {
 		$group_id = (int) $bp->groups->current_group->id;
 	}
 
-	$content = $r['content'];
-	$user_id = (int) $r['user_id'];
-	if ( ! $content || ! strlen( trim( $content ) ) || ! $user_id || ! $group_id ) {
-		return false;
-	}
+	$content          = $r['content'];
+	$user_id          = (int) $r['user_id'];
+	$is_user_active   = bp_is_user_active( $user_id );
+	$is_group_allowed = $group_id && ( bp_current_user_can( 'bp_moderate' ) || groups_is_user_member( $user_id, $group_id ) );
 
-	$bp->groups->current_group = groups_get_group( $group_id );
+	if ( ! $content || ! strlen( trim( $content ) ) || ! $is_user_active || ! $is_group_allowed ) {
+		if ( 'wp_error' === $r['error_type'] ) {
+			$error_code         = 'bp_activity_missing_content';
+			$error_code_message = __( 'Please enter some content to post.', 'buddypress' );
 
-	// Be sure the user is a member of the group before posting.
-	if ( ! bp_current_user_can( 'bp_moderate' ) && ! groups_is_user_member( $user_id, $group_id ) ) {
+			if ( ! $is_user_active ) {
+				$error_code         = 'bp_activity_inactive_user';
+				$error_code_message = __( 'User account has not yet been activated.', 'buddypress' );
+			} elseif ( ! $group_id ) {
+				$error_code         = 'bp_activity_unallowed_group';
+				$error_code_message = __( 'You need to be a member of this group to share updates with their members.', 'buddypress' );
+			}
+
+			return new WP_Error( $error_code, $error_code_message );
+		}
+
 		return false;
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This change is required for the BP Attachments Add-on to be able to simply use a media as the Activity content.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8764

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
