### PR TITLE
PHPDoc: changes to action callbacks that should not be returning anything

### DIFF
--- a/src/bp-activity/actions/delete.php
+++ b/src/bp-activity/actions/delete.php
@@ -13,19 +13,18 @@
  * @since 1.1.0
  *
  * @param int $activity_id Activity id to be deleted. Defaults to 0.
- * @return bool False on failure.
  */
 function bp_activity_action_delete_activity( $activity_id = 0 ) {
 	// Not viewing activity or action is not delete.
 	if ( !bp_is_activity_component() || !bp_is_current_action( 'delete' ) )
-		return false;
+		return;
 
 	if ( empty( $activity_id ) && bp_action_variable( 0 ) )
 		$activity_id = (int) bp_action_variable( 0 );
 
 	// Not viewing a specific activity item.
 	if ( empty( $activity_id ) )
-		return false;
+		return;
 
 	// Check the nonce.
 	check_admin_referer( 'bp_activity_delete_link' );
@@ -35,7 +34,7 @@ function bp_activity_action_delete_activity( $activity_id = 0 ) {
 
 	// Check access.
 	if ( ! bp_activity_user_can_delete( $activity ) )
-		return false;
+		return;
 
 	/**
 	 * Fires before the deletion so plugins can still fetch information about it.

--- a/src/bp-activity/actions/favorite.php
+++ b/src/bp-activity/actions/favorite.php
@@ -11,19 +11,17 @@
  * Mark activity as favorite.
  *
  * @since 1.2.0
- *
- * @return bool False on failure.
  */
 function bp_activity_action_mark_favorite() {
 	if ( !is_user_logged_in() || !bp_is_activity_component() || !bp_is_current_action( 'favorite' ) )
-		return false;
+		return;
 
 	// Check the nonce.
 	check_admin_referer( 'mark_favorite' );
 
 	$activity_item = new BP_Activity_Activity( bp_action_variable( 0 ) );
 	if ( ! bp_activity_user_can_read( $activity_item, bp_loggedin_user_id() ) ) {
-		return false;
+		return;
 	}
 
 	if ( bp_activity_add_user_favorite( bp_action_variable( 0 ) ) )

--- a/src/bp-activity/actions/feeds.php
+++ b/src/bp-activity/actions/feeds.php
@@ -11,14 +11,12 @@
  * Load the sitewide activity feed.
  *
  * @since 1.0.0
- *
- * @return bool False on failure.
  */
 function bp_activity_action_sitewide_feed() {
 	$bp = buddypress();
 
 	if ( ! bp_is_activity_component() || ! bp_is_current_action( 'feed' ) || bp_is_user() || ! empty( $bp->groups->current_group ) ) {
-		return false;
+		return;
 	}
 
 	$link = bp_get_activity_directory_permalink();
@@ -44,12 +42,10 @@ add_action( 'bp_actions', 'bp_activity_action_sitewide_feed' );
  * Load a user's personal activity feed.
  *
  * @since 1.0.0
- *
- * @return bool False on failure.
  */
 function bp_activity_action_personal_feed() {
 	if ( ! bp_is_user_activity() || ! bp_is_current_action( 'feed' ) ) {
-		return false;
+		return;
 	}
 
 	$link = trailingslashit( bp_displayed_user_domain() . bp_get_activity_slug() );
@@ -77,12 +73,10 @@ add_action( 'bp_actions', 'bp_activity_action_personal_feed' );
  * Load a user's friends' activity feed.
  *
  * @since 1.0.0
- *
- * @return bool False on failure.
  */
 function bp_activity_action_friends_feed() {
 	if ( ! bp_is_active( 'friends' ) || ! bp_is_user_activity() || ! bp_is_current_action( bp_get_friends_slug() ) || ! bp_is_action_variable( 'feed', 0 ) ) {
-		return false;
+		return;
 	}
 
 	$link = trailingslashit( bp_displayed_user_domain() . bp_get_activity_slug() . '/' . bp_get_friends_slug() );
@@ -110,12 +104,10 @@ add_action( 'bp_actions', 'bp_activity_action_friends_feed' );
  * Load the activity feed for a user's groups.
  *
  * @since 1.2.0
- *
- * @return bool False on failure.
  */
 function bp_activity_action_my_groups_feed() {
 	if ( ! bp_is_active( 'groups' ) || ! bp_is_user_activity() || ! bp_is_current_action( bp_get_groups_slug() ) || ! bp_is_action_variable( 'feed', 0 ) ) {
-		return false;
+		return;
 	}
 
 	// Get displayed user's group IDs.
@@ -150,16 +142,14 @@ add_action( 'bp_actions', 'bp_activity_action_my_groups_feed' );
  * Load a user's @mentions feed.
  *
  * @since 1.2.0
- *
- * @return bool False on failure.
  */
 function bp_activity_action_mentions_feed() {
 	if ( ! bp_activity_do_mentions() ) {
-		return false;
+		return;
 	}
 
 	if ( ! bp_is_user_activity() || ! bp_is_current_action( 'mentions' ) || ! bp_is_action_variable( 'feed', 0 ) ) {
-		return false;
+		return;
 	}
 
 	$link = trailingslashit( bp_displayed_user_domain() . bp_get_activity_slug() . '/mentions' );
@@ -189,12 +179,10 @@ add_action( 'bp_actions', 'bp_activity_action_mentions_feed' );
  * Load a user's favorites feed.
  *
  * @since 1.2.0
- *
- * @return bool False on failure.
  */
 function bp_activity_action_favorites_feed() {
 	if ( ! bp_is_user_activity() || ! bp_is_current_action( 'favorites' ) || ! bp_is_action_variable( 'feed', 0 ) ) {
-		return false;
+		return;
 	}
 
 	// Get displayed user's favorite activity IDs.

--- a/src/bp-activity/actions/post.php
+++ b/src/bp-activity/actions/post.php
@@ -11,13 +11,11 @@
  * Post user/group activity update.
  *
  * @since 1.2.0
- *
- * @return bool False on failure.
  */
 function bp_activity_action_post_update() {
 	// Do not proceed if user is not logged in, not viewing activity, or not posting.
 	if ( !is_user_logged_in() || !bp_is_activity_component() || !bp_is_current_action( 'post' ) )
-		return false;
+		return;
 
 	// Check the nonce.
 	check_admin_referer( 'post_update', '_wpnonce_post_update' );

--- a/src/bp-activity/actions/reply.php
+++ b/src/bp-activity/actions/reply.php
@@ -11,22 +11,20 @@
  * Post new activity comment.
  *
  * @since 1.2.0
- *
- * @return bool False on failure.
  */
 function bp_activity_action_post_comment() {
 	if ( ! is_user_logged_in() || ! bp_is_activity_component() || ! bp_is_current_action( 'reply' ) ) {
-		return false;
+		return;
 	}
 
 	if ( ! isset( $_POST['comment_form_id'] ) ) {
-		return false;
+		return;
 	}
 
 	$activity_id = absint( wp_unslash( $_POST['comment_form_id'] ) );
 
 	if ( ! isset( $activity_id ) ) {
-		return false;
+		return;
 	}
 
 	// Check the nonce.

--- a/src/bp-activity/actions/spam.php
+++ b/src/bp-activity/actions/spam.php
@@ -13,30 +13,29 @@
  * @since 1.6.0
  *
  * @param int $activity_id Activity id to be deleted. Defaults to 0.
- * @return bool False on failure.
  */
 function bp_activity_action_spam_activity( $activity_id = 0 ) {
 	$bp = buddypress();
 
 	// Not viewing activity, or action is not spam, or Akismet isn't present.
 	if ( !bp_is_activity_component() || !bp_is_current_action( 'spam' ) || empty( $bp->activity->akismet ) )
-		return false;
+		return;
 
 	if ( empty( $activity_id ) && bp_action_variable( 0 ) )
 		$activity_id = (int) bp_action_variable( 0 );
 
 	// Not viewing a specific activity item.
 	if ( empty( $activity_id ) )
-		return false;
+		return;
 
 	// Is the current user allowed to spam items?
 	if ( !bp_activity_user_can_mark_spam() )
-		return false;
+		return;
 
 	// Load up the activity item.
 	$activity = new BP_Activity_Activity( $activity_id );
 	if ( empty( $activity->id ) )
-		return false;
+		return;
 
 	// Check nonce.
 	check_admin_referer( 'bp_activity_akismet_spam_' . $activity->id );

--- a/src/bp-activity/actions/unfavorite.php
+++ b/src/bp-activity/actions/unfavorite.php
@@ -11,12 +11,10 @@
  * Remove activity from favorites.
  *
  * @since 1.2.0
- *
- * @return bool False on failure.
  */
 function bp_activity_action_remove_favorite() {
 	if ( ! is_user_logged_in() || ! bp_is_activity_component() || ! bp_is_current_action( 'unfavorite' ) )
-		return false;
+		return;
 
 	// Check the nonce.
 	check_admin_referer( 'unmark_favorite' );

--- a/src/bp-activity/bp-activity-adminbar.php
+++ b/src/bp-activity/bp-activity-adminbar.php
@@ -17,8 +17,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 2.6.0
  *
  * @global WP_Admin_Bar $wp_admin_bar Core class used to implement the Toolbar API.
- *
- * @return null Null if user does not have access to editing functionality.
  */
 function bp_activity_admin_menu() {
 	global $wp_admin_bar;

--- a/src/bp-activity/bp-activity-cache.php
+++ b/src/bp-activity/bp-activity-cache.php
@@ -76,13 +76,10 @@ add_action( 'bp_activity_deleted_activities', 'bp_activity_clear_cache_for_delet
  * function effectively invalidates all cached results of activity queries.
  *
  * @since 2.7.0
- *
- * @return bool True on success, false on failure.
  */
 function bp_activity_reset_cache_incrementor() {
-	$without_last_activity = bp_core_reset_incrementor( 'bp_activity' );
-	$with_last_activity    = bp_core_reset_incrementor( 'bp_activity_with_last_activity' );
-	return $without_last_activity && $with_last_activity;
+	bp_core_reset_incrementor( 'bp_activity' );
+	bp_core_reset_incrementor( 'bp_activity_with_last_activity' );
 }
 add_action( 'bp_activity_delete',    'bp_activity_reset_cache_incrementor' );
 add_action( 'bp_activity_add',       'bp_activity_reset_cache_incrementor' );

--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -159,13 +159,12 @@ function bp_activity_clear_new_mentions( $user_id ) {
  *
  * @param int    $activity_id The unique id for the activity item.
  * @param string $action      Can be 'delete' or 'add'. Defaults to 'add'.
- * @return bool
  */
 function bp_activity_adjust_mention_count( $activity_id = 0, $action = 'add' ) {
 
 	// Bail if no activity ID passed.
 	if ( empty( $activity_id ) ) {
-		return false;
+		return;
 	}
 
 	// Get activity object.
@@ -176,7 +175,7 @@ function bp_activity_adjust_mention_count( $activity_id = 0, $action = 'add' ) {
 
 	// Still empty? Stop now.
 	if ( empty( $usernames ) ) {
-		return false;
+		return;
 	}
 
 	// Increment mention count foreach mentioned user.
@@ -428,13 +427,12 @@ function bp_activity_set_action( $component_id, $type, $description, $format_cal
  *     @type bool     $activity_comment         Whether to allow comments on the activity items. Defaults to true if
  *                                              the post type does not natively support comments, otherwise false.
  * }
- * @return bool
  */
 function bp_activity_set_post_type_tracking_args( $post_type = '', $args = array() ) {
 	global $wp_post_types;
 
 	if ( empty( $wp_post_types[ $post_type ] ) || ! post_type_supports( $post_type, 'buddypress-activity' ) || ! is_array( $args ) ) {
-		return false;
+		return;
 	}
 
 	$activity_labels = array(
@@ -1360,11 +1358,10 @@ function bp_activity_add_meta( $activity_id, $meta_key, $meta_value, $unique = f
  * @since 1.5.0
  *
  * @param int $user_id ID of the user whose activity is being deleted.
- * @return bool
  */
 function bp_activity_remove_all_user_data( $user_id = 0 ) {
 	if ( empty( $user_id ) ) {
-		return false;
+		return;
 	}
 
 	// Clear the user's activity from the sitewide stream and clear their activity tables.

--- a/src/bp-activity/screens/permalink.php
+++ b/src/bp-activity/screens/permalink.php
@@ -11,17 +11,15 @@
  * Catch and route requests for single activity item permalinks.
  *
  * @since 1.2.0
- *
- * @return bool False on failure.
  */
 function bp_activity_action_permalink_router() {
 	// Not viewing activity.
 	if ( ! bp_is_activity_component() || ! bp_is_current_action( 'p' ) )
-		return false;
+		return;
 
 	// No activity to display.
 	if ( ! bp_action_variable( 0 ) || ! is_numeric( bp_action_variable( 0 ) ) )
-		return false;
+		return;
 
 	// Get the activity details.
 	$activity = bp_activity_get_specific( array( 'activity_ids' => bp_action_variable( 0 ), 'show_hidden' => true ) );
@@ -85,18 +83,16 @@ add_action( 'bp_actions', 'bp_activity_action_permalink_router' );
  * Load the page for a single activity item.
  *
  * @since 1.2.0
- *
- * @return bool|string Boolean on false or the template for a single activity item on success.
  */
 function bp_activity_screen_single_activity_permalink() {
 	// No displayed user or not viewing activity component.
 	if ( ! bp_is_activity_component() ) {
-		return false;
+		return;
 	}
 
 	$action = bp_current_action();
 	if ( ! $action || ! is_numeric( $action ) ) {
-		return false;
+		return;
 	}
 
 	// Get the activity details.

--- a/src/bp-blogs/bp-blogs-activity.php
+++ b/src/bp-blogs/bp-blogs-activity.php
@@ -14,8 +14,6 @@ defined( 'ABSPATH' ) || exit;
  * Register activity actions for the blogs component.
  *
  * @since 1.0.0
- *
- * @return bool|null Returns false if activity component is not active.
  */
 function bp_blogs_register_activity_actions() {
 	if ( is_multisite() ) {
@@ -677,13 +675,12 @@ add_action( 'bp_blogs_remove_data_for_blog', 'bp_blogs_delete_activity_for_site'
  * @param int $blog_id Optional. Defaults to current blog ID.
  * @param int $user_id Optional. Defaults to the logged-in user ID. This param
  *                     is currently unused in the function (but is passed to hooks).
- * @return bool
  */
 function bp_blogs_remove_post( $post_id, $blog_id = 0, $user_id = 0 ) {
 	global $wpdb;
 
 	if ( empty( $wpdb->blogid ) ) {
-		return false;
+		return;
 	}
 
 	$post_id = (int) $post_id;

--- a/src/bp-blogs/bp-blogs-functions.php
+++ b/src/bp-blogs/bp-blogs-functions.php
@@ -346,7 +346,6 @@ function bp_blogs_is_blog_trackable( $blog_id, $user_id = 0 ) {
  * @param int  $user_id     ID of the user for whom the blog is being recorded.
  * @param bool $no_activity Optional. Whether to skip recording an activity
  *                          item about this blog creation. Default: false.
- * @return false|null Returns false on failure.
  */
 function bp_blogs_record_blog( $blog_id, $user_id, $no_activity = false ) {
 
@@ -356,7 +355,7 @@ function bp_blogs_record_blog( $blog_id, $user_id, $no_activity = false ) {
 
 	// If blog is not recordable, do not record the activity.
 	if ( ! bp_blogs_is_blog_recordable( $blog_id, $user_id ) ) {
-		return false;
+		return;
 	}
 
 	$name = get_blog_option( $blog_id, 'blogname' );
@@ -720,11 +719,10 @@ add_action( 'bp_activity_post_type_updated', 'bp_blogs_update_post_activity_meta
  * @param  WP_Comment|null $comment              The comment object.
  * @param  array           $activity_args        Array of activity arguments.
  * @param  object|null     $activity_post_object The post type tracking args object.
- * @return WP_Error|bool|int Returns false if no activity, the activity id otherwise.
  */
 function bp_blogs_comment_sync_activity_comment( &$activity_id, $comment = null, $activity_args = array(), $activity_post_object = null ) {
 	if ( empty( $activity_args ) || empty( $comment->post->ID ) || empty( $activity_post_object->comment_action_id ) ) {
-		return false;
+		return;
 	}
 
 	// Set the current blog id.
@@ -841,8 +839,6 @@ function bp_blogs_comment_sync_activity_comment( &$activity_id, $comment = null,
 		 */
 		do_action( 'bp_blogs_new_blog_comment', $comment->comment_ID, $comment, bp_loggedin_user_id() );
 	}
-
-	return $activity_id;
 }
 add_action( 'bp_activity_post_type_comment', 'bp_blogs_comment_sync_activity_comment', 10, 4 );
 
@@ -860,7 +856,6 @@ add_action( 'bp_activity_post_type_comment', 'bp_blogs_comment_sync_activity_com
  * @param int         $user_id The ID of the user.
  * @param string|bool $role    User's WordPress role for this blog ID.
  * @param int         $blog_id Blog ID user is being added to.
- * @return false|null False on failure.
  */
 function bp_blogs_add_user_to_blog( $user_id, $role = false, $blog_id = 0 ) {
 	global $wpdb;
@@ -898,7 +893,7 @@ function bp_blogs_add_user_to_blog( $user_id, $role = false, $blog_id = 0 ) {
 
 	// Bail if no role was found or role is not in the allowed roles array.
 	if ( empty( $role ) || ! in_array( $role, bp_blogs_get_allowed_roles() ) ) {
-		return false;
+		return;
 	}
 
 	// Record the blog activity for this user being added to this blog.
@@ -917,7 +912,7 @@ add_action( 'user_register',    'bp_blogs_add_user_to_blog'        );
  *
  * @since 2.1.0
  *
- * @return string
+ * @return array
  */
 function bp_blogs_get_allowed_roles() {
 
@@ -1044,8 +1039,6 @@ add_action( 'remove_user_from_blog', 'bp_blogs_remove_blog_for_user', 10, 2 );
  * @param int    $comment_id           ID of the comment to be removed.
  * @param object $activity_post_object The post type tracking args object.
  * @param string $activity_type        The post type comment activity type.
- *
- * @return bool True on success. False on error.
  */
 function bp_blogs_post_type_remove_comment( $deleted, $comment_id, $activity_post_object, $activity_type = '' ) {
 	// Remove synced activity comments, if needed.
@@ -1082,9 +1075,6 @@ function bp_blogs_post_type_remove_comment( $deleted, $comment_id, $activity_pos
 
 				// Rebuild activity comment tree.
 				BP_Activity_Activity::rebuild_activity_comment_tree( $activity['activities'][0]->item_id );
-
-				// Set the result.
-				$deleted = true;
 			}
 		}
 	}
@@ -1102,8 +1092,6 @@ function bp_blogs_post_type_remove_comment( $deleted, $comment_id, $activity_pos
 		 */
 		do_action( 'bp_blogs_remove_comment', get_current_blog_id(), $comment_id, bp_loggedin_user_id() );
 	}
-
-	return $deleted;
 }
 add_action( 'bp_activity_post_type_remove_comment', 'bp_blogs_post_type_remove_comment', 10, 4 );
 
@@ -1415,11 +1403,10 @@ function bp_blogs_add_blogmeta( $blog_id, $meta_key, $meta_value, $unique = fals
  * Remove all blog associations for a given user.
  *
  * @param int $user_id ID whose blog data should be removed.
- * @return bool Returns false on failure.
  */
 function bp_blogs_remove_data( $user_id ) {
 	if ( !is_multisite() )
-		return false;
+		return;
 
 	/**
 	 * Fires before all blog associations are removed for a given user.

--- a/src/bp-blogs/bp-blogs-template.php
+++ b/src/bp-blogs/bp-blogs-template.php
@@ -1521,8 +1521,6 @@ function bp_blog_create_nav_item() {
  * if so, transform the title button into a Blogs directory nav item.
  *
  * @since 2.2.0
- *
- * @return string|null HTML Output
  */
 function bp_blog_backcompat_create_nav_item() {
 	// Bail if Blogs nav item is already used by bp-legacy.

--- a/src/bp-core/admin/bp-core-admin-actions.php
+++ b/src/bp-core/admin/bp-core-admin-actions.php
@@ -44,9 +44,9 @@ add_action( 'admin_notices',                      'bp_admin_notices'            
 add_action( 'admin_enqueue_scripts',              'bp_admin_enqueue_scripts'         );
 add_action( 'customize_controls_enqueue_scripts', 'bp_admin_enqueue_scripts', 8      );
 add_action( 'network_admin_menu',                 'bp_admin_menu'                    );
-add_action( 'custom_menu_order',                  'bp_admin_custom_menu_order'       );
-add_action( 'menu_order',                         'bp_admin_menu_order'              );
 add_action( 'bp_insert_site',                     'bp_new_site',               10, 6 );
+add_filter( 'custom_menu_order',                  'bp_admin_custom_menu_order'       );
+add_filter( 'menu_order',                         'bp_admin_menu_order'              );
 
 // Hook on to admin_init.
 add_action( 'bp_admin_init', 'bp_setup_updater',          1000 );

--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -829,7 +829,7 @@ function bp_admin_separator() {
  * @since 1.7.0
  *
  * @param bool $menu_order Menu order.
- * @return bool Always true.
+ * @return bool
  */
 function bp_admin_custom_menu_order( $menu_order = false ) {
 
@@ -847,7 +847,7 @@ function bp_admin_custom_menu_order( $menu_order = false ) {
  * @since 1.7.0
  *
  * @param array $menu_order Menu Order.
- * @return array Modified menu order.
+ * @return array
  */
 function bp_admin_menu_order( $menu_order = array() ) {
 
@@ -1020,7 +1020,7 @@ function bp_admin_do_wp_nav_menu_meta_box( $object = '', $box = array() ) {
 
 	// Remove temporary post type and filter.
 	unregister_post_type( 'bp_nav_menu_item' );
-	remove_filter( 'posts_pre_query', 'bp_admin_get_wp_nav_menu_items', 10, 2 );
+	remove_filter( 'posts_pre_query', 'bp_admin_get_wp_nav_menu_items' );
 
 	$tab_name    = 'bp_nav_menu_item-tab';
 	$current_tab = 'logged-in';

--- a/src/bp-core/bp-core-cache.php
+++ b/src/bp-core/bp-core-cache.php
@@ -26,8 +26,6 @@ if ( ! function_exists( 'bp_core_clear_cache' ) ) {
 	 * @global string $cache_path Path directory.
 	 *
 	 * @see prune_super_cache()
-	 *
-	 * @return integer
 	 */
 	function bp_core_clear_cache() {
 		global $cache_path;
@@ -41,7 +39,7 @@ if ( ! function_exists( 'bp_core_clear_cache' ) ) {
 			 */
 			do_action( 'bp_core_clear_cache' );
 
-			return prune_super_cache( $cache_path, true );
+			prune_super_cache( $cache_path, true );
 		}
 	}
 }

--- a/src/bp-core/classes/class-bp-admin-types.php
+++ b/src/bp-core/classes/class-bp-admin-types.php
@@ -72,8 +72,6 @@ class BP_Admin_Types {
 	 * Register BP Types Admin.
 	 *
 	 * @since 7.0.0
-	 *
-	 * @return BP_Admin_Types
 	 */
 	public static function register_types_admin() {
 		if ( ! is_admin() ) {
@@ -86,7 +84,7 @@ class BP_Admin_Types {
 			$bp->core->types_admin = new self;
 		}
 
-		return $bp->core->types_admin;
+		$bp->core->types_admin;
 	}
 
 	/**
@@ -459,7 +457,6 @@ class BP_Admin_Types {
 	 *
 	 * @param WP_Term $term     The term object for the BP Type.
 	 * @param string  $taxonomy The type taxonomy name.
-	 * @return string           HTML Output.
 	 */
 	public function edit_form_fields( $term = null, $taxonomy = '' ) {
 		if ( ! isset( $term->name ) || ! $term->name || ! $taxonomy ) {
@@ -482,7 +479,7 @@ class BP_Admin_Types {
 			}
 		}
 
-		return $this->add_form_fields( $taxonomy, $type );
+		$this->add_form_fields( $taxonomy, $type );
 	}
 
 	/**

--- a/src/bp-friends/bp-friends-activity.php
+++ b/src/bp-friends/bp-friends-activity.php
@@ -90,13 +90,11 @@ function friends_delete_activity( $args ) {
  * Register the activity actions for bp-friends.
  *
  * @since 1.1.0
- *
- * @return bool False if activity component is not active.
  */
 function friends_register_activity_actions() {
 
 	if ( ! bp_is_active( 'activity' ) ) {
-		return false;
+		return;
 	}
 
 	$bp = buddypress();

--- a/src/bp-friends/bp-friends-cache.php
+++ b/src/bp-friends/bp-friends-cache.php
@@ -20,19 +20,16 @@ defined( 'ABSPATH' ) || exit;
  *
  * @param int $friendship_id ID of the friendship whose two members should
  *                           have their friends cache busted.
- * @return bool
  */
 function friends_clear_friend_object_cache( $friendship_id ) {
 	$friendship = new BP_Friends_Friendship( $friendship_id );
 	if ( ! $friendship ) {
-		return false;
+		return;
 	}
 
 	wp_cache_delete( 'friends_friend_ids_' . $friendship->initiator_user_id, 'bp' );
 	wp_cache_delete( 'friends_friend_ids_' . $friendship->friend_user_id, 'bp' );
 }
-
-// List actions to clear object caches on.
 add_action( 'friends_friendship_accepted', 'friends_clear_friend_object_cache' );
 add_action( 'friends_friendship_deleted', 'friends_clear_friend_object_cache' );
 

--- a/src/bp-groups/actions/create.php
+++ b/src/bp-groups/actions/create.php
@@ -11,17 +11,15 @@
  * Catch and process group creation form submissions.
  *
  * @since 1.2.0
- *
- * @return bool
  */
 function groups_action_create_group() {
 
 	// If we're not at domain.org/groups/create/ then return false.
 	if ( !bp_is_groups_component() || !bp_is_current_action( 'create' ) )
-		return false;
+		return;
 
 	if ( !is_user_logged_in() )
-		return false;
+		return;
 
 	if ( !bp_user_can_create_groups() ) {
 		bp_core_add_message( __( 'Sorry, you are not allowed to create groups.', 'buddypress' ), 'error' );
@@ -223,7 +221,7 @@ function groups_action_create_group() {
 	// Remove invitations.
 	if ( 'group-invites' === bp_get_groups_current_create_step() && ! empty( $_REQUEST['user_id'] ) && is_numeric( $_REQUEST['user_id'] ) ) {
 		if ( ! check_admin_referer( 'groups_invite_uninvite_user' ) ) {
-			return false;
+			return;
 		}
 
 		$message = __( 'Invite successfully removed', 'buddypress' );

--- a/src/bp-groups/actions/feed.php
+++ b/src/bp-groups/actions/feed.php
@@ -11,8 +11,6 @@
  * Load the activity feed for the current group.
  *
  * @since 1.2.0
- *
- * @return false|null False on failure.
  */
 function groups_action_group_feed() {
 
@@ -20,12 +18,12 @@ function groups_action_group_feed() {
 	$group = groups_get_current_group();
 
 	if ( ! bp_is_active( 'activity' ) || ! bp_is_groups_component() || ! $group || ! bp_is_current_action( 'feed' ) )
-		return false;
+		return;
 
 	// If group isn't public or if logged-in user is not a member of the group, do
 	// not output the group activity feed.
 	if ( ! bp_group_is_visible( $group ) ) {
-		return false;
+		return;
 	}
 
 	// Set up the feed.

--- a/src/bp-groups/actions/join.php
+++ b/src/bp-groups/actions/join.php
@@ -11,17 +11,15 @@
  * Catch and process "Join Group" button clicks.
  *
  * @since 1.0.0
- *
- * @return bool
  */
 function groups_action_join_group() {
 
 	if ( !bp_is_single_item() || !bp_is_groups_component() || !bp_is_current_action( 'join' ) )
-		return false;
+		return;
 
 	// Nonce check.
 	if ( !check_admin_referer( 'groups_join_group' ) )
-		return false;
+		return;
 
 	$bp = buddypress();
 

--- a/src/bp-groups/actions/leave-group.php
+++ b/src/bp-groups/actions/leave-group.php
@@ -17,17 +17,15 @@
  * another function handles this. See {@link bp_legacy_theme_ajax_joinleave_group()}.
  *
  * @since 1.2.4
- *
- * @return bool
  */
 function groups_action_leave_group() {
 	if ( ! bp_is_single_item() || ! bp_is_groups_component() || ! bp_is_current_action( 'leave-group' ) ) {
-		return false;
+		return;
 	}
 
 	// Nonce check.
 	if ( ! check_admin_referer( 'groups_leave_group' ) ) {
-		return false;
+		return;
 	}
 
 	// User wants to leave any group.
@@ -77,7 +75,7 @@ function groups_action_clean_up_invites_requests( $user_id, $group_id ) {
 	/**
 	 * Remove invitations where the deleted user is the sender.
 	 * We'll use groups_uninvite_user() so that notifications will be cleaned up.
-	 */ 
+	 */
 	$pending_invites = groups_get_invites( array(
 		'inviter_id' => $user_id,
 		'item_id'    => $group_id,

--- a/src/bp-groups/bp-groups-activity.php
+++ b/src/bp-groups/bp-groups-activity.php
@@ -17,14 +17,12 @@ defined( 'ABSPATH' ) || exit;
  * Register activity actions for the Groups component.
  *
  * @since 1.1.0
- *
- * @return false|null False on failure.
  */
 function groups_register_activity_actions() {
 	$bp = buddypress();
 
 	if ( ! bp_is_active( 'activity' ) ) {
-		return false;
+		return;
 	}
 
 	bp_activity_set_action(
@@ -748,13 +746,12 @@ add_filter( 'bp_activity_can_comment_reply', 'bp_groups_filter_activity_can_comm
  *
  * @param int $user_id  ID of the user joining the group.
  * @param int $group_id ID of the group.
- * @return false|null False on failure.
  */
 function bp_groups_membership_accepted_add_activity( $user_id, $group_id ) {
 
 	// Bail if Activity is not active.
 	if ( ! bp_is_active( 'activity' ) ) {
-		return false;
+		return;
 	}
 
 	// Get the group so we can get it's name.
@@ -789,17 +786,16 @@ add_action( 'groups_membership_accepted', 'bp_groups_membership_accepted_add_act
  * @param  int             $group_id       ID of the group.
  * @param  BP_Groups_Group $old_group      Group object before the details had been changed.
  * @param  bool            $notify_members True if the admin has opted to notify group members, otherwise false.
- * @return null|WP_Error|bool|int The ID of the activity on success. False on error.
  */
 function bp_groups_group_details_updated_add_activity( $group_id, $old_group, $notify_members ) {
 
 	// Bail if Activity is not active.
 	if ( ! bp_is_active( 'activity' ) ) {
-		return false;
+		return;
 	}
 
 	if ( ! isset( $old_group->name ) || ! isset( $old_group->slug ) || ! isset( $old_group->description ) ) {
-		return false;
+		return;
 	}
 
 	// If the admin has opted not to notify members, don't post an activity item either.
@@ -849,14 +845,13 @@ function bp_groups_group_details_updated_add_activity( $group_id, $old_group, $n
 	groups_update_groupmeta( $group_id, 'updated_details_' . $time, $changed );
 
 	// Record in activity streams.
-	return groups_record_activity( array(
+	groups_record_activity( array(
 		'type'          => 'group_details_updated',
 		'item_id'       => $group_id,
 		'user_id'       => bp_loggedin_user_id(),
 		'recorded_time' => $time,
 
 	) );
-
 }
 add_action( 'groups_details_updated', 'bp_groups_group_details_updated_add_activity', 10, 3 );
 

--- a/src/bp-groups/bp-groups-adminbar.php
+++ b/src/bp-groups/bp-groups-adminbar.php
@@ -20,9 +20,6 @@ defined( 'ABSPATH' ) || exit;
  * @todo Add dynamic menu items for group extensions.
  *
  * @global WP_Admin_Bar $wp_admin_bar WordPress object implementing a Toolbar API.
- *
- * @return false|null False if not on a group page, or if user does not have
- *                    access to group admin options.
  */
 function bp_groups_group_admin_menu() {
 	global $wp_admin_bar;
@@ -30,12 +27,12 @@ function bp_groups_group_admin_menu() {
 
 	// Only show if viewing a group.
 	if ( ! bp_is_group() || bp_is_group_create() ) {
-		return false;
+		return;
 	}
 
 	// Only show this menu to group admins and super admins.
 	if ( ! bp_current_user_can( 'bp_moderate' ) && ! bp_group_is_admin() ) {
-		return false;
+		return;
 	}
 
 	// Unique ID for the 'Edit Group' menu.

--- a/src/bp-groups/bp-groups-cache.php
+++ b/src/bp-groups/bp-groups-cache.php
@@ -319,11 +319,9 @@ add_action( 'bp_groups_member_before_delete', 'bp_groups_clear_user_group_cache_
  *   - A group's metadata is modified.
  *
  * @since 2.7.0
- *
- * @return bool True on success, false on failure.
  */
 function bp_groups_reset_cache_incrementor() {
-	return bp_core_reset_incrementor( 'bp_groups' );
+	bp_core_reset_incrementor( 'bp_groups' );
 }
 add_action( 'groups_group_after_save', 'bp_groups_reset_cache_incrementor' );
 add_action( 'bp_groups_delete_group',  'bp_groups_reset_cache_incrementor' );
@@ -343,15 +341,12 @@ add_action( 'added_group_meta',        'bp_groups_reset_cache_incrementor' );
  * @param array  $terms     Array of object terms.
  * @param array  $tt_ids    Array of term taxonomy IDs.
  * @param string $taxonomy  Taxonomy slug.
- * @return bool True on success, false on failure.
  */
 function bp_groups_reset_cache_incrementor_on_group_term_change( $object_id, $terms, $tt_ids, $taxonomy ) {
 	$tax_object = get_taxonomy( $taxonomy );
 	if ( $tax_object && in_array( 'bp_group', $tax_object->object_type, true ) ) {
-		return bp_groups_reset_cache_incrementor();
+		bp_groups_reset_cache_incrementor();
 	}
-
-	return false;
 }
 add_action( 'bp_set_object_terms', 'bp_groups_reset_cache_incrementor_on_group_term_change', 10, 4 );
 
@@ -366,15 +361,12 @@ add_action( 'bp_set_object_terms', 'bp_groups_reset_cache_incrementor_on_group_t
  * @param int    $object_id ID of the item whose terms are being modified.
  * @param array  $terms     Array of object terms.
  * @param string $taxonomy  Taxonomy slug.
- * @return bool True on success, false on failure.
  */
 function bp_groups_reset_cache_incrementor_on_group_term_remove( $object_id, $terms, $taxonomy ) {
 	$tax_object = get_taxonomy( $taxonomy );
 	if ( $tax_object && in_array( 'bp_group', $tax_object->object_type, true ) ) {
-		return bp_groups_reset_cache_incrementor();
+		bp_groups_reset_cache_incrementor();
 	}
-
-	return false;
 }
 add_action( 'bp_remove_object_terms', 'bp_groups_reset_cache_incrementor_on_group_term_remove', 10, 3 );
 

--- a/src/bp-groups/classes/class-bp-groups-member.php
+++ b/src/bp-groups/classes/class-bp-groups-member.php
@@ -1133,7 +1133,6 @@ class BP_Groups_Member {
 	 * @since 2.7.0
 	 *
 	 * @param array $group_ids IDs of the groups.
-	 * @return bool True on success.
 	 */
 	public static function prime_group_admins_mods_cache( $group_ids ) {
 		global $wpdb;

--- a/src/bp-members/bp-members-cache.php
+++ b/src/bp-members/bp-members-cache.php
@@ -66,11 +66,9 @@ add_action( 'delete_user', 'bp_members_clear_member_type_cache' );
  * Invalidate activity caches when a user's last_activity value is changed.
  *
  * @since 2.7.0
- *
- * @return bool True on success, false on failure.
  */
 function bp_members_reset_activity_cache_incrementor() {
-	return bp_core_reset_incrementor( 'bp_activity_with_last_activity' );
+	bp_core_reset_incrementor( 'bp_activity_with_last_activity' );
 }
 add_action( 'bp_core_user_updated_last_activity', 'bp_members_reset_activity_cache_incrementor' );
 
@@ -114,11 +112,9 @@ add_action( 'bp_core_signup_after_delete',   'bp_members_delete_signup_cache_mul
  *   - A record is deleted.
  *
  * @since 10.0.0
- *
- * @return bool True on success, false on failure.
  */
 function bp_members_reset_signup_cache_incrementor() {
-	return bp_core_reset_incrementor( 'bp_signups' );
+	bp_core_reset_incrementor( 'bp_signups' );
 }
 add_filter( 'bp_core_signups_after_add',         'bp_members_reset_signup_cache_incrementor' );
 add_action( 'bp_core_activated_user',            'bp_members_reset_signup_cache_incrementor' );

--- a/src/bp-members/bp-members-membership-requests.php
+++ b/src/bp-members/bp-members-membership-requests.php
@@ -386,8 +386,6 @@ add_filter( 'bp_members_ms_signup_date_sent_unsent_message', 'bp_members_members
  * Add "Request Membership" link to Widget login form.
  *
  * @since 10.0.0
- *
- * @return string $retval the HTML for the request membership link.
  */
 function bp_members_membership_requests_add_link_to_widget_login_form() {
 	?>
@@ -403,7 +401,7 @@ add_action( 'bp_login_widget_form', 'bp_members_membership_requests_add_link_to_
  * @since 10.0.0
  *
  * @param string $link The HTML code for the link to the Registration or Admin page.
- * @return string      An empty string or the HTML code for the link to the Membership request page.
+ * @return string
  */
 function bp_members_membership_requests_filter_sidebar_register_link( $link ) {
 	// $link should be an empty string when public registration is disabled.
@@ -448,11 +446,11 @@ add_action( 'admin_bar_menu', 'bp_members_membership_requests_add_toolbar_link',
  * @since 10.0.0
  *
  * @param string $link HTML link to the home URL of the current site.
- * @return string      HTML link to the home URL of the current site and the one to request a membership.
+ * @return string
  */
 function bp_members_membership_requests_add_link_wp_login( $link ) {
 	$link_separator = apply_filters( 'login_link_separator', ' | ' );
 
 	return $link . $link_separator . '<a href="' . esc_url( wp_registration_url() ) . '">' . esc_html__( 'Request Membership', 'buddypress' ) . '</a>';
 }
-add_action( 'login_site_html_link', 'bp_members_membership_requests_add_link_wp_login' );
+add_filter( 'login_site_html_link', 'bp_members_membership_requests_add_link_wp_login' );

--- a/src/bp-members/classes/class-bp-members-admin.php
+++ b/src/bp-members/classes/class-bp-members-admin.php
@@ -876,7 +876,6 @@ class BP_Members_Admin {
 	 *
 	 * @param object|null $user   User to create profile navigation for.
 	 * @param string      $active Which profile to highlight.
-	 * @return string|null
 	 */
 	public function profile_nav( $user = null, $active = 'WordPress' ) {
 
@@ -1684,7 +1683,6 @@ class BP_Members_Admin {
 	 * @since 2.0.0
 	 *
 	 * @param WP_User_Query|null $query The users query.
-	 * @return WP_User_Query|null The users query without the signups.
 	 */
 	public function remove_signups_from_user_query( $query = null ) {
 		global $wpdb;

--- a/src/bp-members/classes/class-bp-members-invitations-list-table.php
+++ b/src/bp-members/classes/class-bp-members-invitations-list-table.php
@@ -305,7 +305,6 @@ class BP_Members_Invitations_List_Table extends WP_Users_List_Table {
 	 * @param string        $style    Styles for the row.
 	 * @param string        $role     Role to be assigned to user.
 	 * @param int           $numposts Number of posts.
-	 * @return void
 	 */
 	public function single_row( $invite = null, $style = '', $role = '', $numposts = 0 ) {
 		echo '<tr' . $style . ' id="invitation-' . esc_attr( $invite->id ) . '">';

--- a/src/bp-members/classes/class-bp-members-list-table.php
+++ b/src/bp-members/classes/class-bp-members-list-table.php
@@ -262,7 +262,6 @@ class BP_Members_List_Table extends WP_Users_List_Table {
 	 * @param string      $style         Styles for the row.
 	 * @param string      $role          Role to be assigned to user.
 	 * @param int         $numposts      Numper of posts.
-	 * @return void
 	 */
 	public function single_row( $signup_object = null, $style = '', $role = '', $numposts = 0 ) {
 		echo '<tr' . $style . ' id="signup-' . esc_attr( $signup_object->id ) . '">';

--- a/src/bp-messages/actions/bulk-delete.php
+++ b/src/bp-messages/actions/bulk-delete.php
@@ -9,13 +9,11 @@
 
 /**
  * Process a request to bulk delete messages.
- *
- * @return bool False on failure.
  */
 function messages_action_bulk_delete() {
 
 	if ( ! bp_is_messages_component() || ! bp_is_action_variable( 'bulk-delete', 0 ) ) {
-		return false;
+		return;
 	}
 
 	$thread_ids = $_POST['thread_ids'];
@@ -24,7 +22,7 @@ function messages_action_bulk_delete() {
 		bp_core_redirect( trailingslashit( bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() ) );
 	} else {
 		if ( ! check_admin_referer( 'messages_delete_thread' ) ) {
-			return false;
+			return;
 		}
 
 		if ( ! messages_delete_thread( $thread_ids ) ) {

--- a/src/bp-messages/actions/bulk-manage.php
+++ b/src/bp-messages/actions/bulk-manage.php
@@ -11,14 +11,11 @@
  * Handle bulk management (mark as read/unread, delete) of message threads.
  *
  * @since 2.2.0
- *
- * @return bool Returns false on failure. Otherwise redirects back to the
- *              message box URL.
  */
 function bp_messages_action_bulk_manage() {
 
 	if ( ! bp_is_messages_component() || bp_is_current_action( 'notices' ) || ! bp_is_action_variable( 'bulk-manage', 0 ) ) {
-		return false;
+		return;
 	}
 
 	$action   = ! empty( $_POST['messages_bulk_action'] ) ? $_POST['messages_bulk_action'] : '';
@@ -33,7 +30,7 @@ function bp_messages_action_bulk_manage() {
 
 	// Check the nonce.
 	if ( ! wp_verify_nonce( $nonce, 'messages_bulk_nonce' ) ) {
-		return false;
+		return;
 	}
 
 	// Make sure the user has access to all notifications before managing them.

--- a/src/bp-messages/actions/compose.php
+++ b/src/bp-messages/actions/compose.php
@@ -11,14 +11,12 @@
  * Handle creating of private messages or sitewide notices
  *
  * @since 2.4.0 This function was split from messages_screen_compose(). See #6505.
- *
- * @return bool
  */
 function bp_messages_action_create_message() {
 
 	// Bail if not posting to the compose message screen.
 	if ( ! bp_is_post_request() || ! bp_is_messages_component() || ! bp_is_current_action( 'compose' ) ) {
-		return false;
+		return;
 	}
 
 	// Check the nonce.

--- a/src/bp-messages/actions/delete.php
+++ b/src/bp-messages/actions/delete.php
@@ -9,13 +9,11 @@
 
 /**
  * Process a request to delete a message.
- *
- * @return bool False on failure.
  */
 function messages_action_delete_message() {
 
 	if ( ! bp_is_messages_component() || bp_is_current_action( 'notices' ) || ! bp_is_action_variable( 'delete', 0 ) ) {
-		return false;
+		return;
 	}
 
 	$thread_id = bp_action_variable( 1 );
@@ -24,7 +22,7 @@ function messages_action_delete_message() {
 		bp_core_redirect( trailingslashit( bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() ) );
 	} else {
 		if ( ! check_admin_referer( 'messages_delete_thread' ) ) {
-			return false;
+			return;
 		}
 
 		// Delete message.

--- a/src/bp-messages/actions/notices.php
+++ b/src/bp-messages/actions/notices.php
@@ -11,14 +11,12 @@
  * Handle editing of sitewide notices.
  *
  * @since 2.4.0 This function was split from messages_screen_notices(). See #6505.
- *
- * @return bool
  */
 function bp_messages_action_edit_notice() {
 
 	// Bail if not viewing a single notice URL.
 	if ( ! bp_is_messages_component() || ! bp_is_current_action( 'notices' ) ) {
-		return false;
+		return;
 	}
 
 	// Get the notice ID (1|2|3).
@@ -26,12 +24,12 @@ function bp_messages_action_edit_notice() {
 
 	// Bail if notice ID is not numeric.
 	if ( empty( $notice_id ) || ! is_numeric( $notice_id ) ) {
-		return false;
+		return;
 	}
 
 	// Bail if the current user doesn't have administrator privileges.
 	if ( ! bp_current_user_can( 'bp_moderate' ) ) {
-		return false;
+		return;
 	}
 
 	// Get the action (deactivate|activate|delete).
@@ -97,19 +95,17 @@ add_action( 'bp_actions', 'bp_messages_action_edit_notice' );
  * Handle user dismissal of sitewide notices.
  *
  * @since 9.0.0
- *
- * @return bool False on failure.
  */
 function bp_messages_action_dismiss_notice() {
 
 	// Bail if not viewing a notice dismissal URL.
 	if ( ! bp_is_messages_component() || ! bp_is_current_action( 'notices' ) || 'dismiss' !== sanitize_key( bp_action_variable( 0 ) ) ) {
-		return false;
+		return;
 	}
 
 	// Bail if the current user isn't logged in.
 	if ( ! is_user_logged_in() ) {
-		return false;
+		return;
 	}
 
 	// Check the nonce.

--- a/src/bp-messages/actions/read.php
+++ b/src/bp-messages/actions/read.php
@@ -11,14 +11,11 @@
  * Handle marking a single message thread as read.
  *
  * @since 2.2.0
- *
- * @return bool Returns false on failure. Otherwise redirects back to the
- *              message box URL.
  */
 function bp_messages_action_mark_read() {
 
 	if ( ! bp_is_messages_component() || bp_is_current_action( 'notices' ) || ! bp_is_action_variable( 'read', 0 ) ) {
-		return false;
+		return;
 	}
 
 	$action = ! empty( $_GET['action'] ) ? $_GET['action'] : '';
@@ -27,12 +24,12 @@ function bp_messages_action_mark_read() {
 
 	// Bail if no action or no ID.
 	if ( 'read' !== $action || empty( $id ) || empty( $nonce ) ) {
-		return false;
+		return;
 	}
 
 	// Check the nonce.
 	if ( ! bp_verify_nonce_request( 'bp_message_thread_mark_read_' . $id ) ) {
-		return false;
+		return;
 	}
 
 	// Check access to the message and mark as read.

--- a/src/bp-messages/actions/unread.php
+++ b/src/bp-messages/actions/unread.php
@@ -11,14 +11,11 @@
  * Handle marking a single message thread as unread.
  *
  * @since 2.2.0
- *
- * @return bool Returns false on failure. Otherwise redirects back to the
- *              message box URL.
  */
 function bp_messages_action_mark_unread() {
 
 	if ( ! bp_is_messages_component() || bp_is_current_action( 'notices' ) || ! bp_is_action_variable( 'unread', 0 ) ) {
-		return false;
+		return;
 	}
 
 	$action = ! empty( $_GET['action'] ) ? $_GET['action'] : '';
@@ -27,12 +24,12 @@ function bp_messages_action_mark_unread() {
 
 	// Bail if no action or no ID.
 	if ( 'unread' !== $action || empty( $id ) || empty( $nonce ) ) {
-		return false;
+		return;
 	}
 
 	// Check the nonce.
 	if ( ! bp_verify_nonce_request( 'bp_message_thread_mark_unread_' . $id ) ) {
-		return false;
+		return;
 	}
 
 	// Check access to the message and mark unread.

--- a/src/bp-messages/actions/view.php
+++ b/src/bp-messages/actions/view.php
@@ -9,14 +9,12 @@
 
 /**
  * Process a request to view a single message thread.
- *
- * @return bool False if not a single conversation.
  */
 function messages_action_conversation() {
 
 	// Bail if not viewing a single conversation.
 	if ( ! bp_is_messages_component() || ! bp_is_current_action( 'view' ) ) {
-		return false;
+		return;
 	}
 
 	// Get the thread ID from the action variable.

--- a/src/bp-messages/bp-messages-template.php
+++ b/src/bp-messages/bp-messages-template.php
@@ -976,6 +976,8 @@ function bp_messages_username_value() {
 			/** This filter is documented in bp-messages-template.php */
 			return apply_filters( 'bp_get_messages_username_value', $_GET['r'] );
 		}
+
+		return '';
 	}
 
 /**

--- a/src/bp-messages/classes/class-bp-messages-notices-admin.php
+++ b/src/bp-messages/classes/class-bp-messages-notices-admin.php
@@ -43,8 +43,6 @@ class BP_Messages_Notices_Admin {
 	 * Create a new instance or access the current instance of this class.
 	 *
 	 * @since 3.0.0
-	 *
-	 * @return BP_Messages_Notices_Admin
 	 */
 	public static function register_notices_admin() {
 
@@ -58,7 +56,7 @@ class BP_Messages_Notices_Admin {
 			$bp->messages->admin = new self;
 		}
 
-		return $bp->messages->admin;
+		$bp->messages->admin;
 	}
 
 	/**

--- a/src/bp-messages/classes/class-bp-messages-thread.php
+++ b/src/bp-messages/classes/class-bp-messages-thread.php
@@ -164,7 +164,6 @@ class BP_Messages_Thread {
 	 *     @type int|null    $recipients_page     Page of recipients being requested. Default to null, meaning all.
 	 *     @type int|null    $recipients_per_page Recipients to return per page. Defaults to null, meaning all.
 	 * }
-	 * @return bool False if there are no messages.
 	 */
 	public function populate( $thread_id = 0, $order = 'ASC', $args = array() ) {
 
@@ -195,7 +194,7 @@ class BP_Messages_Thread {
 
 		// Bail early if no thread message is found.
 		if ( empty( $latest_message ) ) {
-			return false;
+			return;
 		}
 
 		// Set latest message data.

--- a/src/bp-messages/screens/view.php
+++ b/src/bp-messages/screens/view.php
@@ -11,14 +11,12 @@
  * Load an individual conversation screen.
  *
  * @since 1.0.0
- *
- * @return bool False on failure.
  */
 function messages_screen_conversation() {
 
 	// Bail if not viewing a single message.
 	if ( ! bp_is_messages_component() || ! bp_is_current_action( 'view' ) ) {
-		return false;
+		return;
 	}
 
 	$thread_id = (int) bp_action_variable( 0 );

--- a/src/bp-notifications/actions/delete.php
+++ b/src/bp-notifications/actions/delete.php
@@ -11,14 +11,12 @@
  * Handle deleting single notifications.
  *
  * @since 1.9.0
- *
- * @return bool
  */
 function bp_notifications_action_delete() {
 
 	// Bail if not the read or unread screen.
 	if ( ! bp_is_notifications_component() || ! ( bp_is_current_action( 'read' ) || bp_is_current_action( 'unread' ) ) ) {
-		return false;
+		return;
 	}
 
 	// Get the action.
@@ -28,7 +26,7 @@ function bp_notifications_action_delete() {
 
 	// Bail if no action or no ID.
 	if ( ( 'delete' !== $action ) || empty( $id ) || empty( $nonce ) ) {
-		return false;
+		return;
 	}
 
 	// Check the nonce and delete the notification.

--- a/src/bp-notifications/bp-notifications-functions.php
+++ b/src/bp-notifications/bp-notifications-functions.php
@@ -471,13 +471,10 @@ function bp_notifications_delete_notifications_from_user( $user_id, $component_n
  * @since 2.5.0
  *
  * @param int $user_id ID of the user who is about to be deleted.
+ * @return int|bool
  */
 function bp_notifications_delete_notifications_on_user_delete( $user_id ) {
-	if ( 'wpmu_delete_user' !== current_action() ) {
-		_doing_it_wrong( __FUNCTION__, __( 'This function is only used once a user is deleted. Please use `bp_notifications_delete_notifications_from_user()` instead.', 'buddypress' ), '12.0.0' );
-	}
-	
-	BP_Notifications_Notification::delete( array(
+	return BP_Notifications_Notification::delete( array(
 		'user_id'           => $user_id,
 		'item_id'           => false,
 		'secondary_item_id' => false,
@@ -485,7 +482,18 @@ function bp_notifications_delete_notifications_on_user_delete( $user_id ) {
 		'component_name'    => false,
 	) );
 }
-add_action( 'wpmu_delete_user', 'bp_notifications_delete_notifications_on_user_delete' );
+
+/**
+ * Callback: Delete a user's notifications when the user is deleted.
+ *
+ * @since 12.0.0
+ *
+ * @param int $user_id ID of the user who is about to be deleted.
+ */
+function bp_notifications_delete_notifications_on_user_delete_callback( $user_id ) {
+	bp_notifications_delete_notifications_on_user_delete( $user_id );
+}
+add_action( 'wpmu_delete_user', 'bp_notifications_delete_notifications_on_user_delete_callback' );
 
 /**
  * Deletes user notifications data on the 'delete_user' hook.

--- a/src/bp-notifications/bp-notifications-functions.php
+++ b/src/bp-notifications/bp-notifications-functions.php
@@ -471,7 +471,7 @@ function bp_notifications_delete_notifications_from_user( $user_id, $component_n
  * @since 2.5.0
  *
  * @param int $user_id ID of the user who is about to be deleted.
- * @return int|bool
+ * @return int|false The number of rows deleted, or false on error.
  */
 function bp_notifications_delete_notifications_on_user_delete( $user_id ) {
 	return BP_Notifications_Notification::delete( array(

--- a/src/bp-notifications/bp-notifications-functions.php
+++ b/src/bp-notifications/bp-notifications-functions.php
@@ -471,10 +471,9 @@ function bp_notifications_delete_notifications_from_user( $user_id, $component_n
  * @since 2.5.0
  *
  * @param int $user_id ID of the user who is about to be deleted.
- * @return int|false The number of rows deleted, or false on error.
  */
 function bp_notifications_delete_notifications_on_user_delete( $user_id ) {
-	return BP_Notifications_Notification::delete( array(
+	BP_Notifications_Notification::delete( array(
 		'user_id'           => $user_id,
 		'item_id'           => false,
 		'secondary_item_id' => false,

--- a/src/bp-notifications/bp-notifications-functions.php
+++ b/src/bp-notifications/bp-notifications-functions.php
@@ -473,6 +473,10 @@ function bp_notifications_delete_notifications_from_user( $user_id, $component_n
  * @param int $user_id ID of the user who is about to be deleted.
  */
 function bp_notifications_delete_notifications_on_user_delete( $user_id ) {
+	if ( 'wpmu_delete_user' !== current_action() ) {
+		_doing_it_wrong( __FUNCTION__, __( 'This function is only used once a user is deleted. Please use `bp_notifications_delete_notifications_from_user()` instead.', 'buddypress' ), '12.0.0' );
+	}
+	
 	BP_Notifications_Notification::delete( array(
 		'user_id'           => $user_id,
 		'item_id'           => false,

--- a/src/bp-notifications/screens/read.php
+++ b/src/bp-notifications/screens/read.php
@@ -35,14 +35,12 @@ function bp_notifications_screen_read() {
  * Handle marking single notifications as unread.
  *
  * @since 1.9.0
- *
- * @return bool
  */
 function bp_notifications_action_mark_unread() {
 
 	// Bail if not the read screen.
 	if ( ! bp_is_notifications_component() || ! bp_is_current_action( 'read' ) ) {
-		return false;
+		return;
 	}
 
 	// Get the action.
@@ -52,7 +50,7 @@ function bp_notifications_action_mark_unread() {
 
 	// Bail if no action or no ID.
 	if ( ( 'unread' !== $action ) || empty( $id ) || empty( $nonce ) ) {
-		return false;
+		return;
 	}
 
 	// Check the nonce and mark the notification.

--- a/src/bp-notifications/screens/unread.php
+++ b/src/bp-notifications/screens/unread.php
@@ -35,14 +35,12 @@ function bp_notifications_screen_unread() {
  * Handle marking single notifications as read.
  *
  * @since 1.9.0
- *
- * @return bool
  */
 function bp_notifications_action_mark_read() {
 
 	// Bail if not the unread screen.
 	if ( ! bp_is_notifications_component() || ! bp_is_current_action( 'unread' ) ) {
-		return false;
+		return;
 	}
 
 	// Get the action.
@@ -52,7 +50,7 @@ function bp_notifications_action_mark_read() {
 
 	// Bail if no action or no ID.
 	if ( ( 'read' !== $action ) || empty( $id ) || empty( $nonce ) ) {
-		return false;
+		return;
 	}
 
 	// Check the nonce and mark the notification.

--- a/src/bp-xprofile/bp-xprofile-activity.php
+++ b/src/bp-xprofile/bp-xprofile-activity.php
@@ -17,7 +17,6 @@ defined( 'ABSPATH' ) || exit;
  * Register the activity actions for the Extended Profile component.
  *
  * @since 1.0.0
- *
  */
 function xprofile_register_activity_actions() {
 
@@ -175,7 +174,7 @@ function xprofile_register_activity_action( $key, $value ) {
  * @param bool  $errors     True if validation or saving errors occurred, otherwise false.
  * @param array $old_values Pre-save xprofile field values and visibility levels.
  * @param array $new_values Post-save xprofile field values and visibility levels.
- * @return bool True on success, false on failure.
+ * @return bool
  */
 function bp_xprofile_updated_profile_activity( $user_id, $field_ids = array(), $errors = false, $old_values = array(), $new_values = array() ) {
 
@@ -255,7 +254,19 @@ function bp_xprofile_updated_profile_activity( $user_id, $field_ids = array(), $
 		'type'         => 'updated_profile',
 	) );
 }
-add_action( 'xprofile_updated_profile', 'bp_xprofile_updated_profile_activity', 10, 5 );
+
+/**
+ * Add an activity item when a user has updated his profile.
+ *
+ * @param int   $user_id    ID of the user who has updated his profile.
+ * @param array $field_ids  IDs of the fields submitted.
+ * @param bool  $errors     True if validation or saving errors occurred, otherwise false.
+ * @param array $old_values Pre-save xprofile field values and visibility levels.
+ * @param array $new_values Post-save xprofile field values and visibility levels.
+ */
+add_action( 'xprofile_updated_profile', function( $user_id, $field_ids, $errors, $old_values, $new_values ) {
+	bp_xprofile_updated_profile_activity( $user_id, $field_ids, $errors, $old_values, $new_values );
+}, 10, 5 );
 
 /**
  * Add filters for xprofile activity types to Show dropdowns.
@@ -265,8 +276,6 @@ add_action( 'xprofile_updated_profile', 'bp_xprofile_updated_profile_activity', 
  */
 function xprofile_activity_filter_options() {
 	?>
-
 	<option value="updated_profile"><?php _e( 'Profile Updates', 'buddypress' ) ?></option>
-
 	<?php
 }

--- a/src/bp-xprofile/bp-xprofile-admin.php
+++ b/src/bp-xprofile/bp-xprofile-admin.php
@@ -15,14 +15,12 @@ defined( 'ABSPATH' ) || exit;
  * tables are set up.
  *
  * @since 1.0.0
- *
- * @return bool
  */
 function xprofile_add_admin_menu() {
 
 	// Bail if current user cannot moderate community.
 	if ( ! bp_current_user_can( 'bp_moderate' ) ) {
-		return false;
+		return;
 	}
 
 	add_users_page( _x( 'Profile Fields', 'xProfile admin page title', 'buddypress' ), _x( 'Profile Fields', 'Admin Users menu', 'buddypress' ), 'manage_options', 'bp-profile-setup', 'xprofile_admin' );

--- a/src/bp-xprofile/bp-xprofile-cache.php
+++ b/src/bp-xprofile/bp-xprofile-cache.php
@@ -52,14 +52,13 @@ function bp_xprofile_get_non_cached_field_ids( $user_id = 0, $field_ids = array(
  *
  * @param array $object_ids Multi-dimensional array of object_ids, keyed by
  *                          object type ('group', 'field', 'data').
- * @return bool
  */
 function bp_xprofile_update_meta_cache( $object_ids = array() ) {
 	global $wpdb;
 
 	// Bail if no objects.
 	if ( empty( $object_ids ) ) {
-		return false;
+		return;
 	}
 
 	$bp = buddypress();
@@ -259,7 +258,6 @@ add_action( 'update_option_bp-xprofile-fullname-field-name', 'xprofile_clear_ful
  * @since 2.4.0
  *
  * @param int|BP_XProfile_Field $field A field ID or a field object.
- * @return bool False on failure.
  */
 function bp_xprofile_clear_field_cache( $field ) {
 	if ( is_numeric( $field ) ) {
@@ -269,7 +267,7 @@ function bp_xprofile_clear_field_cache( $field ) {
 	}
 
 	if ( ! isset( $field_id ) ) {
-		return false;
+		return;
 	}
 
 	wp_cache_delete( $field_id, 'bp_xprofile_fields' );

--- a/src/bp-xprofile/bp-xprofile-functions.php
+++ b/src/bp-xprofile/bp-xprofile-functions.php
@@ -815,13 +815,12 @@ add_action( 'bp_user_query_uid_clauses', 'bp_xprofile_bp_user_query_search', 10,
  *
  * @param int   $user_id ID of the user to sync.
  * @param array $args    Hook's additional arguments.
- * @return bool
  */
 function xprofile_sync_wp_profile( $user_id = 0, ...$args ) {
 
 	// Bail if profile syncing is disabled.
 	if ( bp_disable_profile_sync() ) {
-		return true;
+		return;
 	}
 
 	if ( empty( $user_id ) ) {
@@ -829,7 +828,7 @@ function xprofile_sync_wp_profile( $user_id = 0, ...$args ) {
 	}
 
 	if ( empty( $user_id ) ) {
-		return false;
+		return;
 	}
 
 	$fullname_field_id = (int) bp_xprofile_fullname_field_id();

--- a/src/bp-xprofile/classes/class-bp-xprofile-user-admin.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-user-admin.php
@@ -22,8 +22,6 @@ class BP_XProfile_User_Admin {
 	 * Setup xProfile User Admin.
 	 *
 	 * @since 2.0.0
-	 *
-	 * @return BP_XProfile_User_Admin
 	 */
 	public static function register_xprofile_user_admin() {
 
@@ -38,7 +36,7 @@ class BP_XProfile_User_Admin {
 			$bp->profile->admin = new self;
 		}
 
-		return $bp->profile->admin;
+		$bp->profile->admin;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

There are a lot of action callbacks being misused.

This pull request:

- removes the `@return` PHPdoc in functions without returned values, only with side effects;
- remove boolean values from functions without returned values, only with side effects;
- Update `add_action` to `add_filter` where applicable.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8553

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
