### PR TITLE
PhpDoc: adding global param for `$bp`

### DIFF
--- a/src/bp-activity/actions/feeds.php
+++ b/src/bp-activity/actions/feeds.php
@@ -12,6 +12,8 @@
  *
  * @since 1.0.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @return bool False on failure.
  */
 function bp_activity_action_sitewide_feed() {

--- a/src/bp-activity/actions/spam.php
+++ b/src/bp-activity/actions/spam.php
@@ -12,6 +12,8 @@
  *
  * @since 1.6.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param int $activity_id Activity id to be deleted. Defaults to 0.
  * @return bool False on failure.
  */

--- a/src/bp-activity/bp-activity-admin.php
+++ b/src/bp-activity/bp-activity-admin.php
@@ -982,6 +982,8 @@ function bp_activity_admin_get_activity_actions() {
  *
  * @since 1.6.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param object $item Activity item.
  */
 function bp_activity_admin_edit_metabox_type( $item ) {

--- a/src/bp-activity/bp-activity-akismet.php
+++ b/src/bp-activity/bp-activity-akismet.php
@@ -41,6 +41,7 @@ add_action( 'bp_activity_setup_globals', 'bp_activity_setup_akismet' );
  *
  * @since 1.6.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  * @global wpdb $wpdb WordPress database object.
  */
 function bp_activity_akismet_delete_old_metadata() {
@@ -65,8 +66,9 @@ function bp_activity_akismet_delete_old_metadata() {
 	$activity_ids = $wpdb->get_col( $sql );
 
 	if ( ! empty( $activity_ids ) ) {
-		foreach ( $activity_ids as $activity_id )
+		foreach ( $activity_ids as $activity_id ) {
 			bp_activity_delete_meta( $activity_id, '_bp_akismet_submission' );
+		}
 	}
 }
 add_action( 'bp_activity_akismet_delete_old_metadata', 'bp_activity_akismet_delete_old_metadata' );

--- a/src/bp-activity/bp-activity-cache.php
+++ b/src/bp-activity/bp-activity-cache.php
@@ -19,6 +19,8 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.6.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param int|string|array|bool $activity_ids Accepts a single activity ID, or a comma-
  *                                            separated list or array of activity ids.
  */

--- a/src/bp-activity/bp-activity-filters.php
+++ b/src/bp-activity/bp-activity-filters.php
@@ -321,6 +321,8 @@ function bp_activity_at_name_filter_updates( $activity ) {
  *
  * @since 1.7.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param BP_Activity_Activity $activity The BP_Activity_Activity object.
  */
 function bp_activity_at_name_send_emails( $activity ) {
@@ -497,6 +499,8 @@ add_filter( 'bp_core_get_js_dependencies', 'bp_activity_get_js_dependencies', 10
  *
  * @since 2.0.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param string $classes Array of classes for most recent activity item.
  * @return string $classes
  */
@@ -508,6 +512,7 @@ function bp_activity_newest_class( $classes = '' ) {
 	}
 
 	$classes .= ' just-posted';
+
 	return $classes;
 }
 

--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -327,6 +327,8 @@ function bp_activity_get_userid_from_mentionname( $mentionname ) {
  *
  * @since 1.1.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param  string        $component_id    The unique string ID of the component.
  * @param  string        $type            The action type.
  * @param  string        $description     The action description.
@@ -687,6 +689,8 @@ function _bp_activity_get_types_by_support( $feature = 'generated-content' ) {
  *
  * @since 2.5.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param  string $activity_type The activity type to check.
  * @param  string $feature       The feature to check. Currently supports:
  *                               'post-type-comment-tracking', 'post-type-comment-reply' & 'comment-reply'.
@@ -779,6 +783,8 @@ function bp_activity_type_supports( $activity_type = '', $feature = '' ) {
  *
  * @since 2.5.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param  string       $activity_type the activity type.
  * @param  string       $arg           the key of the tracking argument.
  * @return mixed        the value of the tracking arg, false if not found.
@@ -806,6 +812,8 @@ function bp_activity_post_type_get_tracking_arg( $activity_type, $arg = '' ) {
  * Get all components' activity actions, sorted by their position attribute.
  *
  * @since 2.2.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @return object Actions ordered by their position.
  */
@@ -1409,7 +1417,8 @@ add_action( 'delete_user', 'bp_activity_remove_all_user_data_on_delete_user' );
  *
  * @since 1.6.0
  *
- * @global object $wpdb WordPress database access object.
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ * @global wpdb $wpdb WordPress database object.
  *
  * @param int $user_id ID of the user whose activity is being spammed.
  * @return bool
@@ -1478,7 +1487,8 @@ add_action( 'bp_make_spam_user', 'bp_activity_spam_all_user_data' );
  *
  * @since 1.6.0
  *
- * @global object $wpdb WordPress database access object.
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ * @global wpdb $wpdb WordPress database object.
  *
  * @param int $user_id ID of the user whose activity is being hammed.
  * @return bool
@@ -1562,6 +1572,8 @@ add_action( 'bp_init', 'bp_register_activity_actions', 8 );
  * Register the activity stream actions for updates.
  *
  * @since 1.6.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  */
 function bp_activity_register_activity_actions() {
 	$bp = buddypress();
@@ -1697,6 +1709,8 @@ function bp_activity_format_activity_action_activity_comment( $action, $activity
  *
  * @since 2.2.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param string $action   Static activity action.
  * @param object $activity Activity data object.
  * @return string $action
@@ -1757,6 +1771,8 @@ function bp_activity_format_activity_action_custom_post_type_post( $action, $act
  * Format activity action strings for custom post types comments.
  *
  * @since 2.5.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param string $action   Static activity action.
  * @param object $activity Activity data object.
@@ -2727,6 +2743,8 @@ add_action( 'delete_comment', 'bp_activity_post_type_remove_comment', 10, 1 );
  *              Add the $primary_link parameter for the array of arguments.
  * @since 2.6.0 Added 'error_type' parameter to $args.
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param array|string $args {
  *     An array of arguments.
  *     @type int    $id                Optional. Pass an ID to update an existing comment.
@@ -3233,6 +3251,8 @@ function bp_activity_delete_comment( $activity_id, $comment_id ) {
  *
  * @since 1.2.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param int         $activity_id  The unique id of the activity object.
  * @param object|bool $activity_obj Optional. The activity object.
  * @return string $link Permalink for the activity item.
@@ -3678,6 +3698,8 @@ function bp_activity_user_can_mark_spam() {
  *
  * @since 1.6.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @todo We should probably save $source to activity meta.
  *
  * @param BP_Activity_Activity $activity The activity item to be spammed.
@@ -3732,6 +3754,8 @@ function bp_activity_mark_as_spam( &$activity, $source = 'by_a_person' ) {
  * Mark an activity item as ham.
  *
  * @since 1.6.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param BP_Activity_Activity $activity The activity item to be hammed. Passed by reference.
  * @param string               $source   Optional. Default is "by_a_person" (ie, a person has

--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -107,7 +107,8 @@ function bp_activity_directory_permalink() {
  * @since 1.0.0
  * @since 2.4.0 Introduced the `$fields` parameter.
  *
- * @global object $activities_template {@link BP_Activity_Template}
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ * @global BP_Activity_Template $activities_template {@link BP_Activity_Template}
  *
  * @param array|string $args {
  *     Arguments for limiting the contents of the activity loop. Most arguments
@@ -1039,7 +1040,9 @@ function bp_activity_avatar( $args = '' ) {
 	 * @since 1.1.0
 	 *
 	 * @see bp_core_fetch_avatar() For a description of the arguments.
-	 * @global object $activities_template {@link BP_Activity_Template}
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global BP_Activity_Template $activities_template {@link BP_Activity_Template}
 	 *
 	 * @param array|string $args  {
 	 *     Arguments are listed here with an explanation of their defaults.
@@ -3198,13 +3201,9 @@ function bp_activity_filter_links( $args = false ) {
  *
  * @since 1.2.0
  *
- * @global object $activities_template {@link BP_Activity_Template}
- *
  * @return bool $can_comment True if item can receive comments.
  */
 function bp_activity_can_comment() {
-	global $activities_template;
-	$bp = buddypress();
 
 	// Determine ability to comment based on activity type name.
 	$activity_type = bp_get_activity_type();

--- a/src/bp-activity/classes/class-bp-activity-activity.php
+++ b/src/bp-activity/classes/class-bp-activity-activity.php
@@ -226,6 +226,9 @@ class BP_Activity_Activity {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @return WP_Error|bool True on success.
 	 */
 	public function save() {
@@ -343,6 +346,9 @@ class BP_Activity_Activity {
 	 * @since 2.9.0 Introduced the `$order_by` parameter.
 	 * @since 10.0.0 Introduced the `$count_total_only` parameter.
 	 * @since 11.0.0 Introduced the `$user_id__in` and `$user_id__not_in` parameters.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @see BP_Activity_Activity::get_filter_sql() for a description of the
 	 *      'filter' parameter.
@@ -880,6 +886,9 @@ class BP_Activity_Activity {
 	 *
 	 * @since 2.0.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param array $activity_ids Array of activity IDs.
 	 * @return array
 	 */
@@ -1344,6 +1353,9 @@ class BP_Activity_Activity {
 	 *
 	 * @since 1.2.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param array $args {
 	 *     @int    $id                Optional. The ID of a specific item to delete.
 	 *     @string $action            Optional. The action to filter by.
@@ -1523,6 +1535,9 @@ class BP_Activity_Activity {
 	 *
 	 * @deprecated 2.3.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param array $activity_ids Activity IDs whose comments should be deleted.
 	 * @param bool  $delete_meta  Should we delete the activity meta items for these comments.
 	 * @return bool True on success.
@@ -1600,6 +1615,7 @@ class BP_Activity_Activity {
 	 *
 	 * @since 1.2.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int    $activity_id         Activity ID to fetch comments for.
@@ -1764,6 +1780,7 @@ class BP_Activity_Activity {
 	 *
 	 * @since 1.2.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $parent_id ID of an activity or activity comment.
@@ -1804,6 +1821,7 @@ class BP_Activity_Activity {
 	 *
 	 * @since 1.2.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $parent_id ID of an activity or activity comment.
@@ -1821,6 +1839,9 @@ class BP_Activity_Activity {
 	 * Get a list of components that have recorded activity associated with them.
 	 *
 	 * @since 1.2.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param bool $skip_last_activity If true, components will not be
 	 *                                 included if the only activity type associated with them is
@@ -1994,6 +2015,9 @@ class BP_Activity_Activity {
 	 *
 	 * @since 1.2.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @return string ISO timestamp.
 	 */
 	public static function get_last_updated() {
@@ -2029,6 +2053,9 @@ class BP_Activity_Activity {
 	 *
 	 * @since 1.1.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param string $content The content to filter by.
 	 * @return int|false The ID of the first matching item if found, otherwise false.
 	 */
@@ -2046,6 +2073,9 @@ class BP_Activity_Activity {
 	 * Hide all activity for a given user.
 	 *
 	 * @since 1.2.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $user_id The ID of the user whose activity you want to mark hidden.
 	 * @return mixed

--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -182,6 +182,8 @@ class BP_Activity_Component extends BP_Component {
 	 *
 	 * @since 1.5.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 *
 	 * @see BP_Component::setup_globals() for a description of arguments.
 	 *
 	 * @param array $args See BP_Component::setup_globals() for a description.
@@ -437,6 +439,7 @@ class BP_Activity_Component extends BP_Component {
 	 *
 	 * @since 1.5.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 */
 	public function setup_title() {
 
@@ -564,6 +567,8 @@ class BP_Activity_Component extends BP_Component {
 	 * Add the Activity directory state.
 	 *
 	 * @since 10.0.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 *
 	 * @param array   $states Optional. See BP_Component::admin_directory_states() for description.
 	 * @param WP_Post $post   Optional. See BP_Component::admin_directory_states() for description.

--- a/src/bp-activity/classes/class-bp-activity-template.php
+++ b/src/bp-activity/classes/class-bp-activity-template.php
@@ -137,8 +137,6 @@ class BP_Activity_Template {
 	 * }
 	 */
 	public function __construct( $args ) {
-		$bp = buddypress();
-
 		$function_args = func_get_args();
 
 		// Backward compatibility with old method of passing arguments.

--- a/src/bp-blogs/bp-blogs-activity.php
+++ b/src/bp-blogs/bp-blogs-activity.php
@@ -1026,11 +1026,15 @@ add_action( 'trashed_post_comments', 'bp_blogs_remove_activity_meta_for_trashed_
  * @since 2.1.0
  * @since 2.5.0 Used for any synced Post type comments, in wp-admin or front-end contexts.
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ * @global wpdb $wpdb WordPress database object.
+ *
  * @param array $args Arguments passed from bp_parse_args() in bp_has_activities().
  * @return array $args
  */
 function bp_blogs_new_blog_comment_query_backpat( $args ) {
 	global $wpdb;
+
 	$bp = buddypress();
 
 	// If activity comments are disabled for blog posts, stop now!
@@ -1420,7 +1424,6 @@ function bp_blogs_activity_comment_single_action( $retval, $activity ) {
 	$blog_comment_id = bp_activity_get_meta( $activity->id, "bp_blogs_{$post_type}_comment_id" );
 
 	if ( ! empty( $blog_comment_id ) ) {
-		$bp = buddypress();
 
 		// Check if a comment action id is set for the parent activity.
 		$comment_action_id = bp_activity_post_type_get_tracking_arg( $parent_activity->type, 'comment_action_id' );

--- a/src/bp-blogs/bp-blogs-filters.php
+++ b/src/bp-blogs/bp-blogs-filters.php
@@ -73,7 +73,6 @@ function bp_blogs_comments_clauses_select_by_id( $retval ) {
  * @return bool True to authorize the post to be published, otherwise false.
  */
 function bp_blogs_post_pre_publish( $return = true, $blog_id = 0, $post_id = 0, $user_id = 0 ) {
-	$bp = buddypress();
 
 	// If blog is not trackable, do not record the activity.
 	if ( ! bp_blogs_is_blog_trackable( $blog_id, $user_id ) ) {

--- a/src/bp-blogs/bp-blogs-functions.php
+++ b/src/bp-blogs/bp-blogs-functions.php
@@ -15,7 +15,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.5.0
  *
- * @return bool True if set, false if empty.
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
+ * @return boolean True if set, false if empty.
  */
 function bp_blogs_has_directory() {
 	$bp = buddypress();
@@ -86,6 +88,9 @@ function bp_blogs_get_blogs( $args = '' ) {
  *
  * @since 1.0.0
  * @since 2.6.0 Accepts $args as a parameter.
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ * @global wpdb $wpdb WordPress database object.
  *
  * @param array $args {
  *     Array of arguments.

--- a/src/bp-blogs/classes/class-bp-blogs-blog.php
+++ b/src/bp-blogs/classes/class-bp-blogs-blog.php
@@ -57,7 +57,7 @@ class BP_Blogs_Blog {
 	 * Populate the object with data about the specific activity item.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 */
 	public function populate() {
 		global $wpdb;
@@ -74,7 +74,7 @@ class BP_Blogs_Blog {
 	 * Save the BP blog data to the database.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @return bool True on success, false on failure.
 	 */
@@ -154,7 +154,7 @@ class BP_Blogs_Blog {
 	 * Check whether an association between this user and this blog exists.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @return int $value The number of associations between the user and blog
 	 *                    saved in the blog component tables.
@@ -176,7 +176,7 @@ class BP_Blogs_Blog {
 	 * @since 10.0.0 Converted to array as main function argument. Added $date_query parameter.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param array $data {
 	 *     Array of site data to query for.
@@ -336,7 +336,7 @@ class BP_Blogs_Blog {
 	 * Delete the record of a given blog for all users.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $blog_id The blog being removed from all users.
 	 * @return int|bool Number of rows deleted on success, false on failure.
@@ -355,7 +355,7 @@ class BP_Blogs_Blog {
 	 * Delete the record of a given blog for a specific user.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int      $blog_id The blog being removed.
 	 * @param int|null $user_id Optional. The ID of the user from whom the blog is
@@ -377,7 +377,7 @@ class BP_Blogs_Blog {
 	 * Delete all of a user's blog associations in the BP tables.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int|null $user_id Optional. The ID of the user whose blog associations
 	 *                          are being deleted. If absent, defaults to logged-in user ID.
@@ -403,7 +403,7 @@ class BP_Blogs_Blog {
 	 * does a true query of a user's blog capabilities.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int  $user_id     Optional. ID of the user whose blogs are being
 	 *                          queried. Defaults to logged-in user.
@@ -447,7 +447,7 @@ class BP_Blogs_Blog {
 	 * This method always includes hidden blogs.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $user_id Optional. ID of the user whose blogs are being
 	 *                     queried. Defaults to logged-in user.
@@ -468,7 +468,7 @@ class BP_Blogs_Blog {
 	 * Check whether a blog has been recorded by BuddyPress.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $blog_id ID of the blog being queried.
 	 * @return int|null The ID of the first located entry in the BP table
@@ -492,7 +492,7 @@ class BP_Blogs_Blog {
 	 * cap.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int|null $user_id Optional. ID of the user whose blogs are being
 	 *                          queried. Defaults to logged-in user.
@@ -521,7 +521,7 @@ class BP_Blogs_Blog {
 	 * blogmeta table.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param string   $filter The search term.
 	 * @param int|null $limit  Optional. The maximum number of items to return.
@@ -567,7 +567,7 @@ class BP_Blogs_Blog {
 	 * 'bp_moderate' cap.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int|null $limit Optional. The maximum number of items to return.
 	 *                        Default: null (no limit).
@@ -603,7 +603,7 @@ class BP_Blogs_Blog {
 	 * 'bp_moderate' cap.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param string   $letter The letter you're looking for.
 	 * @param int|null $limit  Optional. The maximum number of items to return.
@@ -651,7 +651,7 @@ class BP_Blogs_Blog {
 	 *   - The blog description
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param array       $paged_blogs Array of results from the original query.
 	 * @param array       $blog_ids    Array of IDs returned from the original query.
@@ -734,7 +734,7 @@ class BP_Blogs_Blog {
 	 *
 	 * Checks the 'public' column in the wp_blogs table.
 	 *
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $blog_id The ID of the blog being checked.
 	 * @return bool True if hidden (public = 0), false otherwise.
@@ -753,7 +753,7 @@ class BP_Blogs_Blog {
 	 * Get ID of user-blog link.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $user_id ID of user.
 	 * @param int $blog_id ID of blog.

--- a/src/bp-blogs/classes/class-bp-blogs-blog.php
+++ b/src/bp-blogs/classes/class-bp-blogs-blog.php
@@ -55,6 +55,9 @@ class BP_Blogs_Blog {
 
 	/**
 	 * Populate the object with data about the specific activity item.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 */
 	public function populate() {
 		global $wpdb;
@@ -69,6 +72,9 @@ class BP_Blogs_Blog {
 
 	/**
 	 * Save the BP blog data to the database.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @return bool True on success, false on failure.
 	 */
@@ -147,6 +153,9 @@ class BP_Blogs_Blog {
 	/**
 	 * Check whether an association between this user and this blog exists.
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @return int $value The number of associations between the user and blog
 	 *                    saved in the blog component tables.
 	 */
@@ -165,6 +174,9 @@ class BP_Blogs_Blog {
 	 *
 	 * @since 1.2.0
 	 * @since 10.0.0 Converted to array as main function argument. Added $date_query parameter.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param array $data {
 	 *     Array of site data to query for.
@@ -323,6 +335,9 @@ class BP_Blogs_Blog {
 	/**
 	 * Delete the record of a given blog for all users.
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param int $blog_id The blog being removed from all users.
 	 * @return int|bool Number of rows deleted on success, false on failure.
 	 */
@@ -338,6 +353,9 @@ class BP_Blogs_Blog {
 
 	/**
 	 * Delete the record of a given blog for a specific user.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int      $blog_id The blog being removed.
 	 * @param int|null $user_id Optional. The ID of the user from whom the blog is
@@ -357,6 +375,9 @@ class BP_Blogs_Blog {
 
 	/**
 	 * Delete all of a user's blog associations in the BP tables.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int|null $user_id Optional. The ID of the user whose blog associations
 	 *                          are being deleted. If absent, defaults to logged-in user ID.
@@ -380,6 +401,9 @@ class BP_Blogs_Blog {
 	 * {@link get_blogs_of_user()}; the current method returns only those
 	 * blogs that have been recorded by BuddyPress, while the WP function
 	 * does a true query of a user's blog capabilities.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int  $user_id     Optional. ID of the user whose blogs are being
 	 *                          queried. Defaults to logged-in user.
@@ -422,6 +446,9 @@ class BP_Blogs_Blog {
 	 *
 	 * This method always includes hidden blogs.
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param int $user_id Optional. ID of the user whose blogs are being
 	 *                     queried. Defaults to logged-in user.
 	 * @return int The number of blogs associated with the user.
@@ -439,6 +466,9 @@ class BP_Blogs_Blog {
 
 	/**
 	 * Check whether a blog has been recorded by BuddyPress.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $blog_id ID of the blog being queried.
 	 * @return int|null The ID of the first located entry in the BP table
@@ -460,6 +490,9 @@ class BP_Blogs_Blog {
 	 * Includes hidden blogs when the logged-in user is the same as the
 	 * $user_id parameter, or when the logged-in user has the bp_moderate
 	 * cap.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int|null $user_id Optional. ID of the user whose blogs are being
 	 *                          queried. Defaults to logged-in user.
@@ -486,6 +519,9 @@ class BP_Blogs_Blog {
 	 *
 	 * Matches against blog names and descriptions, as stored in the BP
 	 * blogmeta table.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param string   $filter The search term.
 	 * @param int|null $limit  Optional. The maximum number of items to return.
@@ -530,6 +566,9 @@ class BP_Blogs_Blog {
 	 * Query will include hidden blogs if the logged-in user has the
 	 * 'bp_moderate' cap.
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param int|null $limit Optional. The maximum number of items to return.
 	 *                        Default: null (no limit).
 	 * @param int|null $page  Optional. The page of results to return. Default:
@@ -562,6 +601,9 @@ class BP_Blogs_Blog {
 	 *
 	 * Query will include hidden blogs if the logged-in user has the
 	 * 'bp_moderate' cap.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param string   $letter The letter you're looking for.
 	 * @param int|null $limit  Optional. The maximum number of items to return.
@@ -607,6 +649,9 @@ class BP_Blogs_Blog {
 	 * fell swoop:
 	 *   - The latest post for each blog, include Featured Image data
 	 *   - The blog description
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param array       $paged_blogs Array of results from the original query.
 	 * @param array       $blog_ids    Array of IDs returned from the original query.
@@ -689,6 +734,8 @@ class BP_Blogs_Blog {
 	 *
 	 * Checks the 'public' column in the wp_blogs table.
 	 *
+     * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param int $blog_id The ID of the blog being checked.
 	 * @return bool True if hidden (public = 0), false otherwise.
 	 */
@@ -704,6 +751,9 @@ class BP_Blogs_Blog {
 
 	/**
 	 * Get ID of user-blog link.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $user_id ID of user.
 	 * @param int $blog_id ID of blog.

--- a/src/bp-blogs/classes/class-bp-blogs-component.php
+++ b/src/bp-blogs/classes/class-bp-blogs-component.php
@@ -45,6 +45,8 @@ class BP_Blogs_Component extends BP_Component {
 	 *
 	 * @since 1.5.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 *
 	 * @see BP_Component::setup_globals() for description of parameters.
 	 *
 	 * @param array $args See {@link BP_Component::setup_globals()}.
@@ -317,6 +319,8 @@ class BP_Blogs_Component extends BP_Component {
 
 	/**
 	 * Set up the title for pages and <title>.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 */
 	public function setup_title() {
 
@@ -437,6 +441,8 @@ class BP_Blogs_Component extends BP_Component {
 	 * Add the Sites directory states.
 	 *
 	 * @since 10.0.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 *
 	 * @param array   $states Optional. See BP_Component::admin_directory_states() for description.
 	 * @param WP_Post $post   Optional. See BP_Component::admin_directory_states() for description.

--- a/src/bp-core/admin/bp-core-admin-components.php
+++ b/src/bp-core/admin/bp-core-admin-components.php
@@ -294,6 +294,8 @@ function bp_core_admin_components_options() {
  *
  * @since 1.6.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @todo Use settings API when it supports saving network settings
  */
 function bp_core_admin_components_settings_handler() {

--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -209,6 +209,7 @@ function bp_core_add_admin_notice( $notice = '', $type = 'updated' ) {
  *   - that no WP page has multiple BP components associated with it.
  * The administrator will be shown a notice for each check that fails.
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  * @global WPDB $wpdb WordPress DB object
  * @global WP_Rewrite $wp_rewrite
  *

--- a/src/bp-core/admin/bp-core-admin-tools.php
+++ b/src/bp-core/admin/bp-core-admin-tools.php
@@ -183,6 +183,8 @@ function bp_admin_repair_list() {
  *
  * @since 2.0.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @return array
  */
 function bp_admin_repair_friend_count() {
@@ -241,6 +243,8 @@ function bp_admin_repair_friend_count() {
  * Recalculate group counts for each user.
  *
  * @since 2.0.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @return array
  */
@@ -406,6 +410,8 @@ function bp_admin_repair_last_activity() {
  * Migrate outstanding group invitations if needed.
  *
  * @since 6.0.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @return array
  */

--- a/src/bp-core/bp-core-avatars.php
+++ b/src/bp-core/bp-core-avatars.php
@@ -17,8 +17,6 @@ defined( 'ABSPATH' ) || exit;
  */
 function bp_core_set_avatar_constants() {
 
-	$bp = buddypress();
-
 	if ( !defined( 'BP_AVATAR_THUMB_WIDTH' ) )
 		define( 'BP_AVATAR_THUMB_WIDTH', 50 );
 
@@ -48,6 +46,8 @@ add_action( 'bp_init', 'bp_core_set_avatar_constants', 3 );
  * Set up global variables related to avatars.
  *
  * @since 1.5.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  */
 function bp_core_set_avatar_globals() {
 	$bp = buddypress();
@@ -142,6 +142,8 @@ function bp_core_is_default_gravatar( $d = '' ) {
  * @since 1.1.0
  * @since 2.4.0 Added 'extra_attr', 'scheme', 'rating' and 'force_default' for $args.
  *              These are inherited from WordPress 4.2.0. See {@link get_avatar()}.
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param array|string $args {
  *     An array of arguments. All arguments are technically optional; some
@@ -1027,6 +1029,8 @@ function bp_core_avatar_handle_upload( $file, $upload_dir_filter ) {
  *
  * @since 2.3.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @return string|null A JSON object containing success data if the upload succeeded
  *                     error message otherwise.
  */
@@ -1614,6 +1618,8 @@ function bp_core_check_avatar_type( $file ) {
  * Fetch data from the BP root blog's upload directory.
  *
  * @since 1.8.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param string $type The variable we want to return from the $bp->avatars object.
  *                     Only 'upload_path' and 'url' are supported. Default: 'upload_path'.

--- a/src/bp-core/bp-core-buddybar.php
+++ b/src/bp-core/bp-core-buddybar.php
@@ -98,6 +98,8 @@ function bp_core_new_nav_item( $args, $component = 'members' ) {
  *              object on success.
  * @since 4.0.0 Introduced `$component_id` argument.
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param array|string $args {
  *     Array describing the new nav item.
  *     @type string      $component_id            Optional. The ID of the component registering this nav item. Defaults to the
@@ -169,7 +171,7 @@ function bp_core_create_nav_link( $args = '', $component = 'members' ) {
 	);
 
 	// Add the item to the nav.
-	buddypress()->{$component}->nav->add_nav( $nav_item );
+	$bp->{$component}->nav->add_nav( $nav_item );
 
 	/**
 	 * Fires after a link is added to the main BuddyPress nav.
@@ -191,6 +193,8 @@ function bp_core_create_nav_link( $args = '', $component = 'members' ) {
  * Register a screen function for an item in the main nav array.
  *
  * @since 2.4.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param array|string $args {
  *     Array describing the new nav item.
@@ -307,6 +311,8 @@ function bp_core_register_nav_screen_function( $args = '' ) {
  * Modify the default subnav item that loads when a top level nav item is clicked.
  *
  * @since 1.1.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param array|string $args {
  *     @type string   $parent_slug     The slug of the nav item whose default is being changed.
@@ -509,6 +515,8 @@ function bp_core_new_subnav_item( $args, $component = null ) {
  * @since 2.4.0
  * @since 2.6.0 Introduced the `$component` parameter. Began returning a BP_Core_Nav_Item object on success.
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param array|string $args {
  *     Array describing the new subnav item.
  *     @type string      $name              Display name for the subnav item.
@@ -611,6 +619,8 @@ function bp_core_create_subnav_link( $args = '', $component = 'members' ) {
  * @since 2.4.0
  * @since 2.6.0 Introduced the `$component` parameter.
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param array|string $args {
  *     Array describing the new subnav item.
  *     @type string   $slug              Unique URL slug for the subnav item.
@@ -701,6 +711,8 @@ function bp_core_register_subnav_screen_function( $args = '', $component = 'memb
  *
  * @since 2.1.0
  * @since 2.6.0 Introduced the `$component` parameter.
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param array  $subnav_item The subnav array added to the secondary navigation of
  *                            the component in bp_core_new_subnav_item().
@@ -806,6 +818,8 @@ function bp_core_maybe_hook_new_subnav_screen_function( $subnav_item, $component
  * @since 1.5.0
  * @since 2.6.0 Introduced the `$component` parameter.
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param string $nav_item  The slug of the top-level nav item whose subnav items you're checking.
  *                          Default: the current component slug.
  * @param string $component The component the navigation is attached to. Defaults to 'members'.
@@ -844,6 +858,8 @@ function bp_nav_item_has_subnav( $nav_item = '', $component = 'members' ) {
  *
  * @since 1.0.0
  * @since 2.6.0 Introduced the `$component` parameter.
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param string      $slug      The slug of the primary navigation item.
  * @param string|null $component The component the navigation is attached to. Defaults to 'members'.
@@ -893,6 +909,8 @@ function bp_core_remove_nav_item( $slug, $component = null ) {
  * @since 1.0.0
  * @since 2.6.0 Introduced the `$component` parameter.
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param string      $parent_slug The slug of the primary navigation item.
  * @param string      $slug        The slug of the secondary item to be removed.
  * @param string|null $component   The component the navigation is attached to. Defaults to 'members'.
@@ -941,6 +959,8 @@ function bp_core_remove_subnav_item( $parent_slug, $slug, $component = null ) {
  *
  * @since 1.0.0
  * @since 2.6.0 Introduced the `$component` parameter.
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param string $parent_slug The slug of the parent navigation item.
  * @param string $component   The component the navigation is attached to. Defaults to 'members'.

--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -31,6 +31,8 @@ defined( 'ABSPATH' ) || exit;
  *    - $bp->action_variables: array ['group', 5]
  *
  * @since 1.0.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  */
 function bp_core_set_uri_globals() {
 	global $current_blog, $wp_rewrite;
@@ -598,6 +600,8 @@ add_filter( 'bp_core_set_uri_globals_member_slug', 'bp_core_members_shortlink_re
  * Catch unauthorized access to certain BuddyPress pages and redirect accordingly.
  *
  * @since 1.5.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  */
 function bp_core_catch_no_access() {
 	global $wp_query;
@@ -794,6 +798,8 @@ add_filter( 'shake_error_codes', 'bp_core_login_filter_shake_codes' );
  *
  * @since 1.6.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @see BP_Members_Component::setup_globals() where
  *      $bp->canonical_stack['base_url'] and ['component'] may be set.
  * @see bp_core_new_nav_item() where $bp->canonical_stack['action'] may be set.
@@ -865,6 +871,8 @@ function bp_rel_canonical() {
  * Get the canonical URL of the current page.
  *
  * @since 1.6.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param array $args {
  *     Optional array of arguments.
@@ -977,6 +985,8 @@ function bp_get_canonical_url( $args = array() ) {
  * Return the URL as requested on the current page load by the user agent.
  *
  * @since 1.6.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @return string Requested URL string.
  */

--- a/src/bp-core/bp-core-cssjs.php
+++ b/src/bp-core/bp-core-cssjs.php
@@ -451,6 +451,8 @@ function bp_core_get_js_dependencies() {
  *
  * @since 2.4.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param bool $return True to get the inline css.
  * @return null|array|false The inline css or an associative array containing
  *                          the css rules and the style handle.

--- a/src/bp-core/bp-core-filters.php
+++ b/src/bp-core/bp-core-filters.php
@@ -124,6 +124,8 @@ add_filter( 'posts_pre_query', 'bp_core_filter_wp_query', 10, 2 );
  *
  * @since 1.5.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param array $pages List of excluded page IDs, as passed to the
  *                     'wp_list_pages_excludes' filter.
  * @return array The exclude list, with BP's pages added.
@@ -157,6 +159,8 @@ add_filter( 'wp_list_pages_excludes', 'bp_core_exclude_pages' );
  * Prevent specific pages (eg 'Activate') from showing in the Pages meta box of the Menu Administration screen.
  *
  * @since 2.0.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param object|null $object The post type object used in the meta box.
  * @return object|null The $object, with a query argument to remove register and activate pages id.

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -63,6 +63,8 @@ function bp_db_version_raw() {
 	 *
 	 * @since 1.6.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 *
 	 * @return string The BuddyPress version direct from the database.
 	 */
 	function bp_get_db_version_raw() {
@@ -962,6 +964,8 @@ function bp_core_component_slug_from_root_slug( $root_slug ) {
  *
  * @since 1.0.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param string $slug The slug of the component being added to the root list.
  */
 function bp_core_add_root_component( $slug ) {
@@ -1003,6 +1007,8 @@ function bp_core_add_root_component( $slug ) {
  * Create WordPress pages to be used as BP component directories.
  *
  * @since 1.5.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  */
 function bp_core_create_root_component_page() {
 
@@ -1060,6 +1066,8 @@ function bp_core_get_component_search_query_arg( $component = null ) {
  * Get a list of all active component objects.
  *
  * @since 8.0.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param array $args {
  *     Optional. An array of key => value arguments to match against the component objects.
@@ -1630,6 +1638,8 @@ function bp_core_time_old( $birth_date ) {
  *
  * @since 1.0.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param string $message Feedback message to be displayed.
  * @param string $type    Message type. 'updated', 'success', 'error', 'warning'.
  *                        Default: 'success'.
@@ -1667,6 +1677,8 @@ function bp_core_add_message( $message, $type = '' ) {
  * so that the message is not shown to the user multiple times.
  *
  * @since 1.1.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  */
 function bp_core_setup_message() {
 
@@ -1700,6 +1712,8 @@ add_action( 'bp_actions', 'bp_core_setup_message', 5 );
  * called directly.
  *
  * @since 1.1.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  */
 function bp_core_render_message() {
 
@@ -1707,7 +1721,7 @@ function bp_core_render_message() {
 	$bp = buddypress();
 
 	if ( !empty( $bp->template_message ) ) :
-		$type    = ( 'success' === $bp->template_message_type ) ? 'updated' : 'error';
+		$type = ( 'success' === $bp->template_message_type ) ? 'updated' : 'error';
 
 		/**
 		 * Filters the 'template_notices' feedback message content.
@@ -1936,6 +1950,8 @@ function bp_delete_user_meta( $user_id, $key, $value = '' ) {
  * Initializes {@link BP_Embed} after everything is loaded.
  *
  * @since 1.5.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  */
 function bp_embed_init() {
 
@@ -2790,6 +2806,8 @@ function bp_core_get_components( $type = 'all' ) {
  *
  * @since 1.9.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @return mixed A URL or an array of dummy pages.
  */
 function bp_nav_menu_get_loggedin_pages() {
@@ -2856,6 +2874,8 @@ function bp_nav_menu_get_loggedin_pages() {
  * menu.
  *
  * @since 1.9.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @return mixed A URL or an array of dummy pages.
  */
@@ -3062,6 +3082,8 @@ add_action( 'wp_ajax_bp_get_suggestions', 'bp_ajax_get_suggestions' );
  * once to get what we need.
  *
  * @since 2.3.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @return bool|array
  */

--- a/src/bp-core/bp-core-options.php
+++ b/src/bp-core/bp-core-options.php
@@ -205,6 +205,8 @@ function bp_setup_option_filters() {
  *
  * @since 1.6.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param bool $value Optional. Default value false.
  * @return mixed False if not overloaded, mixed if set.
  */
@@ -310,6 +312,8 @@ function bp_delete_option( $option_name ) {
  *
  * @since 1.2.4
  * @deprecated 1.6.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param array $keys Array of site options.
  * @return bool
@@ -432,6 +436,8 @@ function bp_core_get_root_options() {
  * See {@see bp_core_get_root_options()}.
  *
  * @since 2.3.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param string $option Name of the option key.
  * @return mixed Value, if found.

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -26,7 +26,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0
  *
- *       viewed user.
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param string $parent_slug Options nav slug.
  * @return string
@@ -112,6 +112,8 @@ function bp_get_options_nav( $parent_slug = '' ) {
  * Not currently used in BuddyPress.
  *
  * @todo Deprecate.
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  */
 function bp_get_options_title() {
 	$bp = buddypress();
@@ -597,6 +599,8 @@ function bp_search_input_name( $component = '' ) {
  *
  * @since 2.7.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param string $component Component name. Defaults to current component.
  * @return string Text for the 'name' attribute.
  */
@@ -662,6 +666,8 @@ function bp_search_default_text( $component = '' ) {
 	 * Return the default text for the search box for a given component.
 	 *
 	 * @since 1.5.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 *
 	 * @param string $component Component name. Default: current component.
 	 * @return string Placeholder text for search field.
@@ -1158,6 +1164,8 @@ function bp_blog_signup_allowed() {
  *
  * @since 1.1.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @return bool True if the activation_complete global flag has been set,
  *              otherwise false.
  */
@@ -1253,6 +1261,8 @@ function bp_get_email_subject( $args = array() ) {
  * WordPress theme without coping the functions from functions.php.
  *
  * @since 1.2.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param string|bool $object Current template component.
  * @return string The AJAX querystring.
@@ -1411,6 +1421,8 @@ function bp_root_domain() {
 	 *
 	 * @since 1.1.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 *
 	 * @return string URL of the BP root blog.
 	 */
 	function bp_get_root_domain() {
@@ -1518,6 +1530,8 @@ function bp_root_slug( $component = '' ) {
  *
  * @since 1.5.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param string $root_slug Needle to our active component haystack.
  * @return mixed False if none found, component name if found.
  */
@@ -1597,6 +1611,8 @@ function bp_search_slug() {
  *
  * @since 1.0.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @return int $id ID of the currently displayed user.
  */
 function bp_displayed_user_id() {
@@ -1620,11 +1636,13 @@ function bp_displayed_user_id() {
  *
  * @since 1.0.0
  *
- * @return int ID of the logged-in user.
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
+ * @return integer ID of the logged-in user.
  */
 function bp_loggedin_user_id() {
-	$bp = buddypress();
-	$id = !empty( $bp->loggedin_user->id )
+	$bp      = buddypress();
+	$user_id = ! empty( $bp->loggedin_user->id )
 		? $bp->loggedin_user->id
 		: 0;
 
@@ -1633,9 +1651,9 @@ function bp_loggedin_user_id() {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param int $id ID of the currently logged-in user.
+	 * @param integer $user_id ID of the currently logged-in user.
 	 */
-	return (int) apply_filters( 'bp_loggedin_user_id', $id );
+	return (int) apply_filters( 'bp_loggedin_user_id', $user_id );
 }
 
 /** The is_() functions to determine the current page *****************************/
@@ -1650,6 +1668,8 @@ function bp_loggedin_user_id() {
  * - the component's id, or 'canonical' name.
  *
  * @since 1.5.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param string $component Name of the component being checked.
  * @return bool Returns true if the component matches, or else false.
@@ -1970,6 +1990,7 @@ function bp_is_root_component( $component_name = '' ) {
  *
  * @since 1.5.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  * @global int $current_blog WordPress global for the current blog.
  *
  * @param string $component Optional. Name of the component to check for.
@@ -2906,6 +2927,8 @@ function bp_is_group_single() {
  *
  * @since 2.4.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @return bool True if the current group page is a custom front.
  */
 function bp_is_group_custom_front() {
@@ -3066,6 +3089,8 @@ function bp_is_register_page() {
  * Get the title parts of the BuddyPress displayed page
  *
  * @since 2.4.3
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param string $seplocation Location for the separator.
  * @return array the title parts

--- a/src/bp-core/bp-core-theme-compatibility.php
+++ b/src/bp-core/bp-core-theme-compatibility.php
@@ -29,6 +29,8 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.7.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param string $theme Optional. The unique ID identifier of a theme package.
  */
 function bp_setup_theme_compat( $theme = '' ) {
@@ -231,6 +233,8 @@ function bp_detect_theme_compat_with_current_theme() {
  *
  * @since 1.7.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @return bool True if the current page uses theme compatibility.
  */
 function bp_is_theme_compat_active() {
@@ -312,6 +316,8 @@ function bp_set_theme_compat_original_template( $template = '' ) {
  * Set a theme compat feature
  *
  * @since 2.4.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param string $theme_id The theme id (eg: legacy).
  * @param array  $feature  An associative array (eg: array( name => 'feature_name', 'settings' => array() )).
@@ -478,6 +484,8 @@ function bp_register_theme_compat_default_features() {
  *
  * @since 1.7.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param string $template The template name to check.
  * @return bool True if the value of $template is the same as the
  *              "original_template" originally selected by WP. Otherwise false.
@@ -499,6 +507,8 @@ function bp_is_theme_compat_original_template( $template = '' ) {
  * {@link BuddyPress::register_theme_packages()}.
  *
  * @since 1.7.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @see BP_Theme_Compat for a description of the $theme parameter arguments.
  *
@@ -805,6 +815,7 @@ function bp_do_theme_compat() {
  *
  * @since 1.7.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  * @global WP_filter $wp_filter
  * @global array $merged_filters
  *
@@ -860,6 +871,7 @@ function bp_remove_all_filters( $tag, $priority = false ) {
  *
  * @since 1.7.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  * @global WP_filter $wp_filter
  * @global array $merged_filters
  *
@@ -998,8 +1010,10 @@ add_filter( 'bp_replace_the_content', 'bp_theme_compat_toggle_is_page', 9999 );
  *
  * @since 1.9.2
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @see bp_theme_compat_toggle_is_page()
- * @param object $query The WP_Query object.
+ * @param WP_Query $query The WP_Query object.
  */
 function bp_theme_compat_loop_end( $query ) {
 

--- a/src/bp-core/bp-core-update.php
+++ b/src/bp-core/bp-core-update.php
@@ -536,6 +536,8 @@ function bp_update_to_2_5() {
  * - Add ignore deprecated code option (false for updates).
  *
  * @since 2.7.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  */
 function bp_update_to_2_7() {
 	bp_add_option( 'bp-emails-unsubscribe-salt', base64_encode( wp_generate_password( 64, true, true ) ) );
@@ -798,10 +800,12 @@ function bp_core_get_11_0_upgrade_email_schema( $emails ) {
  *
  * @since 2.2.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  * @global $wpdb
  */
 function bp_migrate_new_member_activity_component() {
 	global $wpdb;
+
 	$bp = buddypress();
 
 	// Update the component for the new_member type.

--- a/src/bp-core/classes/class-bp-admin-types.php
+++ b/src/bp-core/classes/class-bp-admin-types.php
@@ -73,6 +73,8 @@ class BP_Admin_Types {
 	 *
 	 * @since 7.0.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 *
 	 * @return BP_Admin_Types
 	 */
 	public static function register_types_admin() {

--- a/src/bp-core/classes/class-bp-admin.php
+++ b/src/bp-core/classes/class-bp-admin.php
@@ -117,6 +117,8 @@ class BP_Admin {
 	 * Set admin-related globals.
 	 *
 	 * @since 1.6.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 */
 	private function setup_globals() {
 		$bp = buddypress();

--- a/src/bp-core/classes/class-bp-attachment-avatar.php
+++ b/src/bp-core/classes/class-bp-attachment-avatar.php
@@ -354,10 +354,12 @@ class BP_Attachment_Avatar extends BP_Attachment {
 	 *
 	 * @since 2.3.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 *
 	 * @return integer The user ID.
 	 */
 	private function get_user_id() {
-		$bp = buddypress();
+		$bp      = buddypress();
 		$user_id = 0;
 
 		if ( bp_is_user() ) {

--- a/src/bp-core/classes/class-bp-core-bp-nav-backcompat.php
+++ b/src/bp-core/classes/class-bp-core-bp-nav-backcompat.php
@@ -57,6 +57,8 @@ class BP_Core_BP_Nav_BackCompat implements ArrayAccess {
 	 *
 	 * @since 2.6.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 *
 	 * @param mixed $offset Array offset.
 	 * @param array $value  Nav item.
 	 */
@@ -216,8 +218,6 @@ class BP_Core_BP_Nav_BackCompat implements ArrayAccess {
 	 * @return bool|array
 	 */
 	protected function get_nav( $offset ) {
-		$bp = buddypress();
-
 		$component_nav = $this->get_component_nav( $offset );
 		$primary_nav   = $component_nav->get_primary( array( 'slug' => $offset ), false );
 
@@ -245,13 +245,15 @@ class BP_Core_BP_Nav_BackCompat implements ArrayAccess {
 	 *
 	 * @since 2.6.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 *
 	 * @param string $offset Nav item name.
 	 * @return BP_Core_Nav
 	 */
 	protected function get_component_nav( $offset = '' ) {
 		$component = $this->get_component( $offset );
+		$bp        = buddypress();
 
-		$bp = buddypress();
 		if ( ! isset( $bp->{$component}->nav ) ) {
 			return false;
 		}

--- a/src/bp-core/classes/class-bp-core-user.php
+++ b/src/bp-core/classes/class-bp-core-user.php
@@ -248,6 +248,9 @@ class BP_Core_User {
 	 *
 	 * @deprecated 1.7.0 Use {@link BP_User_Query}.
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @see BP_User_Query for a description of parameters, most of which
 	 *      are used there in the same way.
 	 *
@@ -465,6 +468,7 @@ class BP_Core_User {
 	/**
 	 * Fetch the details for all users whose usernames start with the given letter.
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param string   $letter          The letter the users names are to start with.
@@ -647,6 +651,7 @@ class BP_Core_User {
 	/**
 	 * Find users who match on the value of an xprofile data.
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param string   $search_terms    The terms to search the profile table
@@ -707,6 +712,7 @@ class BP_Core_User {
 	 *
 	 * Accepts multiple user IDs to fetch data for.
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param array       $paged_users An array of stdClass containing the users.
@@ -796,6 +802,9 @@ class BP_Core_User {
 
 	/**
 	 * Get last activity data for a user or set of users.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int|array $user_id User IDs or multiple user IDs.
 	 * @return false|array

--- a/src/bp-core/classes/class-bp-core.php
+++ b/src/bp-core/classes/class-bp-core.php
@@ -67,6 +67,8 @@ class BP_Core extends BP_Component {
 	 * and optional components.
 	 *
 	 * @since 1.5.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 */
 	private function bootstrap() {
 		$bp = buddypress();
@@ -200,6 +202,8 @@ class BP_Core extends BP_Component {
 	 * amount of processing, meaning they cannot be set in the BuddyPress class.
 	 *
 	 * @since 1.5.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 *
 	 * @see BP_Component::setup_globals() for description of parameters.
 	 *

--- a/src/bp-core/classes/class-bp-user-query.php
+++ b/src/bp-core/classes/class-bp-user-query.php
@@ -233,6 +233,9 @@ class BP_User_Query {
 	 * Prepare the query for user_ids.
 	 *
 	 * @since 1.7.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
 	 */
 	public function prepare_user_ids_query() {
 		global $wpdb;

--- a/src/bp-friends/bp-friends-activity.php
+++ b/src/bp-friends/bp-friends-activity.php
@@ -91,6 +91,8 @@ function friends_delete_activity( $args ) {
  *
  * @since 1.1.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @return bool False if activity component is not active.
  */
 function friends_register_activity_actions() {

--- a/src/bp-groups/classes/class-bp-groups-member.php
+++ b/src/bp-groups/classes/class-bp-groups-member.php
@@ -796,6 +796,9 @@ class BP_Groups_Member {
 	 *
 	 * @since 4.0.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param int $user_id ID of the user.
 	 * @param array $args {
 	 *    Array of optional arguments.

--- a/src/bp-messages/classes/class-bp-messages-thread.php
+++ b/src/bp-messages/classes/class-bp-messages-thread.php
@@ -539,6 +539,7 @@ class BP_Messages_Thread {
 	 *
 	 * @since 10.0.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $thread_id The message thread ID.
@@ -918,6 +919,9 @@ class BP_Messages_Thread {
 	 * Returns the total number of message threads for a user.
 	 *
 	 * @since 1.0.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int    $user_id The user ID.
 	 * @param string $box     The type of mailbox to get. Either 'inbox' or 'sentbox'.

--- a/src/bp-notifications/bp-notifications-functions.php
+++ b/src/bp-notifications/bp-notifications-functions.php
@@ -196,6 +196,8 @@ function bp_notifications_get_grouped_notifications_for_user( $user_id = 0 ) {
  *
  * @since 1.9.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @param int    $user_id ID of the user whose notifications are being fetched.
  * @param string $format  Format of the returned values. 'string' returns HTML,
  *                        while 'object' returns a structured object for parsing.
@@ -722,6 +724,8 @@ function bp_notifications_get_unread_notification_count( $user_id = 0 ) {
  * registered Notifications callbacks.
  *
  * @since 1.9.1
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @see http://buddypress.trac.wordpress.org/ticket/5300
  *

--- a/src/bp-notifications/classes/class-bp-notifications-component.php
+++ b/src/bp-notifications/classes/class-bp-notifications-component.php
@@ -91,6 +91,8 @@ class BP_Notifications_Component extends BP_Component {
 	 *
 	 * @since 1.9.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 *
 	 * @see BP_Component::setup_globals() for a description of arguments.
 	 *
 	 * @param array $args See BP_Component::setup_globals() for a description.
@@ -278,6 +280,8 @@ class BP_Notifications_Component extends BP_Component {
 	 * Set up the title for pages and <title>.
 	 *
 	 * @since 1.9.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 */
 	public function setup_title() {
 

--- a/src/bp-notifications/classes/class-bp-notifications-notification.php
+++ b/src/bp-notifications/classes/class-bp-notifications-notification.php
@@ -902,6 +902,9 @@ class BP_Notifications_Notification {
 	 *
 	 * @since 10.0.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param string $field The name of the db field of the items to update.
 	 *                      Possible values are `id` or `item_id`.
 	 * @param int[]  $items The list of items to update.
@@ -911,6 +914,7 @@ class BP_Notifications_Notification {
 	 */
 	public static function update_id_list( $field, $items = array(), $data = array(), $where = array() ) {
 		global $wpdb;
+
 		$bp = buddypress();
 
 		$supported_fields = array( 'id', 'item_id' );
@@ -1000,6 +1004,9 @@ class BP_Notifications_Notification {
 	 *
 	 * @since 10.0.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param string $field The name of the db field of the items to delete.
 	 *                      Possible values are `id` or `item_id`.
 	 * @param int[]  $items The list of items to delete.
@@ -1008,6 +1015,7 @@ class BP_Notifications_Notification {
 	 */
 	public static function delete_by_id_list( $field, $items = array(), $args = array() ) {
 		global $wpdb;
+
 		$bp = buddypress();
 
 		$supported_fields = array( 'id', 'item_id' );

--- a/src/bp-templates/bp-legacy/buddypress-functions.php
+++ b/src/bp-templates/bp-legacy/buddypress-functions.php
@@ -958,6 +958,8 @@ function bp_legacy_theme_activity_template_loader() {
  *
  * @since 1.2.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @return string|null HTML
  */
 function bp_legacy_theme_post_update() {
@@ -1049,8 +1051,6 @@ function bp_legacy_theme_post_update() {
  */
 function bp_legacy_theme_new_activity_comment() {
 	global $activities_template;
-
-	$bp = buddypress();
 
 	if ( ! bp_is_post_request() ) {
 		return;
@@ -1200,6 +1200,8 @@ function bp_legacy_theme_delete_activity_comment() {
  * AJAX spam an activity item or comment.
  *
  * @since 1.6.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @return mixed String on error, void on success.
  */

--- a/src/bp-templates/bp-nouveau/buddypress-functions.php
+++ b/src/bp-templates/bp-nouveau/buddypress-functions.php
@@ -72,6 +72,8 @@ class BP_Nouveau extends BP_Theme_Compat {
 	 * BP Nouveau global variables.
 	 *
 	 * @since 3.0.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 */
 	protected function setup_globals() {
 		$bp = buddypress();

--- a/src/bp-templates/bp-nouveau/includes/activity/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/ajax.php
@@ -342,12 +342,14 @@ function bp_nouveau_ajax_get_single_activity_content() {
  *
  * @since 3.0.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  * @global BP_Activity_Template $activities_template
  *
  * @return string JSON reply
  */
 function bp_nouveau_ajax_new_activity_comment() {
 	global $activities_template;
+
 	$bp = buddypress();
 
 	$response = array(
@@ -497,6 +499,8 @@ function bp_nouveau_ajax_get_activity_objects() {
  *
  * @since 3.0.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @return string JSON reply
  */
 function bp_nouveau_ajax_post_update() {
@@ -608,6 +612,8 @@ function bp_nouveau_ajax_post_update() {
  * AJAX spam an activity item or comment.
  *
  * @since 3.0.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @return string JSON reply.
  */

--- a/src/bp-templates/bp-nouveau/includes/activity/loader.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/loader.php
@@ -87,6 +87,8 @@ class BP_Nouveau_Activity {
 	 * Register do_action() hooks
 	 *
 	 * @since 3.0.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 */
 	protected function setup_actions() {
 		add_action( 'bp_nouveau_enqueue_scripts', 'bp_nouveau_activity_enqueue_scripts' );

--- a/src/bp-templates/bp-nouveau/includes/groups/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/ajax.php
@@ -255,6 +255,8 @@ function bp_nouveau_ajax_joinleave_group() {
 
 /**
  * @since 3.0.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  */
 function bp_nouveau_ajax_get_users_to_invite() {
 	$bp = buddypress();
@@ -377,7 +379,6 @@ function bp_nouveau_ajax_get_users_to_invite() {
  * @since 3.0.0
  */
 function bp_nouveau_ajax_send_group_invites() {
-	$bp = buddypress();
 
 	$response = array(
 		'feedback' => __( 'Invites could not be sent. Please try again.', 'buddypress' ),

--- a/src/bp-templates/bp-nouveau/includes/groups/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/functions.php
@@ -354,6 +354,8 @@ function bp_nouveau_group_invites_create_steps( $steps = array() ) {
  *
  * @since 3.0.0
  * @since 10.0.0 The function is no longer creating a Group invite nav.
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  */
 function bp_nouveau_group_setup_nav() {
 	if ( ! bp_is_group() || ! bp_groups_user_can_send_invites() ) {
@@ -376,6 +378,8 @@ function bp_nouveau_group_setup_nav() {
  *
  * @since 3.0.0
  * @deprecated 6.3.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  *
  * @param string $message The message to send with the invite
  */

--- a/src/bp-templates/bp-nouveau/includes/groups/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/template-tags.php
@@ -257,6 +257,8 @@ function bp_nouveau_groups_get_group_invites_setting( $user_id = 0 ) {
  *
  * @since 3.0.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ *
  * @todo This output isn't localised correctly.
  */
 function bp_nouveau_group_creation_tabs() {

--- a/src/bp-templates/bp-nouveau/includes/messages/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/messages/functions.php
@@ -183,6 +183,8 @@ function bp_nouveau_messages_localize_scripts( $params = array() ) {
 
 /**
  * @since 3.0.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  */
 function bp_nouveau_messages_adjust_nav() {
 	$bp = buddypress();
@@ -305,6 +307,8 @@ function bp_nouveau_unregister_notices_widget() {
  * Add active sitewide notices to the BP template_message global.
  *
  * @since 3.0.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  */
 function bp_nouveau_push_sitewide_notices() {
 	// Do not show notices if user is not logged in.

--- a/src/bp-xprofile/bp-xprofile-admin.php
+++ b/src/bp-xprofile/bp-xprofile-admin.php
@@ -554,8 +554,11 @@ function xprofile_admin_delete_group_screen( $group_id ) {
  *
  * @since 1.0.0
  *
- * @param int      $group_id ID of the group.
- * @param int|null $field_id ID of the field being managed.
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ * @global wpdb $wpdb WordPress database object.
+ *
+ * @param integer      $group_id ID of the group.
+ * @param integer|null $field_id ID of the field being managed.
  */
 function xprofile_admin_manage_field( $group_id, $field_id = null ) {
 	global $wpdb, $message, $groups;

--- a/src/bp-xprofile/bp-xprofile-cache.php
+++ b/src/bp-xprofile/bp-xprofile-cache.php
@@ -50,9 +50,12 @@ function bp_xprofile_get_non_cached_field_ids( $user_id = 0, $field_ids = array(
  *
  * @since 2.0.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ * @global wpdb $wpdb WordPress database object.
+ *
  * @param array $object_ids Multi-dimensional array of object_ids, keyed by
  *                          object type ('group', 'field', 'data').
- * @return bool
+ * @return boolean
  */
 function bp_xprofile_update_meta_cache( $object_ids = array() ) {
 	global $wpdb;

--- a/src/bp-xprofile/bp-xprofile-functions.php
+++ b/src/bp-xprofile/bp-xprofile-functions.php
@@ -767,6 +767,9 @@ add_action( 'bp_setup_globals', 'xprofile_override_user_fullnames', 100 );
  *
  * @since 2.0.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ * @global wpdb $wpdb WordPress database object.
+ *
  * @param array         $sql   Clauses in the user_id SQL query.
  * @param BP_User_Query $query User query object.
  * @return array
@@ -1146,14 +1149,17 @@ function bp_xprofile_update_fielddata_meta( $field_data_id, $meta_key, $meta_val
  *
  * @since 2.0.0
  *
- * @return int Field ID.
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ * @global wpdb $wpdb WordPress database object.
+ *
+ * @return integer Field ID.
  */
 function bp_xprofile_fullname_field_id() {
+	global $wpdb;
+
 	$id = wp_cache_get( 'fullname_field_id', 'bp_xprofile' );
 
 	if ( false === $id ) {
-		global $wpdb;
-
 		$bp = buddypress();
 		$id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$bp->profile->table_name_fields} WHERE name = %s", addslashes( bp_xprofile_fullname_field_name() ) ) );
 
@@ -1475,13 +1481,17 @@ function bp_xprofile_get_wp_user_keys() {
  *
  * @since 8.0.0
  *
+ * @global BuddyPress $bp The one true BuddyPress instance.
+ * @global wpdb $wpdb WordPress database object.
+ *
  * @return int[] The signup field IDs.
  */
 function bp_xprofile_get_signup_field_ids() {
+	global $wpdb;
+
 	$signup_field_ids = wp_cache_get( 'signup_fields', 'bp_xprofile' );
 
 	if ( ! $signup_field_ids ) {
-		global $wpdb;
 		$bp = buddypress();
 
 		$signup_field_ids = $wpdb->get_col( "SELECT object_id FROM {$bp->profile->table_name_meta} WHERE object_type = 'field' AND meta_key = 'signup_position' ORDER BY CONVERT(meta_value, SIGNED) ASC" );

--- a/src/bp-xprofile/bp-xprofile-loader.php
+++ b/src/bp-xprofile/bp-xprofile-loader.php
@@ -17,6 +17,8 @@ defined( 'ABSPATH' ) || exit;
  * Set up the bp-xprofile component.
  *
  * @since 1.6.0
+ *
+ * @global BuddyPress $bp The one true BuddyPress instance.
  */
 function bp_setup_xprofile() {
 	$bp = buddypress();

--- a/src/bp-xprofile/classes/class-bp-xprofile-component.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-component.php
@@ -132,6 +132,8 @@ class BP_XProfile_Component extends BP_Component {
 	 *
 	 * @since 1.5.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 *
 	 * @param array $args Array of globals to set up.
 	 */
 	public function setup_globals( $args = array() ) {
@@ -372,6 +374,8 @@ class BP_XProfile_Component extends BP_Component {
 
 	/**
 	 * Sets up the title for pages and <title>.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
 	 *
 	 * @since 1.5.0
 	 */

--- a/src/bp-xprofile/classes/class-bp-xprofile-field.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-field.php
@@ -207,7 +207,7 @@ class BP_XProfile_Field {
 	 * @since 1.1.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 * @global WP_User $userdata User data object.
 	 *
 	 * @param int      $id Field ID.
@@ -347,7 +347,8 @@ class BP_XProfile_Field {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @global object $wpdb
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param boolean $delete_data Whether or not to delete data.
 	 * @return boolean
@@ -406,7 +407,7 @@ class BP_XProfile_Field {
 	 * @since 1.1.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @return boolean
 	 */
@@ -609,7 +610,8 @@ class BP_XProfile_Field {
 	 *
 	 * @since 1.2.0
 	 *
-	 * @global object $wpdb
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
 	 */
 	public function delete_children() {
 		global $wpdb;
@@ -921,6 +923,9 @@ class BP_XProfile_Field {
 	/**
 	 * Get the type for provided field ID.
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param int $field_id Field ID to get type of.
 	 * @return bool|null|string
 	 */
@@ -949,7 +954,8 @@ class BP_XProfile_Field {
 	 *
 	 * @since 1.2.0
 	 *
-	 * @global object $wpdb
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $group_id ID of the field group to delete fields from.
 	 * @return boolean
@@ -980,7 +986,7 @@ class BP_XProfile_Field {
 	 * @since 1.5.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param string $field_name Name of the field to query the ID for.
 	 * @return int|null Field ID on success; null on failure.
@@ -1010,7 +1016,7 @@ class BP_XProfile_Field {
 	 * @since 1.5.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int      $field_id       ID of the field to update.
 	 * @param int|null $position       Field position to update.
@@ -1058,7 +1064,7 @@ class BP_XProfile_Field {
 	 * @since 2.4.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param string|array $member_types Member type or array of member types. Use 'any' to return unrestricted
 	 *                                   fields (those available for anyone, regardless of member type).

--- a/src/bp-xprofile/classes/class-bp-xprofile-field.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-field.php
@@ -206,8 +206,9 @@ class BP_XProfile_Field {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @global object $wpdb
-	 * @global object $userdata
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
+	 * @global WP_User $userdata User data object.
 	 *
 	 * @param int      $id Field ID.
 	 * @param int|null $user_id User ID.
@@ -404,7 +405,8 @@ class BP_XProfile_Field {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @global object $wpdb
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @return boolean
 	 */
@@ -977,7 +979,8 @@ class BP_XProfile_Field {
 	 *
 	 * @since 1.5.0
 	 *
-	 * @global object $wpdb
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param string $field_name Name of the field to query the ID for.
 	 * @return int|null Field ID on success; null on failure.
@@ -1006,7 +1009,8 @@ class BP_XProfile_Field {
 	 *
 	 * @since 1.5.0
 	 *
-	 * @global object $wpdb
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int      $field_id       ID of the field to update.
 	 * @param int|null $position       Field position to update.
@@ -1021,8 +1025,10 @@ class BP_XProfile_Field {
 			return false;
 		}
 
+		$bp = buddypress();
+
 		// Get table name and field parent.
-		$table_name = buddypress()->profile->table_name_fields;
+		$table_name = $bp->profile->table_name_fields;
 		$sql        = $wpdb->prepare( "UPDATE {$table_name} SET field_order = %d, group_id = %d WHERE id = %d", $position, $field_group_id, $field_id );
 		$parent     = $wpdb->query( $sql );
 
@@ -1050,6 +1056,9 @@ class BP_XProfile_Field {
 	 * Gets the IDs of fields applicable for a given member type or array of member types.
 	 *
 	 * @since 2.4.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param string|array $member_types Member type or array of member types. Use 'any' to return unrestricted
 	 *                                   fields (those available for anyone, regardless of member type).

--- a/src/bp-xprofile/classes/class-bp-xprofile-group.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-group.php
@@ -83,8 +83,6 @@ class BP_XProfile_Group {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @global $wpdb $wpdb
-	 *
 	 * @param int $id Field group ID.
 	 * @return boolean
 	 */
@@ -117,7 +115,7 @@ class BP_XProfile_Group {
 	 * @since 1.1.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @return boolean
 	 */
@@ -178,7 +176,8 @@ class BP_XProfile_Group {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @global object $wpdb
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @return boolean
 	 */
@@ -243,7 +242,7 @@ class BP_XProfile_Group {
 	 * @since 11.0.0 `$profile_group_id` accepts an array of profile group ids.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param array $args {
 	 *      Array of optional arguments.
@@ -470,7 +469,7 @@ class BP_XProfile_Group {
 	 * @since 11.0.0 `$profile_group_id` accepts an array of profile group ids.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param array $args {
 	 *    Array of optional arguments.
@@ -530,7 +529,7 @@ class BP_XProfile_Group {
 	 * @since 5.0.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param array $group_ids Array of group IDs.
 	 * @param array $args {
@@ -722,7 +721,7 @@ class BP_XProfile_Group {
 	 * @since 1.5.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param  int $field_group_id ID of the group the field belongs to.
 	 * @param  int $position       Field group position.
@@ -796,7 +795,7 @@ class BP_XProfile_Group {
 	 * @since 1.6.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @return array $default_visibility_levels An array, keyed by field_id, of default
 	 *                                          visibility level + allow_custom

--- a/src/bp-xprofile/classes/class-bp-xprofile-group.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-group.php
@@ -116,7 +116,8 @@ class BP_XProfile_Group {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @global object $wpdb
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @return boolean
 	 */
@@ -241,7 +242,8 @@ class BP_XProfile_Group {
 	 * @since 8.0.0  Introduced `$hide_field_types` & `$signup_fields_only` arguments.
 	 * @since 11.0.0 `$profile_group_id` accepts an array of profile group ids.
 	 *
-	 * @global object $wpdb WordPress DB access object.
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param array $args {
 	 *      Array of optional arguments.
@@ -467,6 +469,9 @@ class BP_XProfile_Group {
 	 * @since 5.0.0
 	 * @since 11.0.0 `$profile_group_id` accepts an array of profile group ids.
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param array $args {
 	 *    Array of optional arguments.
 	 *
@@ -523,6 +528,9 @@ class BP_XProfile_Group {
 	 * Gets group field IDs, based on passed parameters.
 	 *
 	 * @since 5.0.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param array $group_ids Array of group IDs.
 	 * @param array $args {
@@ -713,7 +721,8 @@ class BP_XProfile_Group {
 	 *
 	 * @since 1.5.0
 	 *
-	 * @global $wpdb $wpdb
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param  int $field_group_id ID of the group the field belongs to.
 	 * @param  int $position       Field group position.
@@ -785,6 +794,9 @@ class BP_XProfile_Group {
 	 * Fetch the admin-set preferences for all fields.
 	 *
 	 * @since 1.6.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @return array $default_visibility_levels An array, keyed by field_id, of default
 	 *                                          visibility level + allow_custom

--- a/src/bp-xprofile/classes/class-bp-xprofile-profiledata.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-profiledata.php
@@ -77,7 +77,7 @@ class BP_XProfile_ProfileData {
 	 * @since 1.0.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $field_id Field ID to populate.
 	 * @param int $user_id  User ID to populate for.
@@ -118,8 +118,8 @@ class BP_XProfile_ProfileData {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @global object $wpdb
-	 * @global array $bp
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @return bool
 	 */
@@ -153,7 +153,8 @@ class BP_XProfile_ProfileData {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @global object $wpdb
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @return bool
 	 */
@@ -180,7 +181,7 @@ class BP_XProfile_ProfileData {
 	 * @since 1.0.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @return bool
 	 */
@@ -281,7 +282,7 @@ class BP_XProfile_ProfileData {
 	 * @since 1.0.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @return boolean
 	 */
@@ -326,7 +327,7 @@ class BP_XProfile_ProfileData {
 	 *              Adds a new parameter `$field_type_objects` to pass the list of field type objects.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int   $user_id            ID of user whose data is being queried.
 	 * @param array $field_ids          Array of field IDs to query for.
@@ -486,7 +487,7 @@ class BP_XProfile_ProfileData {
 	 * @since 1.6.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $field_id Field ID being queried for.
 	 * @param int $user_id  User ID associated with field.
@@ -522,7 +523,7 @@ class BP_XProfile_ProfileData {
 	 * @since 8.0.0 Checks if a null field data is an xProfile WP Field.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int            $field_id ID of the field.
 	 * @param int|array|null $user_ids ID or IDs of user(s).
@@ -634,7 +635,7 @@ class BP_XProfile_ProfileData {
 	 * @deprecated 8.0.0 This function is not used anymore.
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param array|string $fields  Field(s) to get.
 	 * @param int|null     $user_id User ID to get field data for.
@@ -702,7 +703,7 @@ class BP_XProfile_ProfileData {
 	 * @since 1.0.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $field_id ID of the field to delete.
 	 * @return bool
@@ -725,7 +726,7 @@ class BP_XProfile_ProfileData {
 	 * @since 1.0.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
-     * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $user_id User ID to get time for.
 	 * @return null|string
@@ -746,7 +747,7 @@ class BP_XProfile_ProfileData {
 	 * @since 1.0.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
- 	 * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $user_id User ID to remove data for.
 	 * @return false|int
@@ -775,7 +776,7 @@ class BP_XProfile_ProfileData {
 	 * @since 1.0.0
 	 *
 	 * @global BuddyPress $bp The one true BuddyPress instance.
- 	 * @global wpdb $wpdb WordPress database object.
+	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int    $user_id          User ID to query for.
 	 * @param string $exclude_fullname SQL portion used to exclude by field ID.

--- a/src/bp-xprofile/classes/class-bp-xprofile-profiledata.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-profiledata.php
@@ -76,6 +76,9 @@ class BP_XProfile_ProfileData {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param int $field_id Field ID to populate.
 	 * @param int $user_id  User ID to populate for.
 	 */
@@ -176,6 +179,9 @@ class BP_XProfile_ProfileData {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @return bool
 	 */
 	public function save() {
@@ -274,7 +280,8 @@ class BP_XProfile_ProfileData {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @global object $wpdb
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @return boolean
 	 */
@@ -317,6 +324,9 @@ class BP_XProfile_ProfileData {
 	 * @since 2.0.0
 	 * @since 8.0.0 Checks if a null field data is an xProfile WP Field.
 	 *              Adds a new parameter `$field_type_objects` to pass the list of field type objects.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int   $user_id            ID of user whose data is being queried.
 	 * @param array $field_ids          Array of field IDs to query for.
@@ -475,6 +485,9 @@ class BP_XProfile_ProfileData {
 	 *
 	 * @since 1.6.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param int $field_id Field ID being queried for.
 	 * @param int $user_id  User ID associated with field.
 	 * @return int $fielddata_id
@@ -507,6 +520,9 @@ class BP_XProfile_ProfileData {
 	 *
 	 * @since 1.0.0
 	 * @since 8.0.0 Checks if a null field data is an xProfile WP Field.
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int            $field_id ID of the field.
 	 * @param int|array|null $user_ids ID or IDs of user(s).
@@ -617,6 +633,9 @@ class BP_XProfile_ProfileData {
 	 * @since 1.0.0
 	 * @deprecated 8.0.0 This function is not used anymore.
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param array|string $fields  Field(s) to get.
 	 * @param int|null     $user_id User ID to get field data for.
 	 * @return array|bool
@@ -682,6 +701,9 @@ class BP_XProfile_ProfileData {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param int $field_id ID of the field to delete.
 	 * @return bool
 	 */
@@ -702,6 +724,9 @@ class BP_XProfile_ProfileData {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+     * @global wpdb $wpdb WordPress database object.
+	 *
 	 * @param int $user_id User ID to get time for.
 	 * @return null|string
 	 */
@@ -719,6 +744,9 @@ class BP_XProfile_ProfileData {
 	 * Delete all data for provided user ID.
 	 *
 	 * @since 1.0.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+ 	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int $user_id User ID to remove data for.
 	 * @return false|int
@@ -745,6 +773,9 @@ class BP_XProfile_ProfileData {
 	 * Get random field type by user ID.
 	 *
 	 * @since 1.0.0
+	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+ 	 * @global wpdb $wpdb WordPress database object.
 	 *
 	 * @param int    $user_id          User ID to query for.
 	 * @param string $exclude_fullname SQL portion used to exclude by field ID.

--- a/src/bp-xprofile/classes/class-bp-xprofile-user-admin.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-user-admin.php
@@ -23,6 +23,8 @@ class BP_XProfile_User_Admin {
 	 *
 	 * @since 2.0.0
 	 *
+	 * @global BuddyPress $bp The one true BuddyPress instance.
+	 *
 	 * @return BP_XProfile_User_Admin
 	 */
 	public static function register_xprofile_user_admin() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

- As titled;
- Removing `$bp` when not used on the function/method;
- Minor tweaks.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8553

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
