### PR TITLE
This is a major BP Rewrites merge step

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -178,8 +178,7 @@ class BP_Activity_Component extends BP_Component {
 	/**
 	 * Set up component global variables.
 	 *
-	 * The BP_ACTIVITY_SLUG constant is deprecated, and only used here for
-	 * backwards compatibility.
+	 * The BP_ACTIVITY_SLUG constant is deprecated.
 	 *
 	 * @since 1.5.0
 	 *
@@ -188,11 +187,13 @@ class BP_Activity_Component extends BP_Component {
 	 * @param array $args See BP_Component::setup_globals() for a description.
 	 */
 	public function setup_globals( $args = array() ) {
-		$bp = buddypress();
+		$bp           = buddypress();
+		$default_slug = $this->id;
 
-		// Define a slug, if necessary.
-		if ( ! defined( 'BP_ACTIVITY_SLUG' ) ) {
-			define( 'BP_ACTIVITY_SLUG', $this->id );
+		// @deprecated.
+		if ( defined( 'BP_ACTIVITY_SLUG' ) ) {
+			_doing_it_wrong( 'BP_ACTIVITY_SLUG', esc_html__( 'Slug constants are deprecated.', 'buddypress' ), 'BuddyPress 12.0.0' );
+			$default_slug = BP_ACTIVITY_SLUG;
 		}
 
 		// Global tables for activity component.
@@ -213,9 +214,14 @@ class BP_Activity_Component extends BP_Component {
 		// All globals for activity component.
 		// Note that global_tables is included in this array.
 		$args = array(
-			'slug'                  => BP_ACTIVITY_SLUG,
-			'root_slug'             => isset( $bp->pages->activity->slug ) ? $bp->pages->activity->slug : BP_ACTIVITY_SLUG,
+			'slug'                  => $default_slug,
+			'root_slug'             => isset( $bp->pages->activity->slug ) ? $bp->pages->activity->slug : $default_slug,
 			'has_directory'         => true,
+			'rewrite_ids'           => array(
+				'directory'                    => 'activities',
+				'single_item_action'           => 'activity_action',
+				'single_item_action_variables' => 'activity_action_variables',
+			),
 			'directory_title'       => isset( $bp->pages->activity->title ) ? $bp->pages->activity->title : $default_directory_title,
 			'notification_callback' => 'bp_activity_format_notifications',
 			'search_string'         => __( 'Search Activity...', 'buddypress' ),

--- a/src/bp-blogs/classes/class-bp-blogs-component.php
+++ b/src/bp-blogs/classes/class-bp-blogs-component.php
@@ -43,8 +43,7 @@ class BP_Blogs_Component extends BP_Component {
 	/**
 	 * Set up global settings for the blogs component.
 	 *
-	 * The BP_BLOGS_SLUG constant is deprecated, and only used here for
-	 * backwards compatibility.
+	 * The BP_BLOGS_SLUG constant is deprecated.
 	 *
 	 * @since 1.5.0
 	 *
@@ -53,10 +52,13 @@ class BP_Blogs_Component extends BP_Component {
 	 * @param array $args See {@link BP_Component::setup_globals()}.
 	 */
 	public function setup_globals( $args = array() ) {
-		$bp = buddypress();
+		$bp           = buddypress();
+		$default_slug = $this->id;
 
-		if ( ! defined( 'BP_BLOGS_SLUG' ) ) {
-			define ( 'BP_BLOGS_SLUG', $this->id );
+		// @deprecated.
+		if ( defined( 'BP_BLOGS_SLUG' ) ) {
+			_doing_it_wrong( 'BP_BLOGS_SLUG', esc_html__( 'Slug constants are deprecated.', 'buddypress' ), 'BuddyPress 12.0.0' );
+			$default_slug = BP_BLOGS_SLUG;
 		}
 
 		// Global tables for messaging component.
@@ -75,9 +77,14 @@ class BP_Blogs_Component extends BP_Component {
 
 		// All globals for blogs component.
 		$args = array(
-			'slug'                  => BP_BLOGS_SLUG,
-			'root_slug'             => isset( $bp->pages->blogs->slug ) ? $bp->pages->blogs->slug : BP_BLOGS_SLUG,
+			'slug'                  => $default_slug,
+			'root_slug'             => isset( $bp->pages->blogs->slug ) ? $bp->pages->blogs->slug : $default_slug,
 			'has_directory'         => is_multisite(), // Non-multisite installs don't need a top-level Sites directory, since there's only one site.
+			'rewrite_ids'           => array(
+				'directory'                    => 'blogs',
+				'single_item_action'           => 'blogs_action',
+				'single_item_action_variables' => 'blogs_action_variables',
+			),
 			'directory_title'       => isset( $bp->pages->blogs->title ) ? $bp->pages->blogs->title : $default_directory_title,
 			'notification_callback' => 'bp_blogs_format_notifications',
 			'search_string'         => __( 'Search sites...', 'buddypress' ),

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -743,7 +743,7 @@ function bp_core_get_directory_pages() {
 			$posts_table_name = bp_is_multiblog_mode() ? $wpdb->posts : $wpdb->get_blog_prefix( bp_get_root_blog_id() ) . 'posts';
 			$page_ids_sql     = implode( ',', wp_parse_id_list( $page_ids ) );
 			$page_stati_sql   = '\'' . implode( '\', \'', array_map( 'sanitize_key', bp_core_get_directory_pages_stati() ) ) . '\'';
-			$page_names       = $wpdb->get_results( "SELECT ID, post_name, post_parent, post_title FROM {$posts_table_name} WHERE ID IN ({$page_ids_sql}) AND post_status IN ({$page_stati_sql}) " );
+			$page_names       = $wpdb->get_results( "SELECT ID, post_name, post_parent, post_title, post_status FROM {$posts_table_name} WHERE ID IN ({$page_ids_sql}) AND post_status IN ({$page_stati_sql}) " );
 
 			foreach ( (array) $page_ids as $component_id => $page_id ) {
 				foreach ( (array) $page_names as $page_name ) {
@@ -764,7 +764,9 @@ function bp_core_get_directory_pages() {
 							$page_name->post_parent = $parent[0]->post_parent;
 						}
 
-						$pages->{$component_id}->slug = implode( '/', array_reverse( (array) $slug ) );
+						$pages->{$component_id}->slug         = implode( '/', array_reverse( (array) $slug ) );
+						$pages->{$component_id}->custom_slugs = get_post_meta( $page_name->ID, '_bp_component_slugs', true );
+						$pages->{$component_id}->visibility   = $page_name->post_status;
 					}
 
 					unset( $slug );
@@ -1107,21 +1109,24 @@ function bp_do_register_theme_directory() {
  * Eg: http://example.com OR https://example.com
  *
  * @since 1.0.0
+ * @deprecated 12.0.0
  *
  * @return string The domain URL for the blog.
  */
 function bp_core_get_root_domain() {
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_rewrites_get_root_url()' );
 
-	$domain = get_home_url( bp_get_root_blog_id() );
+	$domain = bp_rewrites_get_root_url();
 
 	/**
 	 * Filters the domain for the root blog.
 	 *
 	 * @since 1.0.1
+	 * @deprecated 12.0.0 Use {@see 'bp_rewrites_get_root_url'} instead.
 	 *
 	 * @param string $domain The domain URL for the blog.
 	 */
-	return apply_filters( 'bp_core_get_root_domain', $domain );
+	return apply_filters_deprecated( 'bp_core_get_root_domain', array( $domain ), '12.0.0', 'bp_rewrites_get_root_url' );
 }
 
 /**

--- a/src/bp-core/bp-core-rewrites.php
+++ b/src/bp-core/bp-core-rewrites.php
@@ -43,3 +43,191 @@ function bp_rewrites_get_default_url_chunks() {
 		),
 	);
 }
+
+/**
+ * Delete rewrite rules, so that they are automatically rebuilt on
+ * the subsequent page load.
+ *
+ * @since 12.0.0
+ */
+function bp_delete_rewrite_rules() {
+	delete_option( 'rewrite_rules' );
+}
+
+/**
+ * Are Pretty URLs active?
+ *
+ * @since 12.0.0
+ *
+ * @return bool True if Pretty URLs are on. False otherwise.
+ */
+function bp_has_pretty_urls() {
+	$has_plain_urls = ! get_option( 'permalink_structure', '' );
+	return ! $has_plain_urls;
+}
+
+/**
+ * Returns the slug to use for the view belonging to the requested component.
+ *
+ * @since 12.0.0
+ *
+ * @param string $component_id The BuddyPress component's ID.
+ * @param string $rewrite_id   The view rewrite ID.
+ * @param string $default_slug The view default slug.
+ * @return string The slug to use for the view belonging to the requested component.
+ */
+function bp_rewrites_get_slug( $component_id = '', $rewrite_id = '', $default_slug = '' ) {
+	$directory_pages = bp_core_get_directory_pages();
+	$slug            = $default_slug;
+
+	if ( ! isset( $directory_pages->{$component_id}->custom_slugs ) || ! $rewrite_id ) {
+		return $slug;
+	}
+
+	$custom_slugs = (array) $directory_pages->{$component_id}->custom_slugs;
+	if ( isset( $custom_slugs[ $rewrite_id ] ) && $custom_slugs[ $rewrite_id ] ) {
+		$slug = $custom_slugs[ $rewrite_id ];
+	}
+
+	return $slug;
+}
+
+/**
+ * Builds a BuddyPress link using the WP Rewrite API.
+ *
+ * @since 12.0.0
+ *
+ * @param array $args {
+ *      Optional. An array of arguments.
+ *
+ *      @type string $component_id                The BuddyPress component ID. Defaults ''.
+ *      @type string $directory_type              Whether it's an object type URL. Defaults ''.
+ *                                                Accepts '' (no object type), 'members' or 'groups'.
+ *      @type string $single_item                 The BuddyPress single item's URL chunk. Defaults ''.
+ *                                                Eg: the member's user nicename for Members or the group's slug for Groups.
+ *      @type string $single_item_component       The BuddyPress single item's component URL chunk. Defaults ''.
+ *                                                Eg: the member's Activity page.
+ *      @type string $single_item_action          The BuddyPress single item's action URL chunk. Defaults ''.
+ *                                                Eg: the member's Activity mentions page.
+ *      @type array $single_item_action_variables The list of BuddyPress single item's action variable URL chunks. Defaults [].
+ * }
+ * @return string The BuddyPress link.
+ */
+function bp_rewrites_get_url( $args = array() ) {
+	$bp   = buddypress();
+	$link = get_home_url( bp_get_root_blog_id() );
+
+	$r = bp_parse_args(
+		$args,
+		array(
+			'component_id'                 => '',
+			'directory_type'               => '',
+			'single_item'                  => '',
+			'single_item_component'        => '',
+			'single_item_action'           => '',
+			'single_item_action_variables' => array(),
+		)
+	);
+
+	if ( ! isset( $bp->{$r['component_id']}->rewrite_ids ) ) {
+		return $link;
+	}
+
+	$component = $bp->{$r['component_id']};
+	unset( $r['component_id'] );
+
+	// Using plain links.
+	if ( ! bp_has_pretty_urls() ) {
+		if ( ! isset( $r['member_register'] ) && ! isset( $r['member_activate'] ) ) {
+			$r['directory'] = 1;
+		}
+
+		$r  = array_filter( $r );
+		$qv = array();
+
+		foreach ( $component->rewrite_ids as $key => $rewrite_id ) {
+			if ( ! isset( $r[ $key ] ) ) {
+				continue;
+			}
+
+			$qv[ $rewrite_id ] = $r[ $key ];
+		}
+
+		$link = add_query_arg( $qv, $link );
+
+		// Using pretty URLs.
+	} else {
+		if ( ! isset( $component->rewrite_ids['directory'] ) || ! isset( $component->directory_permastruct ) ) {
+			return $link;
+		}
+
+		if ( isset( $r['member_register'] ) ) {
+			$link = str_replace( '%' . $component->rewrite_ids['member_register'] . '%', '', $component->register_permastruct );
+			unset( $r['member_register'] );
+		} elseif ( isset( $r['member_activate'] ) ) {
+			$link = str_replace( '%' . $component->rewrite_ids['member_activate'] . '%', '', $component->activate_permastruct );
+			unset( $r['member_activate'] );
+		} elseif ( isset( $r['create_single_item'] ) ) {
+			$create_slug = 'create';
+			if ( 'groups' === $component->id ) {
+				$create_slug = bp_rewrites_get_slug( 'groups', 'bp_group_create', 'create' );
+			}
+
+			$link = str_replace( '%' . $component->rewrite_ids['directory'] . '%', $create_slug, $component->directory_permastruct );
+			unset( $r['create_single_item'] );
+		} else {
+			$link = str_replace( '%' . $component->rewrite_ids['directory'] . '%', $r['single_item'], $component->directory_permastruct );
+
+			// Remove the members directory slug when root profiles are on.
+			if ( bp_core_enable_root_profiles() && 'members' === $component->id && isset( $r['single_item'] ) && $r['single_item'] ) {
+				$link = str_replace( $bp->members->root_slug . '/', '', $link );
+			}
+
+			unset( $r['single_item'] );
+		}
+
+		$r = array_filter( $r );
+
+		if ( isset( $r['directory_type'] ) && $r['directory_type'] ) {
+			if ( 'members' === $component->id ) {
+				array_unshift( $r, bp_get_members_member_type_base() );
+			} elseif ( 'groups' === $component->id && bp_is_active( 'groups' ) ) {
+				array_unshift( $r, bp_get_groups_group_type_base() );
+			} else {
+				unset( $r['directory_type'] );
+			}
+		}
+
+		if ( isset( $r['single_item_action_variables'] ) && $r['single_item_action_variables'] ) {
+			$r['single_item_action_variables'] = join( '/', (array) $r['single_item_action_variables'] );
+		}
+
+		if ( isset( $r['create_single_item_variables'] ) && $r['create_single_item_variables'] ) {
+			$r['create_single_item_variables'] = join( '/', (array) $r['create_single_item_variables'] );
+		}
+
+		$link = get_home_url( bp_get_root_blog_id(), user_trailingslashit( '/' . rtrim( $link, '/' ) . '/' . join( '/', $r ) ) );
+	}
+
+	return $link;
+}
+
+/**
+ * Gets the BP root site URL, using BP Rewrites.
+ *
+ * @since 12.0.0
+ *
+ * @return string The BP root site URL.
+ */
+function bp_rewrites_get_root_url() {
+	$url = bp_rewrites_get_url( array() );
+
+	/**
+	 * Filter here to edit the BP root site URL.
+	 *
+	 * @since 12.0.0
+	 *
+	 * @param string $url The BP root site URL.
+	 */
+	return apply_filters( 'bp_rewrites_get_root_url', $url );
+}

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -1399,38 +1399,85 @@ function bp_action_variable( $position = 0 ) {
 }
 
 /**
+ * Gets the BP root blog's URL.
+ *
+ * @since 12.0.0
+ *
+ * @return string The BP root blog's URL.
+ */
+function bp_get_root_url() {
+	$bp = buddypress();
+
+	if ( ! empty( $bp->root_url ) ) {
+		$url = $bp->root_url;
+	} else {
+		$url          = bp_rewrites_get_root_url();
+		$bp->root_url = $url;
+	}
+
+	/**
+	 * Filters the "root url", the URL of the BP root blog.
+	 *
+	 * @since 12.0.0
+	 *
+	 * @param string $url URL of the BP root blog.
+	 */
+	return apply_filters( 'bp_get_root_url', $url );
+}
+
+/**
+ * Output the "root url", the URL of the BP root blog.
+ *
+ * @since 12.0.0
+ */
+function bp_root_url() {
+	echo esc_url( bp_get_root_url() );
+}
+
+/**
  * Output the "root domain", the URL of the BP root blog.
  *
  * @since 1.1.0
+ * @deprecated 12.0.0
  */
 function bp_root_domain() {
-	echo bp_get_root_domain();
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_root_url()' );
+	bp_root_url();
 }
 	/**
 	 * Return the "root domain", the URL of the BP root blog.
 	 *
 	 * @since 1.1.0
+	 * @deprecated 12.0.0
 	 *
 	 * @return string URL of the BP root blog.
 	 */
 	function bp_get_root_domain() {
-		$bp = buddypress();
-
-		if ( ! empty( $bp->root_domain ) ) {
-			$domain = $bp->root_domain;
-		} else {
-			$domain          = bp_core_get_root_domain();
-			$bp->root_domain = $domain;
+		/*
+		 * This function is used at many places and we need to review all this
+		 * places during the 12.0 development cycle. Using BP Rewrites means we
+		 * cannot concatenate URL chunks to build our URL anymore. We now need
+		 * to use `bp_rewrites_get_url( $array )` and make sure to use the right
+		 * arguments inside this `$array`.
+		 *
+		 * @todo Once every link reviewed, we'll be able to remove this check
+		 *       and let PHPUnit tell us the one we forgot, eventually!
+		 */
+		if ( ! buddypress()->is_phpunit_running ) {
+			_deprecated_function( __FUNCTION__, '12.0.0', 'bp_get_root_url()' );
 		}
 
+		$domain = bp_get_root_url();
+
 		/**
-		 * Filters the "root domain", the URL of the BP root blog.
+		 *  Filters the "root domain", the URL of the BP root blog.
 		 *
 		 * @since 1.2.4
+		 * @deprecated 12.0.0 Use {@see 'bp_get_root_url'} instead.
 		 *
 		 * @param string $domain URL of the BP root blog.
 		 */
-		return apply_filters( 'bp_get_root_domain', $domain );
+		return apply_filters_deprecated( 'bp_core_get_root_domain', array( $domain ), '12.0.0', 'bp_get_root_url' );
 	}
 
 /**

--- a/src/bp-core/bp-core-update.php
+++ b/src/bp-core/bp-core-update.php
@@ -861,7 +861,7 @@ function bp_update_to_12_0() {
 		}
 
 		// Finally make sure to rebuilt permalinks at next page load.
-		delete_option( 'rewrite_rules' );
+		bp_delete_rewrite_rules();
 	}
 }
 

--- a/src/bp-core/classes/class-bp-component.php
+++ b/src/bp-core/classes/class-bp-component.php
@@ -1123,7 +1123,7 @@ class BP_Component {
 
 		$queried_object = $query->get_queried_object();
 
-		if ( $queried_object instanceof \WP_Post && 'buddypress' === get_post_type( $queried_object ) ) {
+		if ( $queried_object instanceof WP_Post && 'buddypress' === get_post_type( $queried_object ) ) {
 			// Only include the queried directory post into returned posts.
 			$retval = array( $queried_object );
 		}

--- a/src/bp-core/classes/class-bp-core.php
+++ b/src/bp-core/classes/class-bp-core.php
@@ -217,9 +217,9 @@ class BP_Core extends BP_Component {
 			$bp->table_prefix = bp_core_get_table_prefix();
 		}
 
-		// The domain for the root of the site where the main blog resides.
-		if ( empty( $bp->root_domain ) ) {
-			$bp->root_domain = bp_core_get_root_domain();
+		// The URL for the root of the site where the main blog resides.
+		if ( empty( $bp->root_url ) ) {
+			$bp->root_url = bp_rewrites_get_root_url();
 		}
 
 		// Fetches all of the core BuddyPress settings in one fell swoop.

--- a/src/bp-core/deprecated/12.0.php
+++ b/src/bp-core/deprecated/12.0.php
@@ -139,3 +139,21 @@ function bp_core_admin_slugs_options() {
 function bp_core_admin_slugs_setup_handler() {
 	_deprecated_function( __FUNCTION__, '12.0.0' );
 }
+
+/**
+ * Define the slug constants for the Members component.
+ *
+ * Handles the three slug constants used in the Members component -
+ * BP_MEMBERS_SLUG, BP_REGISTER_SLUG, and BP_ACTIVATION_SLUG. If these
+ * constants are not overridden in wp-config.php or bp-custom.php, they are
+ * defined here to match the slug of the corresponding WP pages.
+ *
+ * In general, fallback values are only used during initial BP page creation,
+ * when no slugs have been explicitly defined.
+ *
+ * @since 1.5.0
+ * @deprecated 12.0.0
+ */
+function bp_core_define_slugs() {
+	_deprecated_function( __FUNCTION__, '12.0.0' );
+}

--- a/src/bp-friends/classes/class-bp-friends-component.php
+++ b/src/bp-friends/classes/class-bp-friends-component.php
@@ -100,8 +100,7 @@ class BP_Friends_Component extends BP_Component {
 	/**
 	 * Set up bp-friends global settings.
 	 *
-	 * The BP_FRIENDS_SLUG constant is deprecated, and only used here for
-	 * backwards compatibility.
+	 * The BP_FRIENDS_SLUG constant is deprecated.
 	 *
 	 * @since 1.5.0
 	 *
@@ -110,17 +109,18 @@ class BP_Friends_Component extends BP_Component {
 	 * @param array $args See {@link BP_Component::setup_globals()}.
 	 */
 	public function setup_globals( $args = array() ) {
-		$bp = buddypress();
+		$bp           = buddypress();
+		$default_slug = $this->id;
 
-		// Deprecated. Do not use.
-		// Defined conditionally to support unit tests.
-		if ( ! defined( 'BP_FRIENDS_DB_VERSION' ) ) {
-			define( 'BP_FRIENDS_DB_VERSION', '1800' );
+		// @deprecated.
+		if ( defined( 'BP_FRIENDS_DB_VERSION' ) ) {
+			_doing_it_wrong( 'BP_FRIENDS_DB_VERSION', esc_html__( 'This constants is not used anymore.', 'buddypress' ), 'BuddyPress 12.0.0' );
 		}
 
-		// Define a slug, if necessary.
-		if ( ! defined( 'BP_FRIENDS_SLUG' ) ) {
-			define( 'BP_FRIENDS_SLUG', $this->id );
+		// @deprecated.
+		if ( defined( 'BP_FRIENDS_SLUG' ) ) {
+			_doing_it_wrong( 'BP_FRIENDS_SLUG', esc_html__( 'Slug constants are deprecated.', 'buddypress' ), 'BuddyPress 12.0.0' );
+			$default_slug = BP_FRIENDS_SLUG;
 		}
 
 		// Global tables for the friends component.
@@ -132,7 +132,7 @@ class BP_Friends_Component extends BP_Component {
 		// All globals for the friends component.
 		// Note that global_tables is included in this array.
 		$args = array(
-			'slug'                  => BP_FRIENDS_SLUG,
+			'slug'                  => $default_slug,
 			'has_directory'         => false,
 			'search_string'         => __( 'Search Friends...', 'buddypress' ),
 			'notification_callback' => 'friends_format_notifications',

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -438,8 +438,7 @@ class BP_Groups_Component extends BP_Component {
 	/**
 	 * Set up component global data.
 	 *
-	 * The BP_GROUPS_SLUG constant is deprecated, and only used here for
-	 * backwards compatibility.
+	 * The BP_GROUPS_SLUG constant is deprecated.
 	 *
 	 * @since 1.5.0
 	 *
@@ -448,11 +447,13 @@ class BP_Groups_Component extends BP_Component {
 	 * @param array $args See BP_Component::setup_globals() for a description.
 	 */
 	public function setup_globals( $args = array() ) {
-		$bp = buddypress();
+		$bp           = buddypress();
+		$default_slug = $this->id;
 
-		// Define a slug, if necessary.
-		if ( ! defined( 'BP_GROUPS_SLUG' ) ) {
-			define( 'BP_GROUPS_SLUG', $this->id );
+		// @deprecated.
+		if ( defined( 'BP_GROUPS_SLUG' ) ) {
+			_doing_it_wrong( 'BP_GROUPS_SLUG', esc_html__( 'Slug constants are deprecated.', 'buddypress' ), 'BuddyPress 12.0.0' );
+			$default_slug = BP_GROUPS_SLUG;
 		}
 
 		// Global tables for groups component.
@@ -474,9 +475,18 @@ class BP_Groups_Component extends BP_Component {
 		// All globals for groups component.
 		// Note that global_tables is included in this array.
 		$args = array(
-			'slug'                  => BP_GROUPS_SLUG,
-			'root_slug'             => isset( $bp->pages->groups->slug ) ? $bp->pages->groups->slug : BP_GROUPS_SLUG,
+			'slug'                  => $default_slug,
+			'root_slug'             => isset( $bp->pages->groups->slug ) ? $bp->pages->groups->slug : $default_slug,
 			'has_directory'         => true,
+			'rewrite_ids'           => array(
+				'directory'                    => 'groups',
+				'directory_type'               => 'groups_type',
+				'create_single_item'           => 'group_create',
+				'create_single_item_variables' => 'group_create_variables',
+				'single_item'                  => 'group',
+				'single_item_action'           => 'group_action',
+				'single_item_action_variables' => 'group_action_variables',
+			),
 			'directory_title'       => isset( $bp->pages->groups->title ) ? $bp->pages->groups->title : $default_directory_title,
 			'notification_callback' => 'groups_format_notifications',
 			'search_string'         => _x( 'Search Groups...', 'Component directory search', 'buddypress' ),

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -26,51 +26,6 @@ function bp_members_has_directory() {
 }
 
 /**
- * Define the slug constants for the Members component.
- *
- * Handles the three slug constants used in the Members component -
- * BP_MEMBERS_SLUG, BP_REGISTER_SLUG, and BP_ACTIVATION_SLUG. If these
- * constants are not overridden in wp-config.php or bp-custom.php, they are
- * defined here to match the slug of the corresponding WP pages.
- *
- * In general, fallback values are only used during initial BP page creation,
- * when no slugs have been explicitly defined.
- *
- * @since 1.5.0
- */
-function bp_core_define_slugs() {
-	$bp = buddypress();
-
-	// No custom members slug.
-	if ( !defined( 'BP_MEMBERS_SLUG' ) ) {
-		if ( !empty( $bp->pages->members ) ) {
-			define( 'BP_MEMBERS_SLUG', $bp->pages->members->slug );
-		} else {
-			define( 'BP_MEMBERS_SLUG', 'members' );
-		}
-	}
-
-	// No custom registration slug.
-	if ( !defined( 'BP_REGISTER_SLUG' ) ) {
-		if ( !empty( $bp->pages->register ) ) {
-			define( 'BP_REGISTER_SLUG', $bp->pages->register->slug );
-		} else {
-			define( 'BP_REGISTER_SLUG', 'register' );
-		}
-	}
-
-	// No custom activation slug.
-	if ( !defined( 'BP_ACTIVATION_SLUG' ) ) {
-		if ( !empty( $bp->pages->activate ) ) {
-			define( 'BP_ACTIVATION_SLUG', $bp->pages->activate->slug );
-		} else {
-			define( 'BP_ACTIVATION_SLUG', 'activate' );
-		}
-	}
-}
-add_action( 'bp_setup_globals', 'bp_core_define_slugs', 11 );
-
-/**
  * Fetch an array of users based on the parameters passed.
  *
  * Since BuddyPress 1.7, bp_core_get_users() uses BP_User_Query. If you
@@ -1547,20 +1502,10 @@ function bp_core_get_illegal_names( $value = '' ) {
 		'activate',
 	);
 
-	// Core constants.
+	// @todo replace slug constants with custom slugs.
 	$slug_constants = array(
-		'BP_GROUPS_SLUG',
-		'BP_MEMBERS_SLUG',
 		'BP_FORUMS_SLUG',
-		'BP_BLOGS_SLUG',
-		'BP_ACTIVITY_SLUG',
-		'BP_XPROFILE_SLUG',
-		'BP_FRIENDS_SLUG',
 		'BP_SEARCH_SLUG',
-		'BP_SETTINGS_SLUG',
-		'BP_NOTIFICATIONS_SLUG',
-		'BP_REGISTER_SLUG',
-		'BP_ACTIVATION_SLUG',
 	);
 	foreach ( $slug_constants as $constant ) {
 		if ( defined( $constant ) ) {

--- a/src/bp-members/bp-members-template.php
+++ b/src/bp-members/bp-members-template.php
@@ -213,14 +213,11 @@ function bp_signup_slug() {
 	 * @return string
 	 */
 	function bp_get_signup_slug() {
-		$bp = buddypress();
+		$bp   = buddypress();
+		$slug = 'register';
 
 		if ( ! empty( $bp->pages->register->slug ) ) {
 			$slug = $bp->pages->register->slug;
-		} elseif ( defined( 'BP_REGISTER_SLUG' ) ) {
-			$slug = BP_REGISTER_SLUG;
-		} else {
-			$slug = 'register';
 		}
 
 		/**
@@ -249,14 +246,11 @@ function bp_activate_slug() {
 	 * @return string
 	 */
 	function bp_get_activate_slug() {
-		$bp = buddypress();
+		$bp   = buddypress();
+		$slug = 'activate';
 
 		if ( ! empty( $bp->pages->activate->slug ) ) {
 			$slug = $bp->pages->activate->slug;
-		} elseif ( defined( 'BP_ACTIVATION_SLUG' ) ) {
-			$slug = BP_ACTIVATION_SLUG;
-		} else {
-			$slug = 'activate';
 		}
 
 		/**

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -275,8 +275,7 @@ class BP_Members_Component extends BP_Component {
 	/**
 	 * Set up bp-members global settings.
 	 *
-	 * The BP_MEMBERS_SLUG constant is deprecated, and only used here for
-	 * backwards compatibility.
+	 * The BP_MEMBERS_SLUG constant is deprecated.
 	 *
 	 * @since 1.5.0
 	 *
@@ -287,14 +286,16 @@ class BP_Members_Component extends BP_Component {
 	public function setup_globals( $args = array() ) {
 		global $wpdb;
 
-		$bp = buddypress();
+		$bp           = buddypress();
+		$default_slug = $this->id;
 
 		/** Component Globals ************************************************
 		 */
 
-		// Define a slug, as a fallback for backpat.
-		if ( !defined( 'BP_MEMBERS_SLUG' ) ) {
-			define( 'BP_MEMBERS_SLUG', $this->id );
+		// @deprecated.
+		if ( defined( 'BP_MEMBERS_SLUG' ) ) {
+			_doing_it_wrong( 'BP_MEMBERS_SLUG', esc_html__( 'Slug constants are deprecated.', 'buddypress' ), 'BuddyPress 12.0.0' );
+			$default_slug = BP_MEMBERS_SLUG;
 		}
 
 		// Fetch the default directory title.
@@ -303,9 +304,20 @@ class BP_Members_Component extends BP_Component {
 
 		// Override any passed args.
 		$args = array(
-			'slug'            => BP_MEMBERS_SLUG,
-			'root_slug'       => isset( $bp->pages->members->slug ) ? $bp->pages->members->slug : BP_MEMBERS_SLUG,
+			'slug'            => $default_slug,
+			'root_slug'       => isset( $bp->pages->members->slug ) ? $bp->pages->members->slug : $default_slug,
 			'has_directory'   => true,
+			'rewrite_ids'     => array(
+				'directory'                    => 'members',
+				'directory_type'               => 'members_type',
+				'single_item'                  => 'member',
+				'single_item_component'        => 'member_component',
+				'single_item_action'           => 'member_action',
+				'single_item_action_variables' => 'member_action_variables',
+				'member_register'              => 'register',
+				'member_activate'              => 'activate',
+				'member_activate_key'          => 'activate_key',
+			),
 			'directory_title' => isset( $bp->pages->members->title ) ? $bp->pages->members->title : $default_directory_title,
 			'search_string'   => __( 'Search Members...', 'buddypress' ),
 			'global_tables'   => array(

--- a/src/bp-messages/classes/class-bp-messages-component.php
+++ b/src/bp-messages/classes/class-bp-messages-component.php
@@ -145,19 +145,20 @@ class BP_Messages_Component extends BP_Component {
 	/**
 	 * Set up globals for the Messages component.
 	 *
-	 * The BP_MESSAGES_SLUG constant is deprecated, and only used here for
-	 * backwards compatibility.
+	 * The BP_MESSAGES_SLUG constant is deprecated.
 	 *
 	 * @since 1.5.0
 	 *
 	 * @param array $args Not used.
 	 */
 	public function setup_globals( $args = array() ) {
-		$bp = buddypress();
+		$bp           = buddypress();
+		$default_slug = $this->id;
 
-		// Define a slug, if necessary.
-		if ( ! defined( 'BP_MESSAGES_SLUG' ) ) {
-			define( 'BP_MESSAGES_SLUG', $this->id );
+		// @deprecated.
+		if ( defined( 'BP_MESSAGES_SLUG' ) ) {
+			_doing_it_wrong( 'BP_MESSAGES_SLUG', esc_html__( 'Slug constants are deprecated.', 'buddypress' ), 'BuddyPress 12.0.0' );
+			$default_slug = BP_MESSAGES_SLUG;
 		}
 
 		// Global tables for messaging component.
@@ -178,7 +179,7 @@ class BP_Messages_Component extends BP_Component {
 		// All globals for messaging component.
 		// Note that global_tables is included in this array.
 		parent::setup_globals( array(
-			'slug'                  => BP_MESSAGES_SLUG,
+			'slug'                  => $default_slug,
 			'has_directory'         => false,
 			'notification_callback' => 'messages_format_notifications',
 			'search_string'         => __( 'Search Messages...', 'buddypress' ),

--- a/src/bp-notifications/classes/class-bp-notifications-component.php
+++ b/src/bp-notifications/classes/class-bp-notifications-component.php
@@ -99,11 +99,13 @@ class BP_Notifications_Component extends BP_Component {
 	 * @param array $args See BP_Component::setup_globals() for a description.
 	 */
 	public function setup_globals( $args = array() ) {
-		$bp = buddypress();
+		$bp           = buddypress();
+		$default_slug = $this->id;
 
-		// Define a slug, if necessary.
-		if ( ! defined( 'BP_NOTIFICATIONS_SLUG' ) ) {
-			define( 'BP_NOTIFICATIONS_SLUG', $this->id );
+		// @deprecated.
+		if ( defined( 'BP_NOTIFICATIONS_SLUG' ) ) {
+			_doing_it_wrong( 'BP_NOTIFICATIONS_SLUG', esc_html__( 'Slug constants are deprecated.', 'buddypress' ), 'BuddyPress 12.0.0' );
+			$default_slug = BP_NOTIFICATIONS_SLUG;
 		}
 
 		// Global tables for the notifications component.
@@ -120,7 +122,7 @@ class BP_Notifications_Component extends BP_Component {
 		// All globals for the notifications component.
 		// Note that global_tables is included in this array.
 		$args = array(
-			'slug'          => BP_NOTIFICATIONS_SLUG,
+			'slug'          => $default_slug,
 			'has_directory' => false,
 			'search_string' => __( 'Search Notifications...', 'buddypress' ),
 			'global_tables' => $global_tables,

--- a/src/bp-settings/classes/class-bp-settings-component.php
+++ b/src/bp-settings/classes/class-bp-settings-component.php
@@ -94,8 +94,7 @@ class BP_Settings_Component extends BP_Component {
 	/**
 	 * Setup globals.
 	 *
-	 * The BP_SETTINGS_SLUG constant is deprecated, and only used here for
-	 * backwards compatibility.
+	 * The BP_SETTINGS_SLUG constant is deprecated.
 	 *
 	 * @since 1.5.0
 	 *
@@ -104,15 +103,17 @@ class BP_Settings_Component extends BP_Component {
 	 * @param array $args See BP_Component::setup_globals() for a description.
 	 */
 	public function setup_globals( $args = array() ) {
+		$default_slug = $this->id;
 
-		// Define a slug, if necessary.
-		if ( ! defined( 'BP_SETTINGS_SLUG' ) ) {
-			define( 'BP_SETTINGS_SLUG', $this->id );
+		// @deprecated.
+		if ( defined( 'BP_SETTINGS_SLUG' ) ) {
+			_doing_it_wrong( 'BP_SETTINGS_SLUG', esc_html__( 'Slug constants are deprecated.', 'buddypress' ), 'BuddyPress 12.0.0' );
+			$default_slug = BP_SETTINGS_SLUG;
 		}
 
 		// All globals for settings component.
 		parent::setup_globals( array(
-			'slug'          => BP_SETTINGS_SLUG,
+			'slug'          => $default_slug,
 			'has_directory' => false,
 		) );
 	}

--- a/src/bp-settings/screens/general.php
+++ b/src/bp-settings/screens/general.php
@@ -36,7 +36,7 @@ function bp_settings_screen_general() {
  */
 function bp_settings_remove_email_subnav() {
 	if ( ! has_action( 'bp_notification_settings' ) ) {
-		bp_core_remove_subnav_item( BP_SETTINGS_SLUG, 'notifications' );
+		bp_core_remove_subnav_item( bp_get_settings_slug(), 'notifications' );
 	}
 }
 add_action( 'bp_actions', 'bp_settings_remove_email_subnav' );

--- a/src/bp-xprofile/classes/class-bp-xprofile-component.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-component.php
@@ -128,19 +128,20 @@ class BP_XProfile_Component extends BP_Component {
 	/**
 	 * Setup globals.
 	 *
-	 * The BP_XPROFILE_SLUG constant is deprecated, and only used here for
-	 * backwards compatibility.
+	 * The BP_XPROFILE_SLUG constant is deprecated.
 	 *
 	 * @since 1.5.0
 	 *
 	 * @param array $args Array of globals to set up.
 	 */
 	public function setup_globals( $args = array() ) {
-		$bp = buddypress();
+		$bp           = buddypress();
+		$default_slug = 'profile';
 
-		// Define a slug, if necessary.
-		if ( ! defined( 'BP_XPROFILE_SLUG' ) ) {
-			define( 'BP_XPROFILE_SLUG', 'profile' );
+		// @deprecated.
+		if ( defined( 'BP_XPROFILE_SLUG' ) ) {
+			_doing_it_wrong( 'BP_XPROFILE_SLUG', esc_html__( 'Slug constants are deprecated.', 'buddypress' ), 'BuddyPress 12.0.0' );
+			$default_slug = BP_XPROFILE_SLUG;
 		}
 
 		// Assign the base group and fullname field names to constants
@@ -208,7 +209,7 @@ class BP_XProfile_Component extends BP_Component {
 		);
 
 		$globals = array(
-			'slug'                  => BP_XPROFILE_SLUG,
+			'slug'                  => $default_slug,
 			'has_directory'         => false,
 			'notification_callback' => 'xprofile_format_notifications',
 			'global_tables'         => $global_tables,

--- a/src/class-buddypress.php
+++ b/src/class-buddypress.php
@@ -306,7 +306,13 @@ class BuddyPress {
 	 * @return mixed
 	 */
 	public function __get( $key ) {
-		return isset( $this->data[ $key ] ) ? $this->data[ $key ] : null;
+		$valid_key = $key;
+		if ( 'root_domain' === $key ) {
+			_doing_it_wrong( 'root_domain', __( 'The root_domain BuddyPress main class property is deprecated since 12.0.0, please use the root_url property instead.', 'buddypress' ), 'BuddyPress 12.0.0' );
+			$valid_key = 'root_url';
+		}
+
+		return isset( $this->data[ $valid_key ] ) ? $this->data[ $valid_key ] : null;
 	}
 
 	/**
@@ -318,7 +324,13 @@ class BuddyPress {
 	 * @param mixed  $value Value to set.
 	 */
 	public function __set( $key, $value ) {
-		$this->data[ $key ] = $value;
+		$valid_key = $key;
+		if ( 'root_domain' === $key ) {
+			_doing_it_wrong( 'root_domain', __( 'The root_domain BuddyPress main class property is deprecated since 12.0.0, please use the root_url property instead.', 'buddypress' ), 'BuddyPress 12.0.0' );
+			$valid_key = 'root_url';
+		}
+
+		$this->data[ $valid_key ] = $value;
 	}
 
 	/**

--- a/tests/phpunit/testcases/core/rewrites.php
+++ b/tests/phpunit/testcases/core/rewrites.php
@@ -1,0 +1,240 @@
+<?php
+include_once BP_TESTS_DIR . '/assets/class-bptest-component.php';
+
+/**
+ * @group core
+ */
+class BP_Tests_Core_Rewrites extends BP_UnitTestCase {
+	protected $permalink_structure = '';
+
+	public function set_up() {
+		$bp = buddypress();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
+
+		$bp->buddies = new BPTest_Component(
+			array(
+				'id'      => 'buddies',
+				'name'    => 'Buddies',
+				'globals' => array(
+					'has_directory' => true,
+					'root_slug'     => 'buddies',
+					'rewrite_ids'   => array(
+						'directory'                    => 'buddies',
+						'single_item'                  => 'buddy',
+						'single_item_component'        => 'buddy_component',
+						'single_item_action'           => 'buddy_action',
+						'single_item_action_variables' => 'buddy_action_variables',
+					),
+				),
+			)
+		);
+
+		$bp->buddies->setup_globals();
+		$bp->buddies->add_rewrite_tags();
+		$bp->buddies->add_rewrite_rules();
+		$bp->buddies->add_permastructs();
+
+		parent::set_up();
+	}
+
+	public function tear_down() {
+		$bp = buddypress();
+		unset( $bp->buddies );
+
+		$this->set_permalink_structure( $this->permalink_structure );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @group bp_rewrites_get_url
+	 * @group bp_rewrites_get_root_url
+	 */
+	public function test_bp_rewrites_get_root_url() {
+		$root_url = get_home_url( bp_get_root_blog_id() );
+		$this->assertEquals( $root_url, bp_rewrites_get_root_url() );
+	}
+
+	/**
+	 * @group bp_rewrites_get_url
+	 */
+	public function test_bp_rewrites_get_url_directory_plain() {
+		$this->set_permalink_structure( '' );
+
+		$buddies_url = bp_rewrites_get_url(
+			array(
+				'component_id' => 'buddies',
+			)
+		);
+
+		$qs = wp_parse_url( $buddies_url, PHP_URL_QUERY );
+		$this->assertEquals( 'bp_buddies=1', $qs );
+	}
+
+	/**
+	 * @group bp_rewrites_get_url
+	 */
+	public function test_bp_rewrites_get_url_directory_pretty() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$buddies_url = bp_rewrites_get_url(
+			array(
+				'component_id' => 'buddies',
+			)
+		);
+
+		$path = wp_parse_url( $buddies_url, PHP_URL_PATH );
+		$this->assertEquals( '/buddies/', $path );
+	}
+
+	/**
+	 * @group bp_rewrites_get_url
+	 */
+	public function test_bp_rewrites_get_url_single_item_plain() {
+		$this->set_permalink_structure( '' );
+
+		$buddies_url = bp_rewrites_get_url(
+			array(
+				'component_id' => 'buddies',
+				'single_item'  => 'foobar',
+			)
+		);
+
+		$qs = wp_parse_url( $buddies_url, PHP_URL_QUERY );
+		$this->assertEquals( 'bp_buddies=1&bp_buddy=foobar', $qs );
+	}
+
+	/**
+	 * @group bp_rewrites_get_url
+	 */
+	public function test_bp_rewrites_get_url_single_item_pretty() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$buddies_url = bp_rewrites_get_url(
+			array(
+				'component_id' => 'buddies',
+				'single_item'  => 'foobar',
+			)
+		);
+
+		$path = wp_parse_url( $buddies_url, PHP_URL_PATH );
+		$this->assertEquals( '/buddies/foobar/', $path );
+	}
+
+	/**
+	 * @group bp_rewrites_get_url
+	 */
+	public function test_bp_rewrites_get_url_single_item_component_plain() {
+		$this->set_permalink_structure( '' );
+
+		$buddies_url = bp_rewrites_get_url(
+			array(
+				'component_id'          => 'buddies',
+				'single_item'           => 'foobar',
+				'single_item_component' => 'activity',
+			)
+		);
+
+		$qs = wp_parse_url( $buddies_url, PHP_URL_QUERY );
+		$this->assertEquals( 'bp_buddies=1&bp_buddy=foobar&bp_buddy_component=activity', $qs );
+	}
+
+	/**
+	 * @group bp_rewrites_get_url
+	 */
+	public function test_bp_rewrites_get_url_single_item_component_pretty() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$buddies_url = bp_rewrites_get_url(
+			array(
+				'component_id'          => 'buddies',
+				'single_item'           => 'foobar',
+				'single_item_component' => 'activity',
+			)
+		);
+
+		$path = wp_parse_url( $buddies_url, PHP_URL_PATH );
+		$this->assertEquals( '/buddies/foobar/activity/', $path );
+	}
+
+	/**
+	 * @group bp_rewrites_get_url
+	 */
+	public function test_bp_rewrites_get_url_single_item_action_plain() {
+		$this->set_permalink_structure( '' );
+
+		$buddies_url = bp_rewrites_get_url(
+			array(
+				'component_id'          => 'buddies',
+				'single_item'           => 'foobar',
+				'single_item_component' => 'activity',
+				'single_item_action'    => 'mention',
+			)
+		);
+
+		$qs = wp_parse_url( $buddies_url, PHP_URL_QUERY );
+		$this->assertEquals( 'bp_buddies=1&bp_buddy=foobar&bp_buddy_component=activity&bp_buddy_action=mention', $qs );
+	}
+
+	/**
+	 * @group bp_rewrites_get_url
+	 */
+	public function test_bp_rewrites_get_url_single_item_action_pretty() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$buddies_url = bp_rewrites_get_url(
+			array(
+				'component_id'          => 'buddies',
+				'single_item'           => 'foobar',
+				'single_item_component' => 'activity',
+				'single_item_action'    => 'mention',
+			)
+		);
+
+		$path = wp_parse_url( $buddies_url, PHP_URL_PATH );
+		$this->assertEquals( '/buddies/foobar/activity/mention/', $path );
+	}
+
+	/**
+	 * @group bp_rewrites_get_url
+	 */
+	public function test_bp_rewrites_get_url_single_item_action_variables_plain() {
+		$this->set_permalink_structure( '' );
+		$expected = array( 'do', 'it', 'again' );
+
+		$buddies_url = bp_rewrites_get_url(
+			array(
+				'component_id'                 => 'buddies',
+				'single_item'                  => 'foobar',
+				'single_item_component'        => 'activity',
+				'single_item_action'           => 'mention',
+				'single_item_action_variables' => $expected,
+			)
+		);
+
+		$qs        = wp_parse_url( $buddies_url, PHP_URL_QUERY );
+		$parsed_qs = bp_parse_args( $qs, array() );
+
+		$this->assertSame( $expected, $parsed_qs['bp_buddy_action_variables'] );
+	}
+
+	/**
+	 * @group bp_rewrites_get_url
+	 */
+	public function test_bp_rewrites_get_url_single_item_action_variables_pretty() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$buddies_url = bp_rewrites_get_url(
+			array(
+				'component_id'                 => 'buddies',
+				'single_item'                  => 'foobar',
+				'single_item_component'        => 'activity',
+				'single_item_action'           => 'mention',
+				'single_item_action_variables' => array( 'do', 'it', 'again' ),
+			)
+		);
+
+		$path = wp_parse_url( $buddies_url, PHP_URL_PATH );
+		$this->assertEquals( '/buddies/foobar/activity/mention/do/it/again/', $path );
+	}
+}


### PR DESCRIPTION
It introduces the `bp_rewrites_get_url()` function. Its role is to build every BuddyPress URL using the BP Rewrites API.

It also deprecates softly some key functions like `bp_get_root_domain()` to let us review all BP links during 12.0 development cycle and make them use the `bp_rewrites_get_url()` function or a wrapper of it.

It also deprecates slug constant as we will be able to customize every slugs from the future "URL" tab of BuddyPress settings page.

It puts the Components `$rewrite_ids` in place and deprecates the `$root_domain` BP global.

This PR will soon be completed with Unit tests for the `bp_rewrites_get_url()` function.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/4954

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
