### PR TITLE
First step of merging BP Rewrites into Core

### DIFF
--- a/src/bp-core/bp-core-rewrites.php
+++ b/src/bp-core/bp-core-rewrites.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Core Rewrite API functions.
+ *
+ * @package BuddyPress
+ * @subpackage Core
+ * @since 12.0.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Gets default URL chunks rewrite information.
+ *
+ * @since 12.0.0
+ *
+ * @return array Default URL chunks rewrite information.
+ */
+function bp_rewrites_get_default_url_chunks() {
+	return array(
+		'directory'                    => array(
+			'regex' => '([1]{1,})',
+			'order' => 100,
+		),
+		'single_item'                  => array(
+			'regex' => '([^/]+)',
+			'order' => 90,
+		),
+		'single_item_component'        => array(
+			'regex' => '([^/]+)',
+			'order' => 80,
+		),
+		'single_item_action'           => array(
+			'regex' => '([^/]+)',
+			'order' => 70,
+		),
+		'single_item_action_variables' => array(
+			'regex' => '(.+?)',
+			'order' => 60,
+		),
+	);
+}

--- a/src/class-buddypress.php
+++ b/src/class-buddypress.php
@@ -622,6 +622,7 @@ class BuddyPress {
 		require $this->plugin_dir . 'bp-core/bp-core-template.php';
 		require $this->plugin_dir . 'bp-core/bp-core-adminbar.php';
 		require $this->plugin_dir . 'bp-core/bp-core-buddybar.php';
+		require $this->plugin_dir . 'bp-core/bp-core-rewrites.php';
 		require $this->plugin_dir . 'bp-core/bp-core-catchuri.php';
 		require $this->plugin_dir . 'bp-core/bp-core-functions.php';
 		require $this->plugin_dir . 'bp-core/bp-core-moderation.php';

--- a/tests/phpunit/assets/class-bptest-component.php
+++ b/tests/phpunit/assets/class-bptest-component.php
@@ -34,4 +34,16 @@ class BPTest_Component extends BP_Component {
 	public function setup_globals( $args = array() ) {
 		parent::setup_globals( $this->globals );
 	}
+
+	public function add_rewrite_tags( $rewrite_tags = array() ) {
+		parent::add_rewrite_tags( $rewrite_tags );
+	}
+
+	public function add_rewrite_rules( $rewrite_rules = array() ) {
+		parent::add_rewrite_rules( $rewrite_rules );
+	}
+
+	public function add_permastructs( $permastructs = array() ) {
+		parent::add_permastructs( $permastructs );
+	}
 }


### PR DESCRIPTION
Create the `bp-core-rewrites.php` file to put BP Rewrites function inside it & edit the BP_Component class to generate rewrites when a component has a directory.

Compared to the BP Rewrites plugin, I've put some new code to make it easier for plugin developers to create BP Rewrites for their custom component. Most of the job can be done by setting the `rewrite_ids` values from this component eg: `$component->rewrite_ids = array( 'directory' => 'custom_rewrite_id' )`.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/4954

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
