### PR TITLE
PHPCS: fixes for WordPress.Arrays.CommaAfterArrayItem

### DIFF
--- a/src/bp-xprofile/bp-xprofile-admin.php
+++ b/src/bp-xprofile/bp-xprofile-admin.php
@@ -71,7 +71,7 @@ function xprofile_admin( $message = '', $type = 'error' ) {
 		'delete_field',
 		'do_delete_field',
 		'delete_option',
-		'do_delete_option'
+		'do_delete_option',
 	);
 
 	// Is an allowed mode.
@@ -133,7 +133,7 @@ function xprofile_admin_screen( $message = '', $type = 'error' ) {
 	// Add Group.
 	$add_group_url = add_query_arg( array(
 		'page' => 'bp-profile-setup',
-		'mode' => 'add_group'
+		'mode' => 'add_group',
 	), $url );
 
 	// Validate type.
@@ -141,7 +141,7 @@ function xprofile_admin_screen( $message = '', $type = 'error' ) {
 
 	// Get all of the profile groups & fields.
 	$groups = bp_xprofile_get_groups( array(
-		'fetch_fields' => true
+		'fetch_fields' => true,
 	) ); ?>
 
 	<div class="wrap">
@@ -202,21 +202,21 @@ function xprofile_admin_screen( $message = '', $type = 'error' ) {
 					$add_field_url = add_query_arg( array(
 						'page'     => 'bp-profile-setup',
 						'mode'     => 'add_field',
-						'group_id' => (int) $group->id
+						'group_id' => (int) $group->id,
 					), $url );
 
 					// Edit Group URL.
 					$edit_group_url = add_query_arg( array(
 						'page'     => 'bp-profile-setup',
 						'mode'     => 'edit_group',
-						'group_id' => (int) $group->id
+						'group_id' => (int) $group->id,
 					), $url );
 
 					// Delete Group URL.
 					$delete_group_url = wp_nonce_url( add_query_arg( array(
 						'page'     => 'bp-profile-setup',
 						'mode'     => 'delete_group',
-						'group_id' => (int) $group->id
+						'group_id' => (int) $group->id,
 					), $url ), 'bp_xprofile_delete_group' ); ?>
 
 					<noscript>
@@ -1026,7 +1026,7 @@ function xprofile_admin_field( $admin_field, $admin_group, $class = '', $is_sign
 		'page'     => 'bp-profile-setup',
 		'mode'     => 'edit_field',
 		'group_id' => (int) $field->group_id,
-		'field_id' => (int) $field->id
+		'field_id' => (int) $field->id,
 	), $url );
 
 	// Delete.
@@ -1034,7 +1034,7 @@ function xprofile_admin_field( $admin_field, $admin_group, $class = '', $is_sign
 		$field_delete_url = add_query_arg( array(
 			'page'     => 'bp-profile-setup',
 			'mode'     => 'delete_field',
-			'field_id' => (int) $field->id
+			'field_id' => (int) $field->id,
 		), $url . '#tabs-' . (int) $field->group_id );
 	}
 

--- a/src/bp-xprofile/bp-xprofile-cache.php
+++ b/src/bp-xprofile/bp-xprofile-cache.php
@@ -68,7 +68,7 @@ function bp_xprofile_update_meta_cache( $object_ids = array() ) {
 	$uncached_object_ids = array(
 		'group',
 		'field',
-		'data'
+		'data',
 	);
 
 	// Define the cache groups for the 3 types of XProfile metadata.

--- a/src/bp-xprofile/bp-xprofile-functions.php
+++ b/src/bp-xprofile/bp-xprofile-functions.php
@@ -1309,16 +1309,16 @@ function bp_xprofile_get_hidden_field_types_for_user( $displayed_user_id = 0, $c
 
 		// If the current user and displayed user are friends, show all.
 		} elseif ( bp_is_active( 'friends' ) && friends_check_friendship( $displayed_user_id, $current_user_id ) ) {
-			$hidden_levels = array( 'adminsonly', );
+			$hidden_levels = array( 'adminsonly' );
 
 		// Current user is logged in but not friends, so exclude friends-only.
 		} else {
-			$hidden_levels = array( 'friends', 'adminsonly', );
+			$hidden_levels = array( 'friends', 'adminsonly' );
 		}
 
 	// Current user is not logged in, so exclude friends-only, loggedin, and adminsonly.
 	} else {
-		$hidden_levels = array( 'friends', 'loggedin', 'adminsonly', );
+		$hidden_levels = array( 'friends', 'loggedin', 'adminsonly' );
 	}
 
 	/**

--- a/src/bp-xprofile/classes/class-bp-xprofile-component.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-component.php
@@ -49,7 +49,7 @@ class BP_XProfile_Component extends BP_Component {
 			_x( 'Extended Profiles', 'Component page <title>', 'buddypress' ),
 			buddypress()->plugin_dir,
 			array(
-				'adminbar_myaccount_order' => 20
+				'adminbar_myaccount_order' => 20,
 			)
 		);
 
@@ -173,22 +173,22 @@ class BP_XProfile_Component extends BP_Component {
 		$this->visibility_levels = array(
 			'public' => array(
 				'id'	  => 'public',
-				'label' => _x( 'Everyone', 'Visibility level setting', 'buddypress' )
+				'label' => _x( 'Everyone', 'Visibility level setting', 'buddypress' ),
 			),
 			'adminsonly' => array(
 				'id'	  => 'adminsonly',
-				'label' => _x( 'Only Me', 'Visibility level setting', 'buddypress' )
+				'label' => _x( 'Only Me', 'Visibility level setting', 'buddypress' ),
 			),
 			'loggedin' => array(
 				'id'	  => 'loggedin',
-				'label' => _x( 'All Members', 'Visibility level setting', 'buddypress' )
-			)
+				'label' => _x( 'All Members', 'Visibility level setting', 'buddypress' ),
+			),
 		);
 
 		if ( bp_is_active( 'friends' ) ) {
 			$this->visibility_levels['friends'] = array(
 				'id'	=> 'friends',
-				'label'	=> _x( 'My Friends', 'Visibility level setting', 'buddypress' )
+				'label'	=> _x( 'My Friends', 'Visibility level setting', 'buddypress' ),
 			);
 		}
 
@@ -249,7 +249,7 @@ class BP_XProfile_Component extends BP_Component {
 			'position'            => 20,
 			'screen_function'     => 'xprofile_screen_display_profile',
 			'default_subnav_slug' => 'public',
-			'item_css_id'         => $this->id
+			'item_css_id'         => $this->id,
 		);
 
 		// Add the subnav items to the profile.
@@ -259,7 +259,7 @@ class BP_XProfile_Component extends BP_Component {
 			'parent_url'      => $profile_link,
 			'parent_slug'     => $slug,
 			'screen_function' => 'xprofile_screen_display_profile',
-			'position'        => 10
+			'position'        => 10,
 		);
 
 		// Edit Profile.
@@ -270,7 +270,7 @@ class BP_XProfile_Component extends BP_Component {
 			'parent_slug'     => $slug,
 			'screen_function' => 'xprofile_screen_edit_profile',
 			'position'        => 20,
-			'user_has_access' => $access
+			'user_has_access' => $access,
 		);
 
 		// The Settings > Profile nav item can only be set up after
@@ -312,7 +312,7 @@ class BP_XProfile_Component extends BP_Component {
 			'parent_slug'     => $settings_slug,
 			'screen_function' => 'bp_xprofile_screen_settings',
 			'position'        => 30,
-			'user_has_access' => bp_core_can_edit_settings()
+			'user_has_access' => bp_core_can_edit_settings(),
 		), 'members' );
 	}
 
@@ -336,7 +336,7 @@ class BP_XProfile_Component extends BP_Component {
 				'parent' => buddypress()->my_account_menu_id,
 				'id'     => 'my-account-' . $this->id,
 				'title'  => _x( 'Profile', 'My Account Profile', 'buddypress' ),
-				'href'   => $profile_link
+				'href'   => $profile_link,
 			);
 
 			// View Profile.
@@ -345,7 +345,7 @@ class BP_XProfile_Component extends BP_Component {
 				'id'       => 'my-account-' . $this->id . '-public',
 				'title'    => _x( 'View', 'My Account Profile sub nav', 'buddypress' ),
 				'href'     => trailingslashit( $profile_link . 'public' ),
-				'position' => 10
+				'position' => 10,
 			);
 
 			// Edit Profile.
@@ -354,7 +354,7 @@ class BP_XProfile_Component extends BP_Component {
 				'id'       => 'my-account-' . $this->id . '-edit',
 				'title'    => _x( 'Edit', 'My Account Profile sub nav', 'buddypress' ),
 				'href'     => trailingslashit( $profile_link . 'edit' ),
-				'position' => 20
+				'position' => 20,
 			);
 		}
 
@@ -388,7 +388,7 @@ class BP_XProfile_Component extends BP_Component {
 					'type'    => 'thumb',
 
 					/* translators: %s: member name */
-					'alt'	  => sprintf( _x( 'Profile picture of %s', 'Avatar alt', 'buddypress' ), bp_get_displayed_user_fullname() )
+					'alt'	  => sprintf( _x( 'Profile picture of %s', 'Avatar alt', 'buddypress' ), bp_get_displayed_user_fullname() ),
 				) );
 				$bp->bp_options_title = bp_get_displayed_user_fullname();
 			}
@@ -435,7 +435,7 @@ class BP_XProfile_Component extends BP_Component {
 			'parent' => 'my-account-' . buddypress()->settings->id,
 			'id'     => 'my-account-' . buddypress()->settings->id . '-profile',
 			'title'  => _x( 'Profile', 'My Account Settings sub nav', 'buddypress' ),
-			'href'   => trailingslashit( $settings_link . 'profile' )
+			'href'   => trailingslashit( $settings_link . 'profile' ),
 		);
 
 		return $wp_admin_nav;

--- a/src/bp-xprofile/classes/class-bp-xprofile-data-template.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-data-template.php
@@ -143,7 +143,7 @@ class BP_XProfile_Data_Template {
 				6 => 'exclude_fields',
 				7 => 'hide_empty_fields',
 				8 => 'fetch_visibility_level',
-				9 => 'update_meta_cache'
+				9 => 'update_meta_cache',
 			);
 
 			$args = bp_core_parse_args_array( $old_args_keys, $function_args );

--- a/src/bp-xprofile/classes/class-bp-xprofile-field-type-checkbox.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-field-type-checkbox.php
@@ -81,7 +81,7 @@ class BP_XProfile_Field_Type_Checkbox extends BP_XProfile_Field_Type {
 			do_action( bp_get_the_profile_field_errors_action() ); ?>
 
 			<?php bp_the_profile_field_options( array(
-				'user_id' => $user_id
+				'user_id' => $user_id,
 			) ); ?>
 
 		<?php

--- a/src/bp-xprofile/classes/class-bp-xprofile-field-type-datebox.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-field-type-datebox.php
@@ -120,7 +120,7 @@ class BP_XProfile_Field_Type_Datebox extends BP_XProfile_Field_Type {
 				<select <?php echo $this->get_edit_field_html_elements( $day_r ); ?>>
 					<?php bp_the_profile_field_options( array(
 						'type'    => 'day',
-						'user_id' => $user_id
+						'user_id' => $user_id,
 					) ); ?>
 				</select>
 
@@ -130,7 +130,7 @@ class BP_XProfile_Field_Type_Datebox extends BP_XProfile_Field_Type {
 				<select <?php echo $this->get_edit_field_html_elements( $month_r ); ?>>
 					<?php bp_the_profile_field_options( array(
 						'type'    => 'month',
-						'user_id' => $user_id
+						'user_id' => $user_id,
 					) ); ?>
 				</select>
 
@@ -140,7 +140,7 @@ class BP_XProfile_Field_Type_Datebox extends BP_XProfile_Field_Type {
 				<select <?php echo $this->get_edit_field_html_elements( $year_r ); ?>>
 					<?php bp_the_profile_field_options( array(
 						'type'    => 'year',
-						'user_id' => $user_id
+						'user_id' => $user_id,
 					) ); ?>
 				</select>
 
@@ -235,7 +235,7 @@ class BP_XProfile_Field_Type_Datebox extends BP_XProfile_Field_Type {
 					__( 'September', 'buddypress' ),
 					__( 'October',   'buddypress' ),
 					__( 'November',  'buddypress' ),
-					__( 'December',  'buddypress' )
+					__( 'December',  'buddypress' ),
 				);
 
 				$html = sprintf( '<option value="" %1$s>%2$s</option>', selected( $month, 0, false ), /* translators: no option picked in select box */ __( '----', 'buddypress' ) );

--- a/src/bp-xprofile/classes/class-bp-xprofile-field-type-multiselectbox.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-field-type-multiselectbox.php
@@ -88,7 +88,7 @@ class BP_XProfile_Field_Type_Multiselectbox extends BP_XProfile_Field_Type {
 
 		<select <?php echo $this->get_edit_field_html_elements( $r ); ?> aria-labelledby="<?php bp_the_profile_field_input_name(); ?>-1" aria-describedby="<?php bp_the_profile_field_input_name(); ?>-3">
 			<?php bp_the_profile_field_options( array(
-				'user_id' => $user_id
+				'user_id' => $user_id,
 			) ); ?>
 		</select>
 

--- a/src/bp-xprofile/classes/class-bp-xprofile-field.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-field.php
@@ -282,7 +282,7 @@ class BP_XProfile_Field {
 
 		$int_fields = array(
 			'id', 'is_required', 'group_id', 'parent_id', 'is_default_option',
-			'field_order', 'option_order', 'can_delete'
+			'field_order', 'option_order', 'can_delete',
 		);
 
 		foreach ( $args as $k => $v ) {
@@ -1237,7 +1237,7 @@ class BP_XProfile_Field {
 			$action = add_query_arg( array(
 				'page'     => 'bp-profile-setup',
 				'mode'     => 'add_field',
-				'group_id' => (int) $this->group_id
+				'group_id' => (int) $this->group_id,
 			), $users_url . '#tabs-' . (int) $this->group_id );
 
 			if ( ! empty( $_POST['saveField'] ) ) {
@@ -1260,7 +1260,7 @@ class BP_XProfile_Field {
 				'page'     => 'bp-profile-setup',
 				'mode'     => 'edit_field',
 				'group_id' => (int) $this->group_id,
-				'field_id' => (int) $this->id
+				'field_id' => (int) $this->id,
 			), $users_url . '#tabs-' . (int) $this->group_id );
 		} ?>
 
@@ -1419,7 +1419,7 @@ class BP_XProfile_Field {
 		// Setup the URL for deleting
 		$users_url  = bp_get_admin_url( 'users.php' );
 		$cancel_url = add_query_arg( array(
-			'page' => 'bp-profile-setup'
+			'page' => 'bp-profile-setup',
 		), $users_url );
 
 
@@ -1428,7 +1428,7 @@ class BP_XProfile_Field {
 			$delete_url = wp_nonce_url( add_query_arg( array(
 				'page'     => 'bp-profile-setup',
 				'mode'     => 'delete_field',
-				'field_id' => (int) $this->id
+				'field_id' => (int) $this->id,
 			), $users_url ), 'bp_xprofile_delete_field-' . $this->id, 'bp_xprofile_delete_field' );
 		}
 		/**

--- a/src/bp-xprofile/classes/class-bp-xprofile-group.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-group.php
@@ -92,7 +92,7 @@ class BP_XProfile_Group {
 
 		// Get this group.
 		$group = self::get( array(
-			'profile_group_id' => $id
+			'profile_group_id' => $id,
 		) );
 
 		// Bail if group not found.
@@ -837,7 +837,7 @@ class BP_XProfile_Group {
 
 		// URL to cancel to.
 		$cancel_url = add_query_arg( array(
-			'page' => 'bp-profile-setup'
+			'page' => 'bp-profile-setup',
 		), $users_url );
 
 		// New field group.
@@ -846,7 +846,7 @@ class BP_XProfile_Group {
 			$button	= __( 'Save',                'buddypress' );
 			$action	= add_query_arg( array(
 				'page' => 'bp-profile-setup',
-				'mode' => 'add_group'
+				'mode' => 'add_group',
 			), $users_url );
 
 		// Existing field group.
@@ -856,7 +856,7 @@ class BP_XProfile_Group {
 			$action	= add_query_arg( array(
 				'page'     => 'bp-profile-setup',
 				'mode'     => 'edit_group',
-				'group_id' => (int) $this->id
+				'group_id' => (int) $this->id,
 			), $users_url );
 
 			if ( $this->can_delete ) {
@@ -864,7 +864,7 @@ class BP_XProfile_Group {
 				$delete_url = wp_nonce_url( add_query_arg( array(
 					'page'     => 'bp-profile-setup',
 					'mode'     => 'delete_group',
-					'group_id' => (int) $this->id
+					'group_id' => (int) $this->id,
 				), $users_url ), 'bp_xprofile_delete_group' );
 			}
 		} ?>

--- a/src/bp-xprofile/classes/class-bp-xprofile-meta-query.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-meta-query.php
@@ -184,7 +184,7 @@ class BP_XProfile_Meta_Query extends WP_Meta_Query {
 			'IN', 'NOT IN',
 			'BETWEEN', 'NOT BETWEEN',
 			'EXISTS', 'NOT EXISTS',
-			'REGEXP', 'NOT REGEXP', 'RLIKE'
+			'REGEXP', 'NOT REGEXP', 'RLIKE',
 		) ) ) {
 			$clause['compare'] = '=';
 		}

--- a/src/bp-xprofile/classes/class-bp-xprofile-query.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-query.php
@@ -370,7 +370,7 @@ class BP_XProfile_Query {
 			'IN', 'NOT IN',
 			'BETWEEN', 'NOT BETWEEN',
 			'EXISTS', 'NOT EXISTS',
-			'REGEXP', 'NOT REGEXP', 'RLIKE'
+			'REGEXP', 'NOT REGEXP', 'RLIKE',
 		) ) ) {
 			$clause['compare'] = '=';
 		}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

- As titled;
- XProfile component only.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/7228

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
