### PR TITLE
Dreprecate `bp-moment` JS dependency in favor of WP’s `moment` one

### DIFF
--- a/src/bp-core/bp-core-cssjs.php
+++ b/src/bp-core/bp-core-cssjs.php
@@ -19,45 +19,55 @@ function bp_core_register_common_scripts() {
 	$min = bp_core_get_minified_asset_suffix();
 	$url = buddypress()->plugin_url . 'bp-core/js/';
 
-	/*
-	 * Moment.js locale.
-	 *
-	 * Try to map current WordPress locale to a moment.js locale file for loading.
-	 *
-	 * eg. French (France) locale for WP is fr_FR. Here, we try to find fr-fr.js
-	 *     (this file doesn't exist).
-	 */
-	$wp_locale = sanitize_file_name( strtolower( get_locale() ) );
-
-	// WP uses ISO 639-2 or -3 codes for some locales, which we must translate back to ISO 639-1.
-	$iso_locales = array(
-		'bel' => 'be',
-		'bre' => 'br',
-		'kir' => 'ky',
-		'mri' => 'mi',
-		'ssw' => 'ss',
-	);
-
-	if ( isset( $iso_locales[ $wp_locale ] ) ) {
-		$locale = $iso_locales[ $wp_locale ];
-	} else {
-		$locale = $wp_locale;
-	}
-
-	$locale = str_replace( '_', '-', $locale );
-	if ( file_exists( buddypress()->core->path . "bp-core/js/vendor/moment-js/locale/{$locale}{$min}.js" ) ) {
-		$moment_locale_url = $url . "vendor/moment-js/locale/{$locale}{$min}.js";
+	// Is WordPress' moment dist library registered?
+	$is_moment_registered = wp_script_is( 'moment', 'registered' );
+	$moment_locale_url    = '';
 
 	/*
-	 * Try to find the short-form locale.
-	 *
-	 * eg. French (France) locale for WP is fr_FR. Here, we try to find fr.js
-	 *     (this exists).
+	 * In 11.0.0 we are deprecating `bp-moment` in favor of WordPress' already bundled `moment`.
+	 * @todo completely remove `bp-moment` in 12.0.0.
 	 */
-	} else {
-		$locale = substr( $locale, 0, strpos( $locale, '-' ) );
+	if ( ! $is_moment_registered ) {
+		/*
+		* Moment.js locale.
+		*
+		* Try to map current WordPress locale to a moment.js locale file for loading.
+		*
+		* eg. French (France) locale for WP is fr_FR. Here, we try to find fr-fr.js
+		*     (this file doesn't exist).
+		*/
+		$wp_locale = sanitize_file_name( strtolower( get_locale() ) );
+
+		// WP uses ISO 639-2 or -3 codes for some locales, which we must translate back to ISO 639-1.
+		$iso_locales = array(
+			'bel' => 'be',
+			'bre' => 'br',
+			'kir' => 'ky',
+			'mri' => 'mi',
+			'ssw' => 'ss',
+		);
+
+		if ( isset( $iso_locales[ $wp_locale ] ) ) {
+			$locale = $iso_locales[ $wp_locale ];
+		} else {
+			$locale = $wp_locale;
+		}
+
+		$locale = str_replace( '_', '-', $locale );
 		if ( file_exists( buddypress()->core->path . "bp-core/js/vendor/moment-js/locale/{$locale}{$min}.js" ) ) {
 			$moment_locale_url = $url . "vendor/moment-js/locale/{$locale}{$min}.js";
+
+		/*
+		* Try to find the short-form locale.
+		*
+		* eg. French (France) locale for WP is fr_FR. Here, we try to find fr.js
+		*     (this exists).
+		*/
+		} else {
+			$locale = substr( $locale, 0, strpos( $locale, '-' ) );
+			if ( file_exists( buddypress()->core->path . "bp-core/js/vendor/moment-js/locale/{$locale}{$min}.js" ) ) {
+				$moment_locale_url = $url . "vendor/moment-js/locale/{$locale}{$min}.js";
+			}
 		}
 	}
 
@@ -83,16 +93,29 @@ function bp_core_register_common_scripts() {
 		'bp-cover-image' => array( 'file' => "{$url}cover-image{$min}.js", 'dependencies' => array(), 'footer' => true ),
 
 		// Version 2.7.
-		'bp-moment'    => array( 'file' => "{$url}vendor/moment-js/moment{$min}.js", 'dependencies' => array(), 'footer' => true ),
-		'bp-livestamp' => array( 'file' => "{$url}vendor/livestamp{$min}.js", 'dependencies' => array( 'jquery', 'bp-moment' ), 'footer' => true ),
+		'bp-livestamp' => array( 'file' => "{$url}vendor/livestamp{$min}.js", 'dependencies' => array( 'jquery', 'moment' ), 'footer' => true ),
 
 		// Version 9.0.
 		'bp-dynamic-widget-block-script' => array( 'file' => "{$url}dynamic-widget-block.js", 'dependencies' => array( 'lodash', 'wp-url' ), 'footer' => true ),
 	);
 
-	// Version 2.7 - Add Moment.js locale to our $scripts array if we found one.
-	if ( isset( $moment_locale_url ) ) {
-		$scripts['bp-moment-locale'] = array( 'file' => esc_url( $moment_locale_url ), 'dependencies' => array( 'bp-moment' ), 'footer' => true );
+	/*
+	 * In 11.0.0 we are deprecating `bp-moment` in favor of WordPress' already bundled `moment`.
+	 * @todo completely remove `bp-moment` in 12.0.0.
+	 */
+	if ( ! $is_moment_registered ) {
+		$scripts['bp-moment']         = array( 'file' => "{$url}vendor/moment-js/moment{$min}.js", 'dependencies' => array(), 'footer' => true );
+		$bp_livestamp                 = $scripts['bp-livestamp'];
+		$bp_livestamp['dependencies'] = array( 'jquery', 'bp-moment' );
+
+		// Reset 'bp-livestamp' after 'bp-moment'.
+		unset( $scripts['bp-livestamp'] );
+		$scripts['bp-livestamp'] = $bp_livestamp;
+
+		// Version 2.7 - Add Moment.js locale to our $scripts array if we found one.
+		if ( $moment_locale_url ) {
+			$scripts['bp-moment-locale'] = array( 'file' => esc_url( $moment_locale_url ), 'dependencies' => array( 'bp-moment' ), 'footer' => true );
+		}
 	}
 
 	/**
@@ -555,7 +578,41 @@ function bp_core_enqueue_livestamp() {
 	 */
 	if ( wp_script_is( 'bp-moment-locale', 'registered' ) ) {
 		wp_enqueue_script( 'bp-moment-locale' );
-		wp_add_inline_script ( 'bp-livestamp', bp_core_moment_js_config() );
+		wp_add_inline_script( 'bp-livestamp', bp_core_moment_js_config() );
+	} else {
+		wp_add_inline_script(
+			'moment',
+			sprintf(
+				"moment.updateLocale( '%s', %s );",
+				get_user_locale(),
+				wp_json_encode(
+					array(
+						'relativeTime' => array(
+							/* Translators: %s is the relative time (eg: in a few seconds). */
+							'future' => __( 'in %s', 'buddypress' ),
+							/* Translators: %s is the relative time (eg: 10 minutes ago). */
+							'past'   => __( '%s ago', 'buddypress' ),
+							's'      => __( 'a few seconds', 'buddypress' ),
+							'm'      => __( 'a minute', 'buddypress' ),
+							/* Translators: %d is the amount of minutes. */
+							'mm'     => __( '%d minutes', 'buddypress' ),
+							'h'      => __( 'an hour', 'buddypress' ),
+							/* Translators: %d is the amount of hours. */
+							'hh'     => __( '%d hours', 'buddypress' ),
+							'd'      => __( 'a day', 'buddypress' ),
+							/* Translators: %d is the amount of days. */
+							'dd'     => __( '%d days', 'buddypress' ),
+							'M'      => __( 'a month', 'buddypress' ),
+							/* Translators: %d is the amount of months. */
+							'MM'     => __( '%d months', 'buddypress' ),
+							'y'      => __( 'a year', 'buddypress' ),
+							/* Translators: %d is the amount of years. */
+							'yy'     => __( '%d years', 'buddypress' ),
+						),
+					)
+				)
+			)
+		);
 	}
 
 	wp_enqueue_script( 'bp-livestamp' );
@@ -565,10 +622,14 @@ function bp_core_enqueue_livestamp() {
  * Return moment.js config.
  *
  * @since 2.7.0
+ * @deprecated 11.0.0 Soflty deprecated as we're keeping the function into this file
+ *                    to avoid fatal errors if deprecated code is ignored.
  *
  * @return string
  */
 function bp_core_moment_js_config() {
+	_deprecated_function( __FUNCTION__, '11.0.0' );
+
 	// Grab the locale from the enqueued JS.
 	$moment_locale = wp_scripts()->query( 'bp-moment-locale' );
 	$moment_locale = substr( $moment_locale->src, strpos( $moment_locale->src, '/moment-js/locale/' ) + 18 );

--- a/src/bp-core/classes/class-bp-admin.php
+++ b/src/bp-core/classes/class-bp-admin.php
@@ -1138,7 +1138,6 @@ class BP_Admin {
 				<a href="https://github.com/carhartl/jquery-cookie">jquery.cookie</a>,
 				<a href="https://mattbradley.github.io/livestampjs/">Livestamp.js</a>,
 				<a href="https://www.mediawiki.org/wiki/MediaWiki">MediaWiki</a>,
-				<a href="https://momentjs.com/">Moment.js</a>,
 				<a href="https://wordpress.org">WordPress</a>.
 			</p>
 


### PR DESCRIPTION
This PR simply & softly deprecates `bp-moment` JS dependency. That being said, as `bp-moment` is only used by `bp-livestamp` to live update human dates/time diff on the website, we could simply remove this dependency and save ~ 740 KB (see https://github.com/buddypress/buddypress/tree/master/src/bp-core/js/vendor/moment-js). Consequence would be the people using a WordPress version < 5.0 (a very limited population, see https://wordpress.org/about/stats/) would not enjoy this live updating feature anymore..

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8766

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
