### PR TITLE
Edit the translator comments for problematic strings

### DIFF
--- a/src/bp-blogs/bp-blogs-activity.php
+++ b/src/bp-blogs/bp-blogs-activity.php
@@ -220,14 +220,14 @@ function bp_blogs_format_activity_action_new_blog_post( $action, $activity ) {
 
 		$action = sprintf(
 			/* translators: 1: the activity user link. 2: the blog link. */
-			esc_html_x( '%1$s wrote a new post on the site %2$s', 'Multisite `new_blog_post` activity action', 'buddypress' ),
+			esc_html_x( '%1$s wrote a new post on the site %2$s', 'Multisite `new_blog_post` activity action, since 11.0 only accepts two arguments', 'buddypress' ),
 			$user_link,
 			'<a href="' . esc_url( $blog_url ) . '">' . esc_html( $blog_name ) . '</a>'
 		);
 	} else {
 		$action = sprintf(
 			/* translators: 1: the activity user link. */
-			esc_html_x( '%s wrote a new post', '`new_blog_post` activity action', 'buddypress' ),
+			esc_html_x( '%s wrote a new post', '`new_blog_post` activity action, since 11.0 only accepts one argument', 'buddypress' ),
 			$user_link
 		);
 	}


### PR DESCRIPTION
In 11.0 we have removed 1 placeholder to 2 strings used to display the activity action for published posts. Issues were raised about the fact some polyglots team did not update corresponding translations leaving the removed placeholder. As these two strings are used inside `sprintf()` function it resulted fatal errors for the corresponding locales. We hope improving the comment will avoid such mistakes. It is a temporary fix, the right one would be to create a sanitization function wrapping `sprintf()` to make sure expected placeholders are found into the translated string. Although this kind of function should be made available by WordPress imho, a quick check into some tickets reported upstream made us realize this would not happen. We will handle it for our usage.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8821

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
