### PR TITLE
Introduces `bp_members_get_user_url()` to build all member URLs

### DIFF
--- a/src/bp-activity/actions/feeds.php
+++ b/src/bp-activity/actions/feeds.php
@@ -175,7 +175,7 @@ function bp_activity_action_mentions_feed() {
 		/* translators: %s: User Display Name */
 		'description'   => sprintf( __( "Activity feed mentioning %s.", 'buddypress' ), bp_get_displayed_user_fullname() ),
 		'activity_args' => array(
-			'search_terms' => '@' . bp_core_get_username( bp_displayed_user_id() )
+			'search_terms' => '@' . bp_members_get_user_slug( bp_displayed_user_id() )
 		)
 	) );
 

--- a/src/bp-activity/bp-activity-filters.php
+++ b/src/bp-activity/bp-activity-filters.php
@@ -264,7 +264,7 @@ function bp_activity_at_name_filter( $content, $activity_id = 0 ) {
 
 	// Linkify the mentions with the username.
 	foreach ( (array) $usernames as $user_id => $username ) {
-		$content = preg_replace( '/(@' . $username . '\b)/', "<a class='bp-suggestions-mention' href='" . bp_core_get_user_domain( $user_id ) . "' rel='nofollow'>@$username</a>", $content );
+		$content = preg_replace( '/(@' . $username . '\b)/', "<a class='bp-suggestions-mention' href='" . bp_members_get_user_url( $user_id ) . "' rel='nofollow'>@$username</a>", $content );
 	}
 
 	// Put everything back.
@@ -305,7 +305,7 @@ function bp_activity_at_name_filter_updates( $activity ) {
 	if ( ! empty( $usernames ) ) {
 		// Replace @mention text with userlinks.
 		foreach( (array) $usernames as $user_id => $username ) {
-			$activity->content = preg_replace( '/(@' . $username . '\b)/', "<a class='bp-suggestions-mention' href='" . bp_core_get_user_domain( $user_id ) . "' rel='nofollow'>@$username</a>", $activity->content );
+			$activity->content = preg_replace( '/(@' . $username . '\b)/', "<a class='bp-suggestions-mention' href='" . bp_members_get_user_url( $user_id ) . "' rel='nofollow'>@$username</a>", $activity->content );
 		}
 
 		// Add our hook to send @mention emails after the activity item is saved.

--- a/src/bp-activity/bp-activity-notifications.php
+++ b/src/bp-activity/bp-activity-notifications.php
@@ -411,7 +411,7 @@ function bp_activity_screen_notification_settings() {
 					<td>
 						<?php
 						/* translators: %s: the displayed user username */
-						printf( __( 'A member mentions you in an update using "@%s"', 'buddypress' ), bp_core_get_username( bp_displayed_user_id() ) );
+						printf( __( 'A member mentions you in an update using "@%s"', 'buddypress' ), bp_members_get_user_slug( bp_displayed_user_id() ) );
 						?>
 					</td>
 					<td class="yes"><input type="radio" name="notifications[notification_activity_new_mention]" id="notification-activity-new-mention-yes" value="yes" <?php checked( $mention, 'yes', true ) ?>/><label for="notification-activity-new-mention-yes" class="bp-screen-reader-text"><?php

--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -1006,7 +1006,7 @@ function bp_activity_user_link() {
 		if ( empty( $activities_template->activity->user_id ) || empty( $activities_template->activity->user_nicename ) || empty( $activities_template->activity->user_login ) ) {
 			$link = $activities_template->activity->primary_link;
 		} else {
-			$link = bp_core_get_user_domain( $activities_template->activity->user_id, $activities_template->activity->user_nicename, $activities_template->activity->user_login );
+			$link = bp_members_get_user_url( $activities_template->activity->user_id );
 		}
 
 		/**
@@ -1539,7 +1539,7 @@ function bp_activity_has_content() {
 			// Set common generated content properties.
 			if ( in_array( $activity_type, array( 'new_avatar', 'new_member', 'friendship_created', 'updated_profile' ), true ) ) {
 				$generated_content->user_url = array(
-					'value'             => bp_core_get_user_domain( $user_id ),
+					'value'             => bp_members_get_user_url( $user_id ),
 					'sanitize_callback' => 'esc_url',
 				);
 
@@ -2254,7 +2254,7 @@ function bp_activity_comment_user_link() {
 	 * @return string $user_link The URL of the activity comment author's profile.
 	 */
 	function bp_get_activity_comment_user_link() {
-		$user_link = bp_core_get_user_domain( bp_get_activity_comment_user_id() );
+		$user_link = bp_members_get_user_url( bp_get_activity_comment_user_id() );
 
 		/**
 		 * Filters the author link for the activity comment currently being displayed.
@@ -3652,7 +3652,7 @@ function bp_activity_comments_user_avatars( $args = array() ) {
 			}
 
 			// Get profile link for this user.
-			$profile_link = bp_core_get_user_domain( $user_id );
+			$profile_link = bp_members_get_user_url( $user_id );
 
 			// Get avatar for this user.
 			$image_html   = bp_core_fetch_avatar( array(

--- a/src/bp-activity/classes/class-bp-activity-oembed-extension.php
+++ b/src/bp-activity/classes/class-bp-activity-oembed-extension.php
@@ -137,7 +137,7 @@ class BP_Activity_oEmbed_Extension extends BP_Core_oEmbed_Extension {
 			'content'      => $activity->content,
 			'title'        => __( 'Activity', 'buddypress' ),
 			'author_name'  => bp_core_get_user_displayname( $activity->user_id ),
-			'author_url'   => bp_core_get_user_domain( $activity->user_id ),
+			'author_url'   => bp_members_get_user_url( $activity->user_id ),
 
 			// Custom identifier.
 			'x_buddypress' => 'activity'

--- a/src/bp-activity/screens/permalink.php
+++ b/src/bp-activity/screens/permalink.php
@@ -35,14 +35,18 @@ function bp_activity_action_permalink_router() {
 	}
 
 	// Do not redirect at default.
-	$redirect = false;
+	$redirect    = false;
+	$path_chunks = array(
+		'single_item_component' => bp_rewrites_get_slug( 'members', 'member_activity', bp_get_activity_slug() ),
+		'single_item_action'    => $activity->id,
+	);
 
 	// Redirect based on the type of activity.
 	if ( bp_is_active( 'groups' ) && $activity->component == buddypress()->groups->id ) {
 
 		// Activity is a user update.
 		if ( ! empty( $activity->user_id ) ) {
-			$redirect = bp_core_get_user_domain( $activity->user_id, $activity->user_nicename, $activity->user_login ) . bp_get_activity_slug() . '/' . $activity->id . '/';
+			$redirect = bp_members_get_user_url( $activity->user_id, $path_chunks );
 
 		// Activity is something else.
 		} else {
@@ -55,7 +59,7 @@ function bp_activity_action_permalink_router() {
 
 	// Set redirect to users' activity stream.
 	} elseif ( ! empty( $activity->user_id ) ) {
-		$redirect = bp_core_get_user_domain( $activity->user_id, $activity->user_nicename, $activity->user_login ) . bp_get_activity_slug() . '/' . $activity->id . '/';
+		$redirect = bp_members_get_user_url( $activity->user_id, $path_chunks );
 	}
 
 	// If set, add the original query string back onto the redirect URL.

--- a/src/bp-blogs/bp-blogs-activity.php
+++ b/src/bp-blogs/bp-blogs-activity.php
@@ -784,7 +784,7 @@ function bp_blogs_sync_add_from_activity_comment( $comment_id, $params, $parent_
 		'comment_post_ID'      => $parent_activity->secondary_item_id,
 		'comment_author'       => bp_core_get_user_displayname( $params['user_id'] ),
 		'comment_author_email' => $user->user_email,
-		'comment_author_url'   => bp_core_get_user_domain( $params['user_id'], $user->user_nicename, $user->user_login ),
+		'comment_author_url'   => bp_members_get_user_url( $params['user_id'] ),
 		'comment_content'      => $params['content'],
 		'comment_type'         => '', // Could be interesting to add 'BuddyPress' here...
 		'comment_parent'       => (int) $comment_parent,

--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -1310,7 +1310,7 @@ function bp_core_admin_user_row_actions( $actions, $user_object ) {
 	}
 
 	// Create a "View" link.
-	$url             = bp_core_get_user_domain( $user_id );
+	$url             = bp_members_get_user_url( $user_id );
 	$actions['view'] = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $url ), esc_html__( 'View', 'buddypress' ) );
 
 	// Return new actions.

--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -590,7 +590,7 @@ function bp_core_members_shortlink_redirector( $member_slug ) {
 
 	$user = wp_get_current_user();
 
-	return bp_core_get_username( $user->ID, $user->user_nicename, $user->user_login );
+	return bp_members_get_user_slug( $user->ID );
 }
 add_filter( 'bp_core_set_uri_globals_member_slug', 'bp_core_members_shortlink_redirector' );
 

--- a/src/bp-core/bp-core-filters.php
+++ b/src/bp-core/bp-core-filters.php
@@ -291,25 +291,30 @@ function bp_core_filter_comments( $comments, $post_id ) {
 	global $wpdb;
 
 	foreach( (array) $comments as $comment ) {
-		if ( $comment->user_id )
+		if ( $comment->user_id ) {
 			$user_ids[] = $comment->user_id;
+		}
 	}
 
-	if ( empty( $user_ids ) )
+	if ( empty( $user_ids ) ) {
 		return $comments;
+	}
 
 	$user_ids = implode( ',', wp_parse_id_list( $user_ids ) );
 
-	if ( !$userdata = $wpdb->get_results( "SELECT ID as user_id, user_login, user_nicename FROM {$wpdb->users} WHERE ID IN ({$user_ids})" ) )
+	if ( ! $userdata = $wpdb->get_results( "SELECT ID as user_id, user_login, user_nicename FROM {$wpdb->users} WHERE ID IN ({$user_ids})" ) ) {
 		return $comments;
+	}
 
-	foreach( (array) $userdata as $user )
-		$users[$user->user_id] = bp_core_get_user_domain( $user->user_id, $user->user_nicename, $user->user_login );
+	foreach( (array) $userdata as $user ) {
+		$users[$user->user_id] = bp_members_get_user_url( $user->user_id );
+	}
 
 	foreach( (array) $comments as $i => $comment ) {
-		if ( !empty( $comment->user_id ) ) {
-			if ( !empty( $users[$comment->user_id] ) )
+		if ( ! empty( $comment->user_id ) ) {
+			if ( ! empty( $users[$comment->user_id] ) ) {
 				$comments[$i]->comment_author_url = $users[$comment->user_id];
+			}
 		}
 	}
 
@@ -1232,7 +1237,7 @@ function bp_email_set_default_tokens( $tokens, $property_name, $transform, $emai
 			if ( bp_is_active( 'settings' ) && empty( $tokens['unsubscribe'] ) ) {
 				$tokens['unsubscribe'] = esc_url( sprintf(
 					'%s%s/notifications/',
-					bp_core_get_user_domain( $user_obj->ID ),
+					bp_members_get_user_url( $user_obj->ID ),
 					bp_get_settings_slug()
 				) );
 			}

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -4335,13 +4335,15 @@ function bp_email_unsubscribe_handler() {
 		$unsub_msg   = __( 'Please go to your notifications settings to unsubscribe from emails.', 'buddypress' );
 
 		if ( bp_is_active( 'settings' ) ) {
-			$redirect_to = sprintf(
-				'%s%s/notifications/',
-				bp_core_get_user_domain( get_current_user_id() ),
-				bp_get_settings_slug()
+			$redirect_to = bp_members_get_user_url(
+				get_current_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_settings', bp_get_settings_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_settings_notifications', 'notifications' ),
+				)
 			);
 		} else {
-			$redirect_to = bp_core_get_user_domain( get_current_user_id() );
+			$redirect_to = bp_members_get_user_url( get_current_user_id() );
 		}
 
 	// This is an unsubscribe request from a nonmember.
@@ -4367,11 +4369,11 @@ function bp_email_unsubscribe_handler() {
 		if ( bp_is_active( 'settings' ) ) {
 			$redirect_to = sprintf(
 				'%s%s/notifications/',
-				bp_core_get_user_domain( $raw_user_id ),
+				bp_members_get_user_url( $raw_user_id ),
 				bp_get_settings_slug()
 			);
 		} else {
-			$redirect_to = bp_core_get_user_domain( $raw_user_id );
+			$redirect_to = bp_members_get_user_url( $raw_user_id );
 		}
 
 		// Unsubscribe.
@@ -4392,7 +4394,7 @@ function bp_email_unsubscribe_handler() {
 
 		// Template notices are only displayed on BP pages.
 		bp_core_add_message( $message );
-		bp_core_redirect( bp_core_get_user_domain( $raw_user_id ) );
+		bp_core_redirect( bp_members_get_user_url( $raw_user_id ) );
 
 		exit;
 	} else {

--- a/src/bp-core/bp-core-rewrites.php
+++ b/src/bp-core/bp-core-rewrites.php
@@ -72,8 +72,9 @@ function bp_has_pretty_urls() {
  * @since 12.0.0
  *
  * @param string $component_id The BuddyPress component's ID.
- * @param string $rewrite_id   The view rewrite ID.
- * @param string $default_slug The view default slug.
+ * @param string $rewrite_id   The view rewrite ID, used to find the custom slugs.
+ *                             Eg: `member_profile_edit` will try to find the xProfile edit's slug.
+ * @param string $default_slug The view default slug, used as a fallback.
  * @return string The slug to use for the view belonging to the requested component.
  */
 function bp_rewrites_get_slug( $component_id = '', $rewrite_id = '', $default_slug = '' ) {
@@ -83,6 +84,9 @@ function bp_rewrites_get_slug( $component_id = '', $rewrite_id = '', $default_sl
 	if ( ! isset( $directory_pages->{$component_id}->custom_slugs ) || ! $rewrite_id ) {
 		return $slug;
 	}
+
+	// Make sure a `bp_` prefix is used.
+	$rewrite_id = 'bp_' . str_replace( 'bp_', '', sanitize_key( $rewrite_id ) );
 
 	$custom_slugs = (array) $directory_pages->{$component_id}->custom_slugs;
 	if ( isset( $custom_slugs[ $rewrite_id ] ) && $custom_slugs[ $rewrite_id ] ) {

--- a/src/bp-core/classes/class-bp-core-user.php
+++ b/src/bp-core/classes/class-bp-core-user.php
@@ -155,12 +155,12 @@ class BP_Core_User {
 		if ( !empty( $this->profile_data ) ) {
 			$full_name_field_name = bp_xprofile_fullname_field_name();
 
-			$this->user_url  = bp_core_get_user_domain( $this->id, $this->profile_data['user_nicename'], $this->profile_data['user_login'] );
+			$this->user_url  = bp_members_get_user_url( $this->id );
 			$this->fullname  = esc_attr( $this->profile_data[$full_name_field_name]['field_data'] );
 			$this->user_link = "<a href='{$this->user_url}'>{$this->fullname}</a>";
 			$this->email     = esc_attr( $this->profile_data['user_email'] );
 		} else {
-			$this->user_url  = bp_core_get_user_domain( $this->id );
+			$this->user_url  = bp_members_get_user_url( $this->id );
 			$this->user_link = bp_core_get_userlink( $this->id );
 			$this->fullname  = esc_attr( bp_core_get_user_displayname( $this->id ) );
 			$this->email     = esc_attr( bp_core_get_user_email( $this->id ) );

--- a/src/bp-core/classes/class-bp-optouts-list-table.php
+++ b/src/bp-core/classes/class-bp-optouts-list-table.php
@@ -324,7 +324,7 @@ class BP_Optouts_List_Table extends WP_Users_List_Table {
 		if ( ! $inviter ) {
 			return;
 		}
-		$user_link = bp_core_get_user_domain( $optout->user_id );
+		$user_link = bp_members_get_user_url( $optout->user_id );
 		echo $avatar . sprintf( '<strong><a href="%1$s" class="edit">%2$s</a></strong><br/>', esc_url( $user_link ), esc_html( $inviter->user_login ) );
 	}
 

--- a/src/bp-core/deprecated/12.0.php
+++ b/src/bp-core/deprecated/12.0.php
@@ -203,3 +203,41 @@ function bp_core_get_username( $user_id = 0, $user_nicename = false, $user_login
 	 */
 	return apply_filters_deprecated( 'bp_core_get_username', array( $username ), '12.0.0', 'bp_members_get_user_slug', );
 }
+
+/**
+ * Return the domain for the passed user: e.g. http://example.com/members/andy/.
+ *
+ * @since 1.0.0
+ * @deprecated 12.0.0
+ *
+ * @param int         $user_id       The ID of the user.
+ * @param string|bool $user_nicename Optional. user_nicename of the user.
+ * @param string|bool $user_login    Optional. user_login of the user.
+ * @return string
+ */
+function bp_core_get_user_domain( $user_id = 0, $user_nicename = false, $user_login = false ) {
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_members_get_user_url()' );
+
+	if ( empty( $user_id ) ) {
+		return;
+	}
+
+	$domain = bp_members_get_user_url( $user_id );
+
+	// Don't use this filter.  Subject to removal in a future release.
+	// Use the 'bp_core_get_user_domain' filter instead.
+	$domain = apply_filters_deprecated( 'bp_core_get_user_domain_pre_cache', array( $domain, $user_id, $user_nicename, $user_login), '12.0.0' );
+
+	/**
+	 * Filters the domain for the passed user.
+	 *
+	 * @since 1.0.1
+	 * @deprecated 12.0.0
+	 *
+	 * @param string $domain        Domain for the passed user.
+	 * @param int    $user_id       ID of the passed user.
+	 * @param string $user_nicename User nicename of the passed user.
+	 * @param string $user_login    User login of the passed user.
+	 */
+	return apply_filters_deprecated( 'bp_core_get_user_domain', array( $domain, $user_id, $user_nicename, $user_login), '12.0.0', 'bp_members_get_user_url' );
+}

--- a/src/bp-core/deprecated/12.0.php
+++ b/src/bp-core/deprecated/12.0.php
@@ -157,3 +157,49 @@ function bp_core_admin_slugs_setup_handler() {
 function bp_core_define_slugs() {
 	_deprecated_function( __FUNCTION__, '12.0.0' );
 }
+
+/**
+ * Return the username for a user based on their user id.
+ *
+ * This function is sensitive to the BP_ENABLE_USERNAME_COMPATIBILITY_MODE,
+ * so it will return the user_login or user_nicename as appropriate.
+ *
+ * @since 1.0.0
+ * @deprecated 12.0.0
+ *
+ * @param int         $user_id       User ID to check.
+ * @param string|bool $user_nicename Optional. user_nicename of user being checked.
+ * @param string|bool $user_login    Optional. user_login of user being checked.
+ * @return string The username of the matched user or an empty string if no user is found.
+ */
+function bp_core_get_username( $user_id = 0, $user_nicename = false, $user_login = false ) {
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_members_get_user_slug()' );
+
+	if ( ! $user_id ) {
+		$value = $user_nicename;
+		$field = 'slug';
+
+		if ( ! $user_nicename ) {
+			$value = $user_login;
+			$field = 'login';
+		}
+
+		$user = get_user_by( $field, $value );
+
+		if ( $user instanceof WP_User ) {
+			$user_id = (int) $user->ID;
+		}
+	}
+
+	$username = bp_members_get_user_slug( $user_id );
+
+	/**
+	 * Filters the username based on originally provided user ID.
+	 *
+	 * @since 1.0.1
+	 * @deprecated 12.0.0
+	 *
+	 * @param string $username Username determined by user ID.
+	 */
+	return apply_filters_deprecated( 'bp_core_get_username', array( $username ), '12.0.0', 'bp_members_get_user_slug', );
+}

--- a/src/bp-friends/bp-friends-blocks.php
+++ b/src/bp-friends/bp-friends-blocks.php
@@ -110,7 +110,12 @@ function bp_friends_render_friends_block( $attributes = array() ) {
 	// Make sure the widget ID is unique.
 	$widget_id = uniqid( 'friends-list-' );
 
-	$link = trailingslashit( bp_core_get_user_domain( $user_id ) . bp_get_friends_slug() );
+	$link = bp_members_get_user_url(
+		$user_id,
+		array(
+			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_friends', bp_get_friends_slug() ),
+		)
+	);
 
 	/* translators: %s: member name */
 	$title = sprintf( __( '%s\'s Friends', 'buddypress' ), bp_core_get_user_displayname( $user_id ) );
@@ -189,7 +194,7 @@ function bp_friends_render_friends_block( $attributes = array() ) {
 					'assets/widgets/friends.php',
 					'php',
 					array(
-						'data.link'              => bp_core_get_user_domain( $user->ID, $user->user_nicename, $user->user_login ),
+						'data.link'              => bp_members_get_user_url( $user->ID ),
 						'data.name'              => $user->display_name,
 						'data.avatar_urls.thumb' => bp_core_fetch_avatar(
 							array(

--- a/src/bp-friends/bp-friends-functions.php
+++ b/src/bp-friends/bp-friends-functions.php
@@ -877,11 +877,19 @@ function friends_notification_new_request( $friendship_id, $initiator_id, $frien
 
 	$args = array(
 		'tokens' => array(
-			'friend-requests.url' => esc_url( bp_core_get_user_domain( $friend_id ) . bp_get_friends_slug() . '/requests/' ),
+			'friend-requests.url' => esc_url(
+				bp_members_get_user_url(
+					$friend_id,
+					array(
+						'single_item_component' => bp_rewrites_get_slug( 'members', 'member_friends', bp_get_friends_slug() ),
+						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_friends_requests', 'requests' ),
+					)
+				)
+			),
 			'friend.id'           => $friend_id,
 			'friendship.id'       => $friendship_id,
 			'initiator.id'        => $initiator_id,
-			'initiator.url'       => esc_url( bp_core_get_user_domain( $initiator_id ) ),
+			'initiator.url'       => esc_url( bp_members_get_user_url( $initiator_id ) ),
 			'initiator.name'      => bp_core_get_user_displayname( $initiator_id ),
 			'unsubscribe'         => esc_url( bp_email_get_unsubscribe_link( $unsubscribe_args ) ),
 		),
@@ -915,7 +923,7 @@ function friends_notification_accepted_request( $friendship_id, $initiator_id, $
 	$args = array(
 		'tokens' => array(
 			'friend.id'      => $friend_id,
-			'friendship.url' => esc_url( bp_core_get_user_domain( $friend_id ) ),
+			'friendship.url' => esc_url( bp_members_get_user_url( $friend_id ) ),
 			'friend.name'    => bp_core_get_user_displayname( $friend_id ),
 			'friendship.id'  => $friendship_id,
 			'initiator.id'   => $initiator_id,

--- a/src/bp-friends/bp-friends-template.php
+++ b/src/bp-friends/bp-friends-template.php
@@ -101,7 +101,7 @@ function bp_friends_random_friends() {
 			<?php for ( $i = 0, $count = count( $friend_ids ); $i < $count; ++$i ) { ?>
 
 				<li>
-					<a href="<?php echo bp_core_get_user_domain( $friend_ids[$i] ) ?>"><?php echo bp_core_fetch_avatar( array( 'item_id' => $friend_ids[$i], 'type' => 'thumb' ) ) ?></a>
+					<a href="<?php echo bp_members_get_user_url( $friend_ids[$i] ) ?>"><?php echo bp_core_fetch_avatar( array( 'item_id' => $friend_ids[$i], 'type' => 'thumb' ) ) ?></a>
 					<h5><?php echo bp_core_get_userlink($friend_ids[$i]) ?></h5>
 				</li>
 
@@ -153,7 +153,7 @@ function bp_friends_random_members( $total_members = 5 ) {
 		<?php for ( $i = 0, $count = count( $user_ids['users'] ); $i < $count; ++$i ) { ?>
 
 			<li>
-				<a href="<?php echo bp_core_get_user_domain( $user_ids['users'][$i]->id ) ?>"><?php echo bp_core_fetch_avatar( array( 'item_id' => $user_ids['users'][$i]->id, 'type' => 'thumb' ) ) ?></a>
+				<a href="<?php echo bp_members_get_user_url( $user_ids['users'][$i]->id ) ?>"><?php echo bp_core_fetch_avatar( array( 'item_id' => $user_ids['users'][$i]->id, 'type' => 'thumb' ) ) ?></a>
 				<h5><?php echo bp_core_get_userlink( $user_ids['users'][$i]->id ) ?></h5>
 
 				<?php if ( bp_is_active( 'xprofile' ) ) { ?>

--- a/src/bp-groups/bp-groups-admin.php
+++ b/src/bp-groups/bp-groups-admin.php
@@ -1033,7 +1033,7 @@ function bp_groups_admin_edit_metabox_members( $item ) {
 						<th scope="row" class="uid-column"><?php echo esc_html( $type_user->ID ); ?></th>
 
 						<td class="uname-column">
-							<a style="float: left;" href="<?php echo bp_core_get_user_domain( $type_user->ID ); ?>"><?php echo bp_core_fetch_avatar( array(
+							<a style="float: left;" href="<?php echo bp_members_get_user_url( $type_user->ID ); ?>"><?php echo bp_core_fetch_avatar( array(
 								'item_id' => $type_user->ID,
 								'width'   => '32',
 								'height'  => '32'

--- a/src/bp-groups/bp-groups-notifications.php
+++ b/src/bp-groups/bp-groups-notifications.php
@@ -168,7 +168,7 @@ function groups_notification_new_membership_request( $requesting_user_id = 0, $a
 			'group.name'           => $group->name,
 			'group.id'             => $group_id,
 			'group-requests.url'   => esc_url( bp_get_group_permalink( $group ) . 'admin/membership-requests' ),
-			'profile.url'          => esc_url( bp_core_get_user_domain( $requesting_user_id ) ),
+			'profile.url'          => esc_url( bp_members_get_user_url( $requesting_user_id ) ),
 			'requesting-user.id'   => $requesting_user_id,
 			'requesting-user.name' => bp_core_get_user_displayname( $requesting_user_id ),
 			'request.message'      => $request_message,
@@ -336,7 +336,12 @@ function groups_notification_group_invites( &$group, &$member, $inviter_user_id 
 		return;
 	}
 
-	$invited_link = bp_core_get_user_domain( $invited_user_id ) . bp_get_groups_slug();
+	$invited_link = bp_members_get_user_url(
+		$invited_user_id,
+		array(
+			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_groups', bp_get_groups_slug() ),
+		)
+	);
 
 	$unsubscribe_args = array(
 		'user_id'           => $invited_user_id,
@@ -359,7 +364,7 @@ function groups_notification_group_invites( &$group, &$member, $inviter_user_id 
 			'group.url'      => bp_get_group_permalink( $group ),
 			'group.name'     => $group->name,
 			'inviter.name'   => bp_core_get_userlink( $inviter_user_id, true, false ),
-			'inviter.url'    => bp_core_get_user_domain( $inviter_user_id ),
+			'inviter.url'    => bp_members_get_user_url( $inviter_user_id ),
 			'inviter.id'     => $inviter_user_id,
 			'invites.url'    => esc_url( $invited_link . '/invites/' ),
 			'invite.message' => $invite_message,
@@ -1251,7 +1256,14 @@ function groups_email_notification_membership_request_completed_by_admin( $user_
 			'group.id'        => $group_id,
 			'group.name'      => $group->name,
 			'group.url'       => esc_url( bp_get_group_permalink( $group ) ),
-			'leave-group.url' => esc_url( bp_core_get_user_domain( $user_id ) . bp_get_groups_slug() ),
+			'leave-group.url' => esc_url(
+				bp_members_get_user_url(
+					$user_id,
+					array(
+						'single_item_component' => bp_rewrites_get_slug( 'members', 'member_groups', bp_get_groups_slug() ),
+					)
+				)
+			),
 		),
 	);
 

--- a/src/bp-groups/bp-groups-template.php
+++ b/src/bp-groups/bp-groups-template.php
@@ -1638,7 +1638,7 @@ function bp_group_creator_permalink( $group = false ) {
 		 * @param string          $permalink Permalink of the group creator.
 		 * @param BP_Groups_Group $group     The group object.
 		 */
-		return apply_filters( 'bp_get_group_creator_permalink', bp_core_get_user_domain( $group->creator_id ), $group );
+		return apply_filters( 'bp_get_group_creator_permalink', bp_members_get_user_url( $group->creator_id ), $group );
 	}
 
 /**
@@ -1796,7 +1796,7 @@ function bp_group_list_admins( $group = false ) {
 			<?php foreach ( (array) $group->admins as $admin ) { ?>
 				<li>
 					<a
-						href="<?php echo esc_url( bp_core_get_user_domain( $admin->user_id, $admin->user_nicename, $admin->user_login ) ); ?>"
+						href="<?php echo esc_url( bp_members_get_user_url( $admin->user_id ) ); ?>"
 						class="bp-tooltip"
 						data-bp-tooltip="<?php printf( ( '%s' ), bp_core_get_user_displayname( $admin->user_id ) ); ?>"
 					>
@@ -1843,7 +1843,7 @@ function bp_group_list_mods( $group = false ) {
 			<?php foreach ( (array) $group->mods as $mod ) { ?>
 				<li>
 					<a
-						href="<?php echo esc_url( bp_core_get_user_domain( $mod->user_id, $mod->user_nicename, $mod->user_login ) ); ?>"
+						href="<?php echo esc_url( bp_members_get_user_url( $mod->user_id ) ); ?>"
 						class="bp-tooltip"
 						data-bp-tooltip="<?php printf( ( '%s' ), bp_core_get_user_displayname( $mod->user_id ) ); ?>">
 						<?php
@@ -4272,7 +4272,7 @@ function bp_group_member_url() {
 		 *
 		 * @param string $value URL for the current user.
 		 */
-		return apply_filters( 'bp_get_group_member_url', bp_core_get_user_domain( $members_template->member->user_id, $members_template->member->user_nicename, $members_template->member->user_login ) );
+		return apply_filters( 'bp_get_group_member_url', bp_members_get_user_url( $members_template->member->user_id ) );
 	}
 
 /**
@@ -4296,7 +4296,7 @@ function bp_group_member_link() {
 		 *
 		 * @param string $value HTML link for the current user.
 		 */
-		return apply_filters( 'bp_get_group_member_link', '<a href="' . bp_core_get_user_domain( $members_template->member->user_id, $members_template->member->user_nicename, $members_template->member->user_login ) . '">' . $members_template->member->display_name . '</a>' );
+		return apply_filters( 'bp_get_group_member_link', '<a href="' . bp_members_get_user_url( $members_template->member->user_id ) . '">' . $members_template->member->display_name . '</a>' );
 	}
 
 /**
@@ -4320,7 +4320,7 @@ function bp_group_member_domain() {
 		 *
 		 * @param string $value Domain for the current user.
 		 */
-		return apply_filters( 'bp_get_group_member_domain', bp_core_get_user_domain( $members_template->member->user_id, $members_template->member->user_nicename, $members_template->member->user_login ) );
+		return apply_filters( 'bp_get_group_member_domain', bp_members_get_user_url( $members_template->member->user_id ) );
 	}
 
 /**

--- a/src/bp-groups/classes/class-bp-groups-invite-template.php
+++ b/src/bp-groups/classes/class-bp-groups-invite-template.php
@@ -292,7 +292,7 @@ class BP_Groups_Invite_Template {
 		);
 
 		$this->invite->user->email     = $this->invite->user->user_email;
-		$this->invite->user->user_url  = bp_core_get_user_domain( $user_id, $this->invite->user->user_nicename, $this->invite->user->user_login );
+		$this->invite->user->user_url  = bp_members_get_user_url( $user_id );
 		$this->invite->user->user_link = "<a href='{$this->invite->user->user_url}'>{$this->invite->user->fullname}</a>";
 
 		/* translators: %s: last activity timestamp (e.g. "Active 1 hour ago") */

--- a/src/bp-members/actions/random.php
+++ b/src/bp-members/actions/random.php
@@ -17,6 +17,6 @@ function bp_core_get_random_member() {
 		return;
 
 	$user = bp_core_get_users( array( 'type' => 'random', 'per_page' => 1 ) );
-	bp_core_redirect( bp_core_get_user_domain( $user['users'][0]->id ) );
+	bp_core_redirect( bp_members_get_user_url( $user['users'][0]->id ) );
 }
 add_action( 'bp_actions', 'bp_core_get_random_member' );

--- a/src/bp-members/bp-members-blocks.php
+++ b/src/bp-members/bp-members-blocks.php
@@ -57,7 +57,7 @@ function bp_members_render_member_block( $attributes = array() ) {
 
 	// Member name variables.
 	$display_name = bp_core_get_user_displayname( $member_id );
-	$member_link  = bp_core_get_user_domain( $member_id );
+	$member_link  = bp_members_get_user_url( $member_id );
 
 	// Member action button.
 	$action_button         = '';
@@ -229,7 +229,7 @@ function bp_members_render_members_block( $attributes = array() ) {
 		$output .= sprintf( '<div class="%s">', $member_item_classes );
 
 		// Get Member link.
-		$member_link = bp_core_get_user_domain( $member->ID );
+		$member_link = bp_members_get_user_url( $member->ID );
 
 		// Set the Avatar output.
 		if ( $bp->avatar && $bp->avatar->show_avatars && 'none' !== $block_args['avatarSize'] ) {
@@ -482,7 +482,7 @@ function bp_members_render_dynamic_members_block( $attributes = array() ) {
 					'assets/widgets/dynamic-members.php',
 					'php',
 					array(
-						'data.link'              => bp_core_get_user_domain( $user->ID, $user->user_nicename, $user->user_login ),
+						'data.link'              => bp_members_get_user_url( $user->ID ),
 						'data.name'              => $user->display_name,
 						'data.avatar_urls.thumb' => bp_core_fetch_avatar(
 							array(
@@ -632,7 +632,7 @@ function bp_members_render_members_avatars_block( $block_args = array() ) {
 						<img loading="lazy" src="%3$s" class="avatar user-%4$s-avatar avatar-50 photo" width="50" height="50" alt="%5$s">
 					</a>
 				</div>',
-				esc_url( bp_core_get_user_domain( $member->ID, $member->user_nicename, $member->user_login ) ),
+				esc_url( bp_members_get_user_url( $member->ID ) ),
 				esc_html( $member->display_name ),
 				bp_core_fetch_avatar(
 					array(

--- a/src/bp-members/bp-members-blocks.php
+++ b/src/bp-members/bp-members-blocks.php
@@ -43,7 +43,7 @@ function bp_members_render_member_block( $attributes = array() ) {
 	$container_classes = array( 'bp-block-member' );
 
 	// Mention variables.
-	$username   = bp_core_get_username( $member_id );
+	$username   = bp_members_get_user_slug( $member_id );
 	$at_mention = '';
 
 	// Avatar variables.

--- a/src/bp-members/bp-members-filters.php
+++ b/src/bp-members/bp-members-filters.php
@@ -108,7 +108,13 @@ function bp_members_edit_profile_url( $url, $user_id, $scheme = 'admin' ) {
 
 	// If xprofile is active, use profile domain link.
 	if ( ! is_admin() && bp_is_active( 'xprofile' ) ) {
-		$profile_link = trailingslashit( bp_core_get_user_domain( $user_id ) . bp_get_profile_slug() . '/edit' );
+		$profile_link = bp_members_get_user_url(
+			$user_id,
+			array(
+				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_profile', bp_get_profile_slug() ),
+				'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_profile_edit', 'edit' ),
+			)
+		);
 
 	} else {
 		// Default to $url.

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -139,44 +139,6 @@ function bp_core_get_users( $args = '' ) {
 }
 
 /**
- * Return the domain for the passed user: e.g. http://example.com/members/andy/.
- *
- * @since 1.0.0
- * @deprecated 12.0.0
- *
- * @param int         $user_id       The ID of the user.
- * @param string|bool $user_nicename Optional. user_nicename of the user.
- * @param string|bool $user_login    Optional. user_login of the user.
- * @return string
- */
-function bp_core_get_user_domain( $user_id = 0, $user_nicename = false, $user_login = false ) {
-	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_members_get_user_url()' );
-
-	if ( empty( $user_id ) ) {
-		return;
-	}
-
-	$domain = bp_members_get_user_url( $user_id );
-
-	// Don't use this filter.  Subject to removal in a future release.
-	// Use the 'bp_core_get_user_domain' filter instead.
-	$domain = apply_filters_deprecated( 'bp_core_get_user_domain_pre_cache', array( $domain, $user_id, $user_nicename, $user_login), '12.0.0' );
-
-	/**
-	 * Filters the domain for the passed user.
-	 *
-	 * @since 1.0.1
-	 * @deprecated 12.0.0
-	 *
-	 * @param string $domain        Domain for the passed user.
-	 * @param int    $user_id       ID of the passed user.
-	 * @param string $user_nicename User nicename of the passed user.
-	 * @param string $user_login    User login of the passed user.
-	 */
-	return apply_filters_deprecated( 'bp_core_get_user_domain', array( $domain, $user_id, $user_nicename, $user_login), '12.0.0', 'bp_members_get_user_url' );
-}
-
-/**
  * Return the Mmbers single item's URL.
  *
  * @since 12.0.0
@@ -458,7 +420,7 @@ function bp_core_get_userlink( $user_id, $no_anchor = false, $just_link = false 
 		return $display_name;
 	}
 
-	if ( !$url = bp_core_get_user_domain( $user_id ) ) {
+	if ( !$url = bp_members_get_user_url( $user_id ) ) {
 		return false;
 	}
 
@@ -3393,7 +3355,7 @@ function bp_send_welcome_email( $user_id = 0 ) {
 		return;
 	}
 
-	$profile_url = bp_core_get_user_domain( $user_id );
+	$profile_url = bp_members_get_user_url( $user_id );
 
 	/**
 	 * Use this filter to add/edit/remove tokens to use for your welcome email.

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -142,6 +142,7 @@ function bp_core_get_users( $args = '' ) {
  * Return the domain for the passed user: e.g. http://example.com/members/andy/.
  *
  * @since 1.0.0
+ * @deprecated 12.0.0
  *
  * @param int         $user_id       The ID of the user.
  * @param string|bool $user_nicename Optional. user_nicename of the user.
@@ -149,35 +150,98 @@ function bp_core_get_users( $args = '' ) {
  * @return string
  */
 function bp_core_get_user_domain( $user_id = 0, $user_nicename = false, $user_login = false ) {
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_members_get_user_url()' );
 
 	if ( empty( $user_id ) ) {
 		return;
 	}
 
-	$username = bp_core_get_username( $user_id, $user_nicename, $user_login );
-
-	if ( bp_is_username_compatibility_mode() ) {
-		$username = rawurlencode( $username );
-	}
-
-	$after_domain = bp_core_enable_root_profiles() ? $username : bp_get_members_root_slug() . '/' . $username;
-	$domain       = trailingslashit( bp_get_root_domain() . '/' . $after_domain );
+	$domain = bp_members_get_user_url( $user_id );
 
 	// Don't use this filter.  Subject to removal in a future release.
 	// Use the 'bp_core_get_user_domain' filter instead.
-	$domain = apply_filters( 'bp_core_get_user_domain_pre_cache', $domain, $user_id, $user_nicename, $user_login );
+	$domain = apply_filters_deprecated( 'bp_core_get_user_domain_pre_cache', array( $domain, $user_id, $user_nicename, $user_login), '12.0.0' );
 
 	/**
 	 * Filters the domain for the passed user.
 	 *
 	 * @since 1.0.1
+	 * @deprecated 12.0.0
 	 *
 	 * @param string $domain        Domain for the passed user.
 	 * @param int    $user_id       ID of the passed user.
 	 * @param string $user_nicename User nicename of the passed user.
 	 * @param string $user_login    User login of the passed user.
 	 */
-	return apply_filters( 'bp_core_get_user_domain', $domain, $user_id, $user_nicename, $user_login );
+	return apply_filters_deprecated( 'bp_core_get_user_domain', array( $domain, $user_id, $user_nicename, $user_login), '12.0.0', 'bp_members_get_user_url' );
+}
+
+/**
+ * Return the Mmbers single item's URL.
+ *
+ * @since 12.0.0
+ *
+ * @param integer $user_id  The user ID.
+ * @param array   $action {
+ *     An array of arguments. Optional.
+ *
+ *     @type string $single_item_component        The component slug the action is relative to.
+ *     @type string $single_item_action           The slug of the action to perform.
+ *     @type array  $single_item_action_variables An array of additional informations about the action to perform.
+ * }
+ * @return string The URL built for the BP Rewrites URL parser.
+ */
+function bp_members_get_user_url( $user_id = 0, $path_chunks = array() ) {
+	$url  = '';
+	$slug = bp_members_get_user_slug( $user_id );
+
+	if ( $slug ) {
+		if ( bp_is_username_compatibility_mode() ) {
+			$slug = rawurlencode( $slug );
+		}
+
+		$supported_chunks = array_fill_keys( array( 'single_item_component', 'single_item_action', 'single_item_action_variables' ), true );
+		$path_chunks      = bp_parse_args(
+			array_intersect_key( $path_chunks, $supported_chunks ),
+			array(
+				'component_id' => 'members',
+				'single_item'  => $slug,
+			)
+		);
+
+		$url = bp_rewrites_get_url( $path_chunks );
+	}
+
+	/**
+	 * Filters the domain for the passed user.
+	 *
+	 * @since 1.0.1
+	 * @deprecated 12.0.0
+	 *
+	 * @param string $domain        Domain for the passed user.
+	 * @param int    $user_id       ID of the passed user.
+	 * @param string $user_nicename User nicename of the passed user.
+	 * @param string $user_login    User login of the passed user.
+	 */
+	$url = apply_filters_deprecated( 'bp_core_get_user_domain', array( $url, $user_id, false, false ), '12.0.0', 'bp_members_get_user_url' );
+
+	/**
+	 * Filters the domain for the passed user.
+	 *
+	 * @since 12.0.0
+	 *
+	 * @param string  $url      The user url.
+	 * @param integer $user_id  The user ID.
+	 * @param string  $slug     The user slug.
+	 * @param array   $path_chunks {
+	 *     An array of arguments. Optional.
+	 *
+	 *     @type string $single_item_component        The component slug the action is relative to.
+	 *     @type string $single_item_action           The slug of the action to perform.
+	 *     @type array  $single_item_action_variables An array of additional informations about the action to perform.
+	 * }
+	 */
+	return apply_filters( 'bp_members_get_user_url', $url, $user_id, $slug, $path_chunks );
 }
 
 /**
@@ -273,39 +337,53 @@ function bp_core_get_userid_from_nicename( $user_nicename = '' ) {
 }
 
 /**
- * Return the username for a user based on their user id.
+ * Returns the members single item (member) slug.
  *
- * This function is sensitive to the BP_ENABLE_USERNAME_COMPATIBILITY_MODE,
- * so it will return the user_login or user_nicename as appropriate.
+ * @since 12.0.0
  *
- * @since 1.0.0
- *
- * @param int         $user_id       User ID to check.
- * @param string|bool $user_nicename Optional. user_nicename of user being checked.
- * @param string|bool $user_login    Optional. user_login of user being checked.
- * @return string The username of the matched user or an empty string if no user is found.
+ * @param integer $user_id The User ID.
+ * @return string The member slug.
  */
-function bp_core_get_username( $user_id = 0, $user_nicename = false, $user_login = false ) {
+function bp_members_get_user_slug( $user_id = 0 ) {
+	$bp  = buddypress();
+	$lug = '';
 
-	if ( ! $user_nicename && ! $user_login ) {
-		// Pull an audible and maybe use the login over the nicename.
-		if ( bp_is_username_compatibility_mode() ) {
-			$username = get_the_author_meta( 'login', $user_id );
-		} else {
-			$username = get_the_author_meta( 'nicename', $user_id );
-		}
+	$prop = 'user_nicename';
+	if ( bp_is_username_compatibility_mode() ) {
+		$prop = 'user_login';
+	}
+
+	if ( (int) bp_loggedin_user_id() === (int) $user_id ) {
+		$slug = isset( $bp->loggedin_user->userdata->{$prop} ) ? $bp->loggedin_user->userdata->{$prop} : null;
+	} elseif ( (int) bp_displayed_user_id() === (int) $user_id ) {
+		$slug = isset( $bp->displayed_user->userdata->{$prop} ) ? $bp->displayed_user->userdata->{$prop} : null;
 	} else {
-		$username = bp_is_username_compatibility_mode() ? $user_login : $user_nicename;
+		$user = get_user_by( 'id', $user_id );
+
+		if ( $user instanceof WP_User ) {
+			$slug = $user->{$prop};
+		}
 	}
 
 	/**
 	 * Filters the username based on originally provided user ID.
 	 *
 	 * @since 1.0.1
+	 * @deprecated 12.0.0
 	 *
-	 * @param string $username Username determined by user ID.
+	 * @param string $slug Username determined by user ID.
 	 */
-	return apply_filters( 'bp_core_get_username', $username );
+	$slug = apply_filters_deprecated( 'bp_core_get_username', array( $slug ), '12.0.0', 'bp_members_get_user_slug', );
+
+	/**
+	 * Filter here to edit the user's slug.
+	 *
+	 * @since 12.0.0
+	 *
+	 * @param string $slug     The user's slug.
+	 * @param integer $user_id The user ID.
+	 */
+	return apply_filters( 'bp_members_get_user_slug', $slug, $user_id );
 }
 
 /**

--- a/src/bp-members/bp-members-notifications.php
+++ b/src/bp-members/bp-members-notifications.php
@@ -47,7 +47,7 @@ function members_format_notifications( $action, $item_id, $secondary_item_id, $t
 					$text = sprintf( __( '%d members are now members of the site', 'buddypress' ), (int) $total_items );
 				}
 			} else {
-				$link   = add_query_arg( 'welcome', 1, bp_core_get_user_domain( $item_id ) );
+				$link   = add_query_arg( 'welcome', 1, bp_members_get_user_url( $item_id ) );
 				$amount = 'single';
 
 				// This is the inviter whose invitation was accepted.

--- a/src/bp-members/bp-members-template.php
+++ b/src/bp-members/bp-members-template.php
@@ -2049,7 +2049,7 @@ function bp_displayed_user_username() {
 		$bp = buddypress();
 
 		if ( bp_displayed_user_id() ) {
-			$username = bp_core_get_username( bp_displayed_user_id(), $bp->displayed_user->userdata->user_nicename, $bp->displayed_user->userdata->user_login );
+			$username = bp_members_get_user_slug( bp_displayed_user_id() );
 		} else {
 			$username = '';
 		}
@@ -2083,7 +2083,7 @@ function bp_loggedin_user_username() {
 		$bp = buddypress();
 
 		if ( bp_loggedin_user_id() ) {
-			$username = bp_core_get_username( bp_loggedin_user_id(), $bp->loggedin_user->userdata->user_nicename, $bp->loggedin_user->userdata->user_login );
+			$username = bp_members_get_user_slug( bp_loggedin_user_id() );
 		} else {
 			$username = '';
 		}

--- a/src/bp-members/bp-members-template.php
+++ b/src/bp-members/bp-members-template.php
@@ -901,11 +901,7 @@ function bp_member_permalink() {
 	function bp_get_member_permalink() {
 		global $members_template;
 
-		$permalink = bp_core_get_user_domain(
-			$members_template->member->id,
-			$members_template->member->user_nicename,
-			$members_template->member->user_login
-		);
+		$permalink = bp_members_get_user_url( $members_template->member->id );
 
 		/**
 		 * Filters the permalink for the current member in the loop.
@@ -3571,7 +3567,7 @@ function bp_members_invitations_list_invites_permalink( $user_id = 0 ) {
 			$user_id = bp_loggedin_user_id();
 			$domain  = bp_loggedin_user_domain();
 		} else {
-			$domain = bp_core_get_user_domain( (int) $user_id );
+			$domain = bp_members_get_user_url( (int) $user_id );
 		}
 
 		$retval = trailingslashit( $domain . bp_get_members_invitations_slug() . '/list-invites' );
@@ -3610,7 +3606,7 @@ function bp_members_invitations_send_invites_permalink( $user_id = 0 ) {
 			$user_id = bp_loggedin_user_id();
 			$domain  = bp_loggedin_user_domain();
 		} else {
-			$domain = bp_core_get_user_domain( (int) $user_id );
+			$domain = bp_members_get_user_url( (int) $user_id );
 		}
 
 		$retval = trailingslashit( $domain . bp_get_members_invitations_slug() . '/send-invites' );

--- a/src/bp-members/classes/class-bp-members-admin.php
+++ b/src/bp-members/classes/class-bp-members-admin.php
@@ -1333,7 +1333,7 @@ class BP_Members_Admin {
 			<div id="major-publishing-actions">
 
 				<div id="publishing-action">
-					<a class="button bp-view-profile" href="<?php echo esc_url( bp_core_get_user_domain( $user->ID ) ); ?>" target="_blank"><?php esc_html_e( 'View Profile', 'buddypress' ); ?></a>
+					<a class="button bp-view-profile" href="<?php echo esc_url( bp_members_get_user_url( $user->ID ) ); ?>" target="_blank"><?php esc_html_e( 'View Profile', 'buddypress' ); ?></a>
 					<?php submit_button( esc_html__( 'Update Profile', 'buddypress' ), 'primary', 'save', false ); ?>
 				</div>
 				<div class="clear"></div>

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -228,7 +228,7 @@ class BP_Members_Component extends BP_Component {
 		$bp->loggedin_user->is_super_admin = $bp->loggedin_user->is_site_admin = is_super_admin( bp_loggedin_user_id() );
 
 		// The domain for the user currently logged in. eg: http://example.com/members/andy.
-		$bp->loggedin_user->domain = bp_core_get_user_domain( bp_loggedin_user_id() );
+		$bp->loggedin_user->domain = bp_members_get_user_url( bp_loggedin_user_id() );
 
 		/** Displayed user ***************************************************
 		 */
@@ -240,7 +240,7 @@ class BP_Members_Component extends BP_Component {
 		$bp->displayed_user->fullname = isset( $bp->displayed_user->userdata->display_name ) ? $bp->displayed_user->userdata->display_name : '';
 
 		// The domain for the user currently being displayed.
-		$bp->displayed_user->domain = bp_core_get_user_domain( bp_displayed_user_id() );
+		$bp->displayed_user->domain = bp_members_get_user_url( bp_displayed_user_id() );
 
 		// If A user is displayed, check if there is a front template
 		if ( bp_get_displayed_user() ) {

--- a/src/bp-members/classes/class-bp-members-invitation-manager.php
+++ b/src/bp-members/classes/class-bp-members-invitation-manager.php
@@ -73,7 +73,7 @@ class BP_Members_Invitation_Manager extends BP_Invitation_Manager {
 			$args = array(
 				'tokens' => array(
 					'inviter.name'      => bp_core_get_userlink( $invitation->inviter_id, true, false ),
-					'inviter.url'       => bp_core_get_user_domain( $invitation->inviter_id ),
+					'inviter.url'       => bp_members_get_user_url( $invitation->inviter_id ),
 					'inviter.id'        => $invitation->inviter_id,
 					'invite.accept_url' => esc_url( $invite_url ),
 					'usermessage'       => wp_kses( $invitation->content, array() ),

--- a/src/bp-members/classes/class-bp-members-invitations-list-table.php
+++ b/src/bp-members/classes/class-bp-members-invitations-list-table.php
@@ -425,7 +425,7 @@ class BP_Members_Invitations_List_Table extends WP_Users_List_Table {
 			return;
 		}
 
-		$user_link = bp_core_get_user_domain( $invite->inviter_id );
+		$user_link = bp_members_get_user_url( $invite->inviter_id );
 
 		printf( '%1$s <strong><a href="%2$s" class="edit">%3$s</a></strong><br/>', $avatar, esc_url( $user_link ), esc_html( $inviter->user_login ) );
 	}

--- a/src/bp-messages/bp-messages-functions.php
+++ b/src/bp-messages/bp-messages-functions.php
@@ -626,7 +626,16 @@ function messages_notification_new_message( $raw_args = array() ) {
 		bp_send_email( 'messages-unread', $ud, array(
 			'tokens' => array(
 				'usermessage' => wp_strip_all_tags( stripslashes( $message ) ),
-				'message.url' => esc_url( bp_core_get_user_domain( $recipient->user_id ) . bp_get_messages_slug() . '/view/' . $thread_id . '/' ),
+				'message.url' => esc_url(
+					bp_members_get_user_url(
+						$recipient->user_id,
+						array(
+							'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_messages', bp_get_messages_slug() ),
+							'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_messages_view', 'view' ),
+							'single_item_action_variables' => array( $thread_id ),
+						)
+					)
+				),
 				'sender.name' => $sender_name,
 				'usersubject' => sanitize_text_field( stripslashes( $subject ) ),
 				'unsubscribe' => esc_url( bp_email_get_unsubscribe_link( $unsubscribe_args ) ),

--- a/src/bp-messages/bp-messages-star.php
+++ b/src/bp-messages/bp-messages-star.php
@@ -128,7 +128,7 @@ function bp_the_message_star_action_link( $args = array() ) {
 
 			// Empty or other.
 			default :
-				$user_domain = bp_core_get_user_domain( $r['user_id'] );
+				$user_domain = bp_members_get_user_url( $r['user_id'] );
 				break;
 		}
 

--- a/src/bp-messages/bp-messages-template.php
+++ b/src/bp-messages/bp-messages-template.php
@@ -1483,7 +1483,7 @@ function bp_send_private_message_link() {
 		 *
 		 * @param string $value URL for the Private Message link in member profile headers.
 		 */
-		return apply_filters( 'bp_get_send_private_message_link', wp_nonce_url( bp_loggedin_user_domain() . bp_get_messages_slug() . '/compose/?r=' . bp_core_get_username( bp_displayed_user_id() ) ) );
+		return apply_filters( 'bp_get_send_private_message_link', wp_nonce_url( bp_loggedin_user_domain() . bp_get_messages_slug() . '/compose/?r=' . bp_members_get_user_slug( bp_displayed_user_id() ) ) );
 	}
 
 /**

--- a/src/bp-messages/bp-messages-template.php
+++ b/src/bp-messages/bp-messages-template.php
@@ -337,7 +337,7 @@ function bp_message_thread_view_link( $thread_id = 0, $user_id = null ) {
 			$user_id = bp_loggedin_user_id();
 		}
 
-		$domain = bp_core_get_user_domain( $user_id );
+		$domain = bp_members_get_user_url( $user_id );
 
 		/**
 		 * Filters the permalink of a particular thread.
@@ -382,7 +382,7 @@ function bp_message_thread_delete_link( $user_id = null ) {
 			$user_id = bp_loggedin_user_id();
 		}
 
-		$domain = bp_core_get_user_domain( $user_id );
+		$domain = bp_members_get_user_url( $user_id );
 
 		/**
 		 * Filters the URL for deleting the current thread.
@@ -434,7 +434,7 @@ function bp_the_message_thread_mark_unread_url( $user_id = null ) {
 			$user_id = bp_loggedin_user_id();
 		}
 
-		$domain = bp_core_get_user_domain( $user_id );
+		$domain = bp_members_get_user_url( $user_id );
 
 		// Base unread URL.
 		$url = trailingslashit( $domain . bp_get_messages_slug() . '/' . bp_current_action() . '/unread' );
@@ -496,7 +496,7 @@ function bp_the_message_thread_mark_read_url( $user_id = null ) {
 			$user_id = bp_loggedin_user_id();
 		}
 
-		$domain = bp_core_get_user_domain( $user_id );
+		$domain = bp_members_get_user_url( $user_id );
 
 		// Base read URL.
 		$url = trailingslashit( $domain . bp_get_messages_slug() . '/' . bp_current_action() . '/read' );

--- a/src/bp-notifications/bp-notifications-template.php
+++ b/src/bp-notifications/bp-notifications-template.php
@@ -62,7 +62,7 @@ function bp_notifications_permalink( $user_id = 0 ) {
 			$user_id = bp_loggedin_user_id();
 			$domain  = bp_loggedin_user_domain();
 		} else {
-			$domain = bp_core_get_user_domain( (int) $user_id );
+			$domain = bp_members_get_user_url( (int) $user_id );
 		}
 
 		$retval = trailingslashit( $domain . bp_get_notifications_slug() );
@@ -103,7 +103,7 @@ function bp_notifications_unread_permalink( $user_id = 0 ) {
 			$user_id = bp_loggedin_user_id();
 			$domain  = bp_loggedin_user_domain();
 		} else {
-			$domain = bp_core_get_user_domain( (int) $user_id );
+			$domain = bp_members_get_user_url( (int) $user_id );
 		}
 
 		$retval = trailingslashit( $domain . bp_get_notifications_slug() . '/unread' );
@@ -143,7 +143,7 @@ function bp_notifications_read_permalink( $user_id = 0 ) {
 			$user_id = bp_loggedin_user_id();
 			$domain  = bp_loggedin_user_domain();
 		} else {
-			$domain = bp_core_get_user_domain( (int) $user_id );
+			$domain = bp_members_get_user_url( (int) $user_id );
 		}
 
 		$retval = trailingslashit( $domain . bp_get_notifications_slug() . '/read' );

--- a/src/bp-templates/bp-nouveau/includes/activity/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/ajax.php
@@ -267,7 +267,7 @@ function bp_nouveau_ajax_delete_activity() {
 
 	// If on a single activity redirect to user's home.
 	if ( ! empty( $_POST['is_single'] ) ) {
-		$response['redirect'] = bp_core_get_user_domain( $activity->user_id );
+		$response['redirect'] = bp_members_get_user_url( $activity->user_id );
 		bp_core_add_message( __( 'Activity deleted successfully', 'buddypress' ) );
 	}
 
@@ -665,7 +665,7 @@ function bp_nouveau_ajax_spam_activity() {
 
 	// If on a single activity redirect to user's home.
 	if ( ! empty( $_POST['is_single'] ) ) {
-		$response['redirect'] = bp_core_get_user_domain( $activity->user_id );
+		$response['redirect'] = bp_members_get_user_url( $activity->user_id );
 		bp_core_add_message( __( 'This activity has been marked as spam and is no longer visible.', 'buddypress' ) );
 	}
 

--- a/src/bp-templates/bp-nouveau/includes/groups/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/functions.php
@@ -253,7 +253,7 @@ function bp_nouveau_prepare_group_potential_invites_for_js( $user ) {
 					)
 				),
 				'user_link' => bp_core_get_userlink( $inviter_id, false, true ),
-				'user_name' => bp_core_get_username( $inviter_id ),
+				'user_name' => bp_members_get_user_slug( $inviter_id ),
 			);
 		}
 

--- a/src/bp-templates/bp-nouveau/includes/messages/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/messages/ajax.php
@@ -367,7 +367,7 @@ function bp_nouveau_ajax_get_user_message_threads() {
 						'html'    => false,
 					) ) ),
 					'user_link' => bp_core_get_userlink( $recipient->user_id, false, true ),
-					'user_name' => bp_core_get_username( $recipient->user_id ),
+					'user_name' => bp_members_get_user_slug( $recipient->user_id ),
 				);
 			}
 		}
@@ -517,7 +517,7 @@ function bp_nouveau_ajax_get_thread_messages() {
 						'html'    => false,
 					) ) ),
 					'user_link' => bp_core_get_userlink( $recipient->user_id, false, true ),
-					'user_name' => bp_core_get_username( $recipient->user_id ),
+					'user_name' => bp_members_get_user_slug( $recipient->user_id ),
 				);
 			}
 		}

--- a/src/bp-templates/bp-nouveau/includes/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/template-tags.php
@@ -2267,7 +2267,7 @@ function bp_nouveau_get_customizer_link( $args = array() ) {
 
 	} elseif ( ! empty( $r['object'] ) && ! empty( $r['item_id'] ) ) {
 		if ( 'user' === $r['object'] ) {
-			$url = rawurlencode( bp_core_get_user_domain( $r['item_id'] ) );
+			$url = rawurlencode( bp_members_get_user_url( $r['item_id'] ) );
 
 		} elseif ( 'group' === $r['object'] ) {
 			$group = groups_get_group( array( 'group_id' => $r['item_id'] ) );

--- a/src/bp-xprofile/bp-xprofile-activity.php
+++ b/src/bp-xprofile/bp-xprofile-activity.php
@@ -49,12 +49,18 @@ add_action( 'bp_register_activity_actions', 'xprofile_register_activity_actions'
  * @return string
  */
 function bp_xprofile_format_activity_action_updated_profile( $action, $activity ) {
-
-	// Note for translators: The natural phrasing in English, "Joe updated
-	// his profile", requires that we know Joe's gender, which we don't. If
-	// your language doesn't have this restriction, feel free to use a more
-	// natural translation.
-	$profile_link = trailingslashit( bp_core_get_user_domain( $activity->user_id ) . bp_get_profile_slug() );
+	/*
+	 * Note for translators: The natural phrasing in English, "Joe updated
+	 * his profile", requires that we know Joe's gender, which we don't. If
+	 * your language doesn't have this restriction, feel free to use a more
+	 * natural translation.
+	 */
+	$profile_link = bp_members_get_user_url(
+		$activity->user_id,
+		array(
+			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_profile', bp_get_profile_slug() ),
+		)
+	);
 
 	/* translators: %s: user profile link */
 	$action = sprintf( esc_html__( "%s's profile was updated", 'buddypress' ), '<a href="' . esc_url( $profile_link ) . '">' . bp_core_get_user_displayname( $activity->user_id ) . '</a>' );
@@ -246,7 +252,12 @@ function bp_xprofile_updated_profile_activity( $user_id, $field_ids = array(), $
 	}
 
 	// If we've reached this point, assemble and post the activity item.
-	$profile_link = trailingslashit( bp_core_get_user_domain( $user_id ) . bp_get_profile_slug() );
+	$profile_link = bp_members_get_user_url(
+		$user_id,
+		array(
+			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_profile', bp_get_profile_slug() ),
+		)
+	);
 
 	return (bool) xprofile_record_activity( array(
 		'user_id'      => $user_id,

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -209,7 +209,7 @@ class BP_UnitTestCase extends WP_UnitTestCase {
 		$bp->loggedin_user->id = $user_id;
 		$bp->loggedin_user->fullname       = bp_core_get_user_displayname( $user_id );
 		$bp->loggedin_user->is_super_admin = $bp->loggedin_user->is_site_admin = is_super_admin( $user_id );
-		$bp->loggedin_user->domain         = bp_core_get_user_domain( $user_id );
+		$bp->loggedin_user->domain         = bp_members_get_user_url( $user_id );
 		$bp->loggedin_user->userdata       = bp_core_get_core_userdata( $user_id );
 
 		wp_set_current_user( $user_id );

--- a/tests/phpunit/testcases/activity/filters.php
+++ b/tests/phpunit/testcases/activity/filters.php
@@ -20,9 +20,9 @@ class BP_Tests_Activity_Filters extends BP_UnitTestCase {
 		) );
 
 		$u1_mention_name = bp_activity_get_user_mentionname( $u1 );
-		$u1_domain = bp_core_get_user_domain( $u1 );
+		$u1_domain = bp_members_get_user_url( $u1 );
 		$u2_mention_name = bp_activity_get_user_mentionname( $u2 );
-		$u2_domain = bp_core_get_user_domain( $u2 );
+		$u2_domain = bp_members_get_user_url( $u2 );
 
 		// mentions normal text should be replaced
 		$at_name_in_text = sprintf( 'Hello @%s', $u1_mention_name );

--- a/tests/phpunit/testcases/activity/notifications.php
+++ b/tests/phpunit/testcases/activity/notifications.php
@@ -6,6 +6,7 @@
  */
 #[AllowDynamicProperties]
 class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
+	protected $permalink_structure = '';
 	protected $current_user;
 	protected $u1;
 	protected $u2;
@@ -14,6 +15,7 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 
 	public function set_up() {
 		parent::set_up();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
 		$this->current_user = get_current_user_id();
 		$this->u1 = self::factory()->user->create();
 		$this->u2 = self::factory()->user->create();
@@ -30,6 +32,8 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 
 	public function tear_down() {
 		$this->set_current_user( $this->current_user );
+		$this->set_permalink_structure( $this->permalink_structure );
+
 		parent::tear_down();
 
 		// Restore the filter
@@ -42,6 +46,7 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 	 */
 	public function test_bp_activity_remove_screen_notifications_on_single_activity_permalink() {
 		$this->create_notifications();
+		$this->set_permalink_structure( '/%postname%/' );
 
 		$notifications = BP_Notifications_Notification::get( array(
 			'user_id' => $this->u1,
@@ -51,7 +56,15 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 		$this->assertEquals( array( $this->a1 ), wp_list_pluck( $notifications, 'item_id' ) );
 
 		// Go to the activity permalink page
-		$this->go_to( bp_core_get_user_domain( $this->u1 ) . 'activity/' . $this->a1 );
+		$this->go_to(
+			bp_members_get_user_url(
+				$this->u1,
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_activity', bp_get_activity_slug() ),
+					'single_item_action'    => $this->a1,
+				)
+			)
+		);
 
 		$notifications = BP_Notifications_Notification::get( array(
 			'user_id' => $this->u1,
@@ -67,6 +80,7 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 	 */
 	public function test_bp_activity_remove_screen_notifications_on_single_activity_permalink_logged_out() {
 		$this->create_notifications();
+		$this->set_permalink_structure( '/%postname%/' );
 
 		$notifications = BP_Notifications_Notification::get( array(
 			'user_id' => $this->u1,
@@ -79,7 +93,15 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 		$this->set_current_user( 0 );
 
 		// Go to the activity permalink page
-		$this->go_to( bp_core_get_user_domain( $this->u1 ) . 'activity/' . $this->a1 );
+		$this->go_to(
+			bp_members_get_user_url(
+				$this->u1,
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_activity', bp_get_activity_slug() ),
+					'single_item_action'    => $this->a1,
+				)
+			)
+		);
 
 		$notifications = BP_Notifications_Notification::get( array(
 			'user_id' => $this->u1,
@@ -97,6 +119,7 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 	 */
 	public function test_bp_activity_remove_screen_notifications_on_single_activity_permalink_wrong_user() {
 		$this->create_notifications();
+		$this->set_permalink_structure( '/%postname%/' );
 
 		$notifications = BP_Notifications_Notification::get( array(
 			'user_id' => $this->u1,
@@ -109,7 +132,15 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 		$this->set_current_user( $this->u2 );
 
 		// Go to the activity permalink page
-		$this->go_to( bp_core_get_user_domain( $this->u1 ) . 'activity/' . $this->a1 );
+		$this->go_to(
+			bp_members_get_user_url(
+				$this->u1,
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_activity', bp_get_activity_slug() ),
+					'single_item_action'    => $this->a1,
+				)
+			)
+		);
 
 		$notifications = BP_Notifications_Notification::get( array(
 			'user_id' => $this->u1,
@@ -127,6 +158,7 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 	 */
 	public function test_bp_activity_remove_screen_notifications_on_mentions() {
 		$this->create_notifications();
+		$this->set_permalink_structure( '/%postname%/' );
 
 		$notifications = BP_Notifications_Notification::get( array(
 			'user_id' => $this->u1,
@@ -136,7 +168,15 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 		$this->assertEquals( array( $this->a1 ), wp_list_pluck( $notifications, 'item_id' ) );
 
 		// Go to the My Activity page
-		$this->go_to( bp_core_get_user_domain( $this->u1 ) . bp_get_activity_slug() . '/mentions/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				$this->u1,
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_activity', bp_get_activity_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_activity_mentions', 'mentions' ),
+				)
+			)
+		);
 
 		$notifications = BP_Notifications_Notification::get( array(
 			'user_id' => $this->u1,
@@ -152,6 +192,7 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 	 */
 	public function test_bp_activity_remove_screen_notifications_on_mentions_logged_out() {
 		$this->create_notifications();
+		$this->set_permalink_structure( '/%postname%/' );
 
 		$notifications = BP_Notifications_Notification::get( array(
 			'user_id' => $this->u1,
@@ -164,7 +205,15 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 		$this->set_current_user( 0 );
 
 		// Go to the My Activity page
-		$this->go_to( bp_core_get_user_domain( $this->u1 ) . bp_get_activity_slug() . '/mentions/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				$this->u1,
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_activity', bp_get_activity_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_activity_mentions', 'mentions' ),
+				)
+			)
+		);
 
 		$notifications = BP_Notifications_Notification::get( array(
 			'user_id' => $this->u1,
@@ -183,6 +232,7 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 	 */
 	public function test_bp_activity_remove_screen_notifications_on_mentions_wrong_user() {
 		$this->create_notifications();
+		$this->set_permalink_structure( '/%postname%/' );
 
 		$notifications = BP_Notifications_Notification::get( array(
 			'user_id' => $this->u1,
@@ -195,7 +245,15 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 		$this->set_current_user( $this->u2 );
 
 		// Go to the My Activity page
-		$this->go_to( bp_core_get_user_domain( $this->u1 ) . bp_get_activity_slug() . '/mentions/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				$this->u1,
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_activity', bp_get_activity_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_activity_mentions', 'mentions' ),
+				)
+			)
+		);
 
 		$notifications = BP_Notifications_Notification::get( array(
 			'user_id' => $this->u1,
@@ -214,6 +272,7 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 	 */
 	public function test_bp_activity_at_mention_delete_notification() {
 		$this->create_notifications();
+		$this->set_permalink_structure( '/%postname%/' );
 
 		$notifications = BP_Notifications_Notification::get( array(
 			'item_id' => $this->a1,

--- a/tests/phpunit/testcases/core/class-bp-button.php
+++ b/tests/phpunit/testcases/core/class-bp-button.php
@@ -5,14 +5,28 @@
  * @group BP_Button
  */
 class BP_Tests_BP_Button extends BP_UnitTestCase {
+	protected $permalink_structure = '';
+
+	public function set_up() {
+		parent::set_up();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
+	}
+
+	public function tear_down() {
+		$this->set_permalink_structure( $this->permalink_structure );
+
+		parent::tear_down();
+	}
+
 	/**
 	 * @group block_self
 	 */
 	public function test_block_self_own_profile() {
 		$u = self::factory()->user->create();
 		$this->set_current_user( $u );
+		$this->set_permalink_structure( '/%postname%/' );
 
-		$this->go_to( bp_core_get_user_domain( $u ) );
+		$this->go_to( bp_members_get_user_url( $u ) );
 
 		$b = new BP_Button( array(
 			'id' => 'foo',
@@ -29,9 +43,10 @@ class BP_Tests_BP_Button extends BP_UnitTestCase {
 	public function test_block_self_others_profile() {
 		$u1 = self::factory()->user->create();
 		$this->set_current_user( $u1 );
+		$this->set_permalink_structure( '/%postname%/' );
 
 		$u2 = self::factory()->user->create();
-		$this->go_to( bp_core_get_user_domain( $u2 ) );
+		$this->go_to( bp_members_get_user_url( $u2 ) );
 
 		$b = new BP_Button( array(
 			'id' => 'foo',
@@ -135,7 +150,8 @@ class BP_Tests_BP_Button extends BP_UnitTestCase {
 		) );
 
 		$this->set_current_user( $u1 );
-		$this->go_to( bp_core_get_user_domain( $u1 ) );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to( bp_members_get_user_url( $u1 ) );
 
 		$found = array();
 		if ( bp_has_members() ) {

--- a/tests/phpunit/testcases/core/nav/bpCoreMaybeHookNewSubnavScreenFunction.php
+++ b/tests/phpunit/testcases/core/nav/bpCoreMaybeHookNewSubnavScreenFunction.php
@@ -4,6 +4,18 @@
  * @group nav
  */
 class BP_Tests_Core_Nav_BpCoreMaybeHookNewSubnavScreenFunction extends BP_UnitTestCase {
+	protected $permalink_structure = '';
+
+	public function set_up() {
+		parent::set_up();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
+	}
+
+	public function tear_down() {
+		$this->set_permalink_structure( $this->permalink_structure );
+
+		parent::tear_down();
+	}
 
 	public function test_user_has_access_true_no_callable_function() {
 		$subnav_item = array(
@@ -56,8 +68,9 @@ class BP_Tests_Core_Nav_BpCoreMaybeHookNewSubnavScreenFunction extends BP_UnitTe
 		$u = self::factory()->user->create();
 		$old_current_user = get_current_user_id();
 		$this->set_current_user( $u );
+		$this->set_permalink_structure( '/%postname%/' );
 
-		$this->go_to( bp_core_get_user_domain( $u ) );
+		$this->go_to( bp_members_get_user_url( $u ) );
 
 		$subnav_item = array(
 			'user_has_access' => false,
@@ -66,7 +79,7 @@ class BP_Tests_Core_Nav_BpCoreMaybeHookNewSubnavScreenFunction extends BP_UnitTe
 		// Just test relevant info
 		$found = bp_core_maybe_hook_new_subnav_screen_function( $subnav_item );
 		$this->assertSame( 'failure', $found['status'] );
-		$this->assertSame( bp_core_get_user_domain( $u ), $found['redirect_args']['root'] );
+		$this->assertSame( bp_members_get_user_url( $u ), $found['redirect_args']['root'] );
 
 		$this->set_current_user( $old_current_user );
 	}
@@ -76,8 +89,9 @@ class BP_Tests_Core_Nav_BpCoreMaybeHookNewSubnavScreenFunction extends BP_UnitTe
 		$u2 = self::factory()->user->create();
 		$old_current_user = get_current_user_id();
 		$this->set_current_user( $u1 );
+		$this->set_permalink_structure( '/%postname%/' );
 
-		$this->go_to( bp_core_get_user_domain( $u2 ) );
+		$this->go_to( bp_members_get_user_url( $u2 ) );
 
 		$old_bp_nav = buddypress()->bp_nav;
 		$old_default_component = buddypress()->default_component;
@@ -103,7 +117,7 @@ class BP_Tests_Core_Nav_BpCoreMaybeHookNewSubnavScreenFunction extends BP_UnitTe
 		buddypress()->bp_nav = $old_bp_nav;
 
 		$this->assertSame( 'failure', $found['status'] );
-		$this->assertSame( bp_core_get_user_domain( $u2 ), $found['redirect_args']['root'] );
+		$this->assertSame( bp_members_get_user_url( $u2 ), $found['redirect_args']['root'] );
 	}
 
 	public function test_user_has_access_false_user_logged_in_others_profile_default_component_not_accessible() {
@@ -111,8 +125,9 @@ class BP_Tests_Core_Nav_BpCoreMaybeHookNewSubnavScreenFunction extends BP_UnitTe
 		$u2 = self::factory()->user->create();
 		$old_current_user = get_current_user_id();
 		$this->set_current_user( $u1 );
+		$this->set_permalink_structure( '/%postname%/' );
 
-		$this->go_to( bp_core_get_user_domain( $u2 ) );
+		$this->go_to( bp_members_get_user_url( $u2 ) );
 
 		$old_bp_nav = buddypress()->bp_nav;
 		$old_default_component = buddypress()->default_component;
@@ -139,7 +154,15 @@ class BP_Tests_Core_Nav_BpCoreMaybeHookNewSubnavScreenFunction extends BP_UnitTe
 		buddypress()->bp_nav = $old_bp_nav;
 
 		$this->assertSame( 'failure', $found['status'] );
-		$this->assertSame( bp_core_get_user_domain( $u2 ) . bp_get_activity_slug() . '/', $found['redirect_args']['root'] );
+		$this->assertSame(
+			bp_members_get_user_url(
+				$u2,
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_activity', bp_get_activity_slug() ),
+				)
+			),
+			$found['redirect_args']['root']
+		);
 	}
 
 	public function test_user_has_access_false_user_logged_in_group() {

--- a/tests/phpunit/testcases/core/nav/bpCoreNewNavItem.php
+++ b/tests/phpunit/testcases/core/nav/bpCoreNewNavItem.php
@@ -4,6 +4,18 @@
  * @group nav
  */
 class BP_Tests_Core_Nav_BpCoreNewNavItem extends BP_UnitTestCase {
+	protected $permalink_structure = '';
+
+	public function set_up() {
+		parent::set_up();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
+	}
+
+	public function tear_down() {
+		$this->set_permalink_structure( $this->permalink_structure );
+
+		parent::tear_down();
+	}
 
 	/**
 	 * @expectedIncorrectUsage bp_nav
@@ -14,8 +26,9 @@ class BP_Tests_Core_Nav_BpCoreNewNavItem extends BP_UnitTestCase {
 		$u = self::factory()->user->create();
 		$old_current_user = get_current_user_id();
 		$this->set_current_user( $u );
+		$this->set_permalink_structure( '/%postname%/' );
 
-		$this->go_to( bp_core_get_user_domain( $u ) );
+		$this->go_to( bp_members_get_user_url( $u ) );
 
 		bp_core_new_nav_item( array(
 			'name'                    => 'Foo',
@@ -28,7 +41,12 @@ class BP_Tests_Core_Nav_BpCoreNewNavItem extends BP_UnitTestCase {
 		$expected = array(
 			'name'                    => 'Foo',
 			'slug'                    => 'foo',
-			'link'                    => trailingslashit( bp_core_get_user_domain( $u ) . 'foo' ),
+			'link'                    => bp_members_get_user_url(
+				$u,
+				array(
+					'single_item_component' => 'foo',
+				)
+			),
 			'css_id'                  => 'foo',
 			'show_for_displayed_user' => true,
 			'position'                => 25,
@@ -146,8 +164,9 @@ class BP_Tests_Core_Nav_BpCoreNewNavItem extends BP_UnitTestCase {
 		$u2 = self::factory()->user->create();
 		$old_current_user = get_current_user_id();
 		$this->set_current_user( $u2 );
+		$this->set_permalink_structure( '/%postname%/' );
 
-		$this->go_to( bp_core_get_user_domain( $u ) );
+		$this->go_to( bp_members_get_user_url( $u ) );
 
 		$expected = array(
 			'name'                    => 'Settings',
@@ -181,8 +200,9 @@ class BP_Tests_Core_Nav_BpCoreNewNavItem extends BP_UnitTestCase {
 		$u2 = self::factory()->user->create();
 		$old_current_user = get_current_user_id();
 		$this->set_current_user( $u2 );
+		$this->set_permalink_structure( '/%postname%/' );
 
-		$this->go_to( bp_core_get_user_domain( $u ) );
+		$this->go_to( bp_members_get_user_url( $u ) );
 
 		bp_core_new_nav_item( array(
 			'name'                    => 'Woof',

--- a/tests/phpunit/testcases/core/nav/bpCoreNewSubnavItem.php
+++ b/tests/phpunit/testcases/core/nav/bpCoreNewSubnavItem.php
@@ -15,7 +15,7 @@ class BP_Tests_Core_Nav_BpCoreNewSubnavItem extends BP_UnitTestCase {
 		$old_current_user = get_current_user_id();
 		$this->set_current_user( $u );
 
-		$user_domain = bp_core_get_user_domain( $u );
+		$user_domain = bp_members_get_user_url( $u );
 
 		$this->go_to( $user_domain );
 
@@ -344,7 +344,7 @@ class BP_Tests_Core_Nav_BpCoreNewSubnavItem extends BP_UnitTestCase {
 		$old_current_user = get_current_user_id();
 		$this->set_current_user( $u );
 
-		$user_domain = bp_core_get_user_domain( $u );
+		$user_domain = bp_members_get_user_url( $u );
 
 		// Register a subnav on 'bp_setup_nav' hook early (at priority zero).
 		add_action( 'bp_setup_nav', function() use ( $user_domain ) {

--- a/tests/phpunit/testcases/core/nav/bpGetNavMenuItems.php
+++ b/tests/phpunit/testcases/core/nav/bpGetNavMenuItems.php
@@ -5,6 +5,19 @@
  * @group nav
  */
 class BP_Tests_Core_Nav_BpGetNavMenuItems extends BP_UnitTestCase {
+	protected $permalink_structure = '';
+
+	public function set_up() {
+		parent::set_up();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
+	}
+
+	public function tear_down() {
+		$this->set_permalink_structure( $this->permalink_structure );
+
+		parent::tear_down();
+	}
+
 	/**
 	 * @ticket BP7110
 	 */
@@ -12,7 +25,9 @@ class BP_Tests_Core_Nav_BpGetNavMenuItems extends BP_UnitTestCase {
 		$users = self::factory()->user->create_many( 2 );
 
 		$this->set_current_user( $users[0] );
-		$user_1_domain = bp_core_get_user_domain( $users[1] );
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$user_1_domain = bp_members_get_user_url( $users[1] );
 		$this->go_to( $user_1_domain );
 
 		$found = bp_get_nav_menu_items();
@@ -36,7 +51,9 @@ class BP_Tests_Core_Nav_BpGetNavMenuItems extends BP_UnitTestCase {
 		$user = self::factory()->user->create();
 
 		$this->set_current_user( 0 );
-		$user_domain = bp_core_get_user_domain( $user );
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$user_domain = bp_members_get_user_url( $user );
 		$this->go_to( $user_domain );
 
 		$found = bp_get_nav_menu_items();

--- a/tests/phpunit/testcases/core/template/bpUserHasAccess.php
+++ b/tests/phpunit/testcases/core/template/bpUserHasAccess.php
@@ -4,13 +4,27 @@
  * @group template
  */
 class BP_Tests_Core_Template_BpUserHasAccess extends BP_UnitTestCase {
+	protected $permalink_structure = '';
+
+	public function set_up() {
+		parent::set_up();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
+	}
+
+	public function tear_down() {
+		$this->set_permalink_structure( $this->permalink_structure );
+
+		parent::tear_down();
+	}
+
 	public function test_should_return_true_for_bp_moderate_user() {
 		$users = self::factory()->user->create_many( 2 );
 
 		$this->grant_bp_moderate( $users[0] );
 		$this->set_current_user( $users[0] );
+		$this->set_permalink_structure( '/%postname%/' );
 
-		$this->go_to( bp_core_get_user_domain( $users[1] ) );
+		$this->go_to( bp_members_get_user_url( $users[1] ) );
 
 		$this->assertTrue( bp_user_has_access( $users[0] ) );
 	}
@@ -19,8 +33,9 @@ class BP_Tests_Core_Template_BpUserHasAccess extends BP_UnitTestCase {
 		$users = self::factory()->user->create_many( 2 );
 
 		$this->set_current_user( $users[0] );
+		$this->set_permalink_structure( '/%postname%/' );
 
-		$this->go_to( bp_core_get_user_domain( $users[1] ) );
+		$this->go_to( bp_members_get_user_url( $users[1] ) );
 
 		$this->assertFalse( bp_user_has_access( $users[0] ) );
 	}
@@ -29,8 +44,9 @@ class BP_Tests_Core_Template_BpUserHasAccess extends BP_UnitTestCase {
 		$users = self::factory()->user->create_many( 2 );
 
 		$this->set_current_user( $users[0] );
+		$this->set_permalink_structure( '/%postname%/' );
 
-		$this->go_to( bp_core_get_user_domain( $users[0] ) );
+		$this->go_to( bp_members_get_user_url( $users[0] ) );
 
 		$this->assertTrue( bp_user_has_access( $users[0] ) );
 	}

--- a/tests/phpunit/testcases/members/functions.php
+++ b/tests/phpunit/testcases/members/functions.php
@@ -4,6 +4,18 @@
  */
 #[AllowDynamicProperties]
 class BP_Tests_Members_Functions extends BP_UnitTestCase {
+	protected $permalink_structure = '';
+
+	public function set_up() {
+		parent::set_up();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
+	}
+
+	public function tear_down() {
+		$this->set_permalink_structure( $this->permalink_structure );
+
+		parent::tear_down();
+	}
 
 	/**
 	 * @ticket BP4915
@@ -113,12 +125,13 @@ class BP_Tests_Members_Functions extends BP_UnitTestCase {
 	 * @group object_cache
 	 * @group bp_core_get_directory_pages
 	 */
-	public function test_bp_core_get_user_domain_after_directory_page_update() {
+	public function test_bp_members_get_user_url_after_directory_page_update() {
 		// Generate user
 		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->set_permalink_structure( '/%postname%/' );
 
 		// Set object cache first for user domain
-		$user_domain = bp_core_get_user_domain( $user_id );
+		$user_domain = bp_members_get_user_url( $user_id );
 
 		// Now change the members directory slug
 		$pages = bp_core_get_directory_pages();
@@ -136,7 +149,7 @@ class BP_Tests_Members_Functions extends BP_UnitTestCase {
 		$this->go_to( trailingslashit( home_url( $new_members_slug ) ) );
 		$user = new WP_User( $user_id );
 
-		$this->assertSame( home_url( $new_members_slug ) . '/' . $user->user_nicename . '/', bp_core_get_user_domain( $user_id ) );
+		$this->assertSame( home_url( $new_members_slug ) . '/' . $user->user_nicename . '/', bp_members_get_user_url( $user_id ) );
 	}
 
 	/**

--- a/tests/phpunit/testcases/members/template.php
+++ b/tests/phpunit/testcases/members/template.php
@@ -3,11 +3,25 @@
  * @group members
  */
 class BP_Tests_Members_Template extends BP_UnitTestCase {
+	protected $permalink_structure = '';
+
+	public function set_up() {
+		parent::set_up();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
+	}
+
+	public function tear_down() {
+		$this->set_permalink_structure( $this->permalink_structure );
+
+		parent::tear_down();
+	}
+
 	public function test_bp_has_members_include_on_user_page() {
 		$u1 = self::factory()->user->create();
 		$u2 = self::factory()->user->create();
+		$this->set_permalink_structure( '/%postname%/' );
 
-		$this->go_to( bp_core_get_user_domain( $u1 ) );
+		$this->go_to( bp_members_get_user_url( $u1 ) );
 
 		global $members_template;
 		bp_has_members( array(
@@ -58,8 +72,17 @@ class BP_Tests_Members_Template extends BP_UnitTestCase {
 
 		$old_user = get_current_user_id();
 		$this->set_current_user( $u2 );
+		$this->set_permalink_structure( '/%postname%/' );
 
-		$this->go_to( bp_core_get_user_domain( $u2 ) . bp_get_friends_slug() . '/requests/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				$u2,
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_friends', bp_get_friends_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_friends_requests', 'requests' ),
+				)
+			)
+		);
 		$this->restore_admins();
 
 		global $members_template;
@@ -85,6 +108,7 @@ class BP_Tests_Members_Template extends BP_UnitTestCase {
 
 		$old_user = get_current_user_id();
 		$this->set_current_user( $u2 );
+		$this->set_permalink_structure( '/%postname%/' );
 
 		// For some reason, in all the user switching, the cache gets
 		// confused. Never comes up when BP runs normally, because the
@@ -92,7 +116,15 @@ class BP_Tests_Members_Template extends BP_UnitTestCase {
 		// real in BP
 		wp_cache_delete( 'bp_user_domain_' . $u2, 'bp' );
 
-		$this->go_to( bp_core_get_user_domain( $u2 ) . bp_get_friends_slug() . '/requests/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				$u2,
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_friends', bp_get_friends_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_friends_requests', 'requests' ),
+				)
+			)
+		);
 		$this->restore_admins();
 
 		global $members_template;

--- a/tests/phpunit/testcases/routing/activity.php
+++ b/tests/phpunit/testcases/routing/activity.php
@@ -5,20 +5,24 @@
  */
 class BP_Tests_Routing_Activity extends BP_UnitTestCase {
 	protected $old_current_user = 0;
+	protected $permalink_structure = '';
 
 	public function set_up() {
 		parent::set_up();
 
 		$this->old_current_user = get_current_user_id();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
 		$this->set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
 	}
 
 	public function tear_down() {
 		parent::tear_down();
 		$this->set_current_user( $this->old_current_user );
+		$this->set_permalink_structure( $this->permalink_structure );
 	}
 
 	function test_activity_directory() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$this->go_to( bp_get_activity_directory_permalink() );
 
 		$pages        = bp_core_get_directory_pages();
@@ -31,26 +35,59 @@ class BP_Tests_Routing_Activity extends BP_UnitTestCase {
 	 * Can't test using bp_activity_get_permalink(); see bp_activity_action_permalink_router().
 	 */
 	function test_activity_permalink() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$a = self::factory()->activity->create();
 		$activity = self::factory()->activity->get_object_by_id( $a );
 
-		$url = bp_core_get_user_domain( $activity->user_id ) . bp_get_activity_slug() . '/' . $activity->id . '/';
+		$url = bp_members_get_user_url(
+			$activity->user_id,
+			array(
+				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_activity', bp_get_activity_slug() ),
+				'single_item_action'    => $activity->id,
+			)
+		);
 		$this->go_to( $url );
 		$this->assertTrue( bp_is_single_activity() );
 	}
 
 	function test_member_activity() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_activity_slug() );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_activity', bp_get_activity_slug() ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_user_activity() );
 	}
 
 	function test_member_activity_mentions() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_activity_slug() . '/mentions'  );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_activity', bp_get_activity_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_activity_mentions', 'mentions' ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_user_activity() );
 	}
 
 	function test_member_activity_favourites() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_activity_slug() . '/favorites'  );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_activity', bp_get_activity_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_activity_favorites', 'favorites' ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_user_activity() );
 	}
 
@@ -58,7 +95,16 @@ class BP_Tests_Routing_Activity extends BP_UnitTestCase {
 	 * @group friends
 	 */
 	function test_member_activity_friends() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_activity_slug() . '/' . bp_get_friends_slug() );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_activity', bp_get_activity_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_activity_friends', bp_get_friends_slug() ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_user_friends_activity() );
 	}
 
@@ -66,7 +112,16 @@ class BP_Tests_Routing_Activity extends BP_UnitTestCase {
 	 * @group groups
 	 */
 	function test_member_activity_groups() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_activity_slug() . '/' . bp_get_groups_slug() );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_activity', bp_get_activity_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_activity_groups', bp_get_groups_slug() ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_user_groups_activity() );
 	}
 }

--- a/tests/phpunit/testcases/routing/friends.php
+++ b/tests/phpunit/testcases/routing/friends.php
@@ -5,26 +5,46 @@
  */
 class BP_Tests_Routing_Friends extends BP_UnitTestCase {
 	protected $old_current_user = 0;
+	protected $permalink_structure = '';
 
 	public function set_up() {
 		parent::set_up();
 
 		$this->old_current_user = get_current_user_id();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
 		$this->set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
 	}
 
 	public function tear_down() {
 		parent::tear_down();
 		$this->set_current_user( $this->old_current_user );
+		$this->set_permalink_structure( $this->permalink_structure );
 	}
 
 	function test_member_friends() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_friends_slug() );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_friends', bp_get_friends_slug() ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_user_friends() );
 	}
 
 	function test_member_friends_requests() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_friends_slug()  . '/requests' );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_friends', bp_get_friends_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_friends_requests', 'requests' ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_user_friend_requests() );
 	}
 }

--- a/tests/phpunit/testcases/routing/groups.php
+++ b/tests/phpunit/testcases/routing/groups.php
@@ -5,27 +5,47 @@
  */
 class BP_Tests_Routing_Groups extends BP_UnitTestCase {
 	protected $old_current_user = 0;
+	protected $permalink_structure = '';
 
 	public function set_up() {
 		parent::set_up();
 
 		buddypress()->members->types = array();
 		$this->old_current_user = get_current_user_id();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
 		$this->set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
 	}
 
 	public function tear_down() {
 		parent::tear_down();
 		$this->set_current_user( $this->old_current_user );
+		$this->set_permalink_structure( $this->permalink_structure );
 	}
 
 	function test_member_groups() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_groups_slug() );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_groups', bp_get_groups_slug() ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_user_groups() );
 	}
 
 	function test_member_groups_invitations() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_groups_slug() . '/invites' );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_groups', bp_get_groups_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_friends_invites', 'invites' ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_user_groups() && bp_is_current_action( 'invites' ) );
 	}
 
@@ -33,6 +53,7 @@ class BP_Tests_Routing_Groups extends BP_UnitTestCase {
 	 * @group group_types
 	 */
 	public function test_group_directory_with_type() {
+		$this->set_permalink_structure( '/%postname%/' );
 		bp_groups_register_group_type( 'foo' );
 		$this->go_to( bp_get_groups_directory_permalink() . 'type/foo/' );
 		$this->assertTrue( bp_is_groups_component() && ! bp_is_group() && bp_is_current_action( bp_get_groups_group_type_base() ) && bp_is_action_variable( 'foo', 0 ) );
@@ -42,6 +63,7 @@ class BP_Tests_Routing_Groups extends BP_UnitTestCase {
 	 * @group group_types
 	 */
 	public function test_group_directory_with_type_that_has_custom_directory_slug() {
+		$this->set_permalink_structure( '/%postname%/' );
 		bp_groups_register_group_type( 'foo', array( 'has_directory' => 'foos' ) );
 		$this->go_to( bp_get_groups_directory_permalink() . 'type/foos/' );
 		$this->assertTrue( bp_is_groups_component() && ! bp_is_group() && bp_is_current_action( bp_get_groups_group_type_base() ) && bp_is_action_variable( 'foos', 0 ) );
@@ -51,6 +73,7 @@ class BP_Tests_Routing_Groups extends BP_UnitTestCase {
 	 * @group group_types
 	 */
 	public function test_group_directory_should_404_for_group_types_that_have_no_directory() {
+		$this->set_permalink_structure( '/%postname%/' );
 		bp_register_member_type( 'foo', array( 'has_directory' => false ) );
 		$this->go_to( bp_get_members_directory_permalink() . 'type/foo/' );
 		$this->assertTrue( is_404() );
@@ -60,6 +83,7 @@ class BP_Tests_Routing_Groups extends BP_UnitTestCase {
 	 * @group group_types
 	 */
 	public function test_group_directory_should_404_for_invalid_group_types() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$this->go_to( bp_get_members_directory_permalink() . 'type/foo/' );
 		$this->assertTrue( is_404() );
 	}
@@ -68,6 +92,7 @@ class BP_Tests_Routing_Groups extends BP_UnitTestCase {
 	 * @group group_previous_slug
 	 */
 	public function test_group_previous_slug_current_slug_should_resolve() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g1 = self::factory()->group->create( array(
 			'slug' => 'george',
 		) );
@@ -85,6 +110,7 @@ class BP_Tests_Routing_Groups extends BP_UnitTestCase {
 	 * @group group_previous_slug
 	 */
 	public function test_group_previous_slug_should_resolve() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g1 = self::factory()->group->create( array(
 			'slug' => 'george',
 		) );
@@ -103,6 +129,7 @@ class BP_Tests_Routing_Groups extends BP_UnitTestCase {
 	 * @group group_previous_slug
 	 */
 	public function test_group_previous_slug_most_recent_takes_precedence() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g1 = self::factory()->group->create( array(
 			'slug' => 'george',
 		) );

--- a/tests/phpunit/testcases/routing/members.php
+++ b/tests/phpunit/testcases/routing/members.php
@@ -5,21 +5,25 @@
  */
 class BP_Tests_Routing_Members extends BP_UnitTestCase {
 	protected $old_current_user = 0;
+	protected $permalink_structure = '';
 
 	public function set_up() {
 		parent::set_up();
 
 		buddypress()->members->types = array();
 		$this->old_current_user = get_current_user_id();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
 		$this->set_current_user( self::factory()->user->create( array( 'user_login' => 'paulgibbs', 'role' => 'subscriber' ) ) );
 	}
 
 	public function tear_down() {
 		$this->set_current_user( $this->old_current_user );
+		$this->set_permalink_structure( $this->permalink_structure );
 		parent::tear_down();
 	}
 
 	function test_members_directory() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$this->go_to( bp_get_members_directory_permalink() );
 
 		$pages        = bp_core_get_directory_pages();
@@ -29,7 +33,8 @@ class BP_Tests_Routing_Members extends BP_UnitTestCase {
 	}
 
 	function test_member_permalink() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to( bp_members_get_user_url( bp_loggedin_user_id() ) );
 		$this->assertTrue( bp_is_my_profile() );
 	}
 
@@ -38,6 +43,7 @@ class BP_Tests_Routing_Members extends BP_UnitTestCase {
 	 * @group member_types
 	 */
 	public function test_member_directory_with_member_type() {
+		$this->set_permalink_structure( '/%postname%/' );
 		bp_register_member_type( 'foo' );
 		$this->go_to( bp_get_members_directory_permalink() . 'type/foo/' );
 		$this->assertTrue( bp_is_members_component() );
@@ -48,6 +54,7 @@ class BP_Tests_Routing_Members extends BP_UnitTestCase {
 	 * @group member_types
 	 */
 	public function test_member_directory_with_member_type_should_obey_filtered_type_slug() {
+		$this->set_permalink_structure( '/%postname%/' );
 		bp_register_member_type( 'foo' );
 
 		add_filter( 'bp_members_member_type_base', array( $this, 'filter_member_type_base' ) );
@@ -65,6 +72,7 @@ class BP_Tests_Routing_Members extends BP_UnitTestCase {
 	 * @group member_types
 	 */
 	public function test_member_directory_with_member_type_that_has_custom_directory_slug() {
+		$this->set_permalink_structure( '/%postname%/' );
 		bp_register_member_type( 'foo', array( 'has_directory' => 'foos' ) );
 		$this->go_to( bp_get_members_directory_permalink() . 'type/foos/' );
 		$this->assertTrue( bp_is_members_component() );
@@ -75,6 +83,7 @@ class BP_Tests_Routing_Members extends BP_UnitTestCase {
 	 * @group member_types
 	 */
 	public function test_member_directory_with_member_type_should_be_overridden_by_member_with_same_nicename() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$u = self::factory()->user->create( array( 'user_nicename' => 'foo' ) );
 		bp_register_member_type( 'foo' );
 		$this->go_to( bp_get_members_directory_permalink() . 'type/foo/' );
@@ -90,6 +99,7 @@ class BP_Tests_Routing_Members extends BP_UnitTestCase {
 	 * @group member_types
 	 */
 	public function test_member_directory_should_404_for_member_types_that_have_no_directory() {
+		$this->set_permalink_structure( '/%postname%/' );
 		bp_register_member_type( 'foo', array( 'has_directory' => false ) );
 		$this->go_to( bp_get_members_directory_permalink() . 'type/foo/' );
 		$this->assertTrue( is_404() );
@@ -99,6 +109,7 @@ class BP_Tests_Routing_Members extends BP_UnitTestCase {
 	 * @ticket BP6325
 	 */
 	function test_members_shortlink_redirector() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$shortlink_member_slug = 'me';
 
 		$this->go_to( bp_get_members_directory_permalink() . $shortlink_member_slug );

--- a/tests/phpunit/testcases/routing/messages.php
+++ b/tests/phpunit/testcases/routing/messages.php
@@ -5,36 +5,74 @@
  */
 class BP_Tests_Routing_Messages extends BP_UnitTestCase {
 	protected $old_current_user = 0;
+	protected $permalink_structure = '';
 
 	public function set_up() {
 		parent::set_up();
 
 		$this->old_current_user = get_current_user_id();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
 		$this->set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
 	}
 
 	public function tear_down() {
 		parent::tear_down();
 		$this->set_current_user( $this->old_current_user );
+		$this->set_permalink_structure( $this->permalink_structure );
 	}
 
 	function test_member_messages() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_messages_slug() );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_messages', bp_get_messages_slug() ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_messages_inbox() );
 	}
 
 	function test_member_messages_sentbox() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_messages_slug() . '/sentbox' );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_messages', bp_get_messages_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_messages_sentbox', 'sentbox' ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_messages_sentbox() );
 	}
 
 	function test_member_messages_compose() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_messages_slug() . '/compose' );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_messages', bp_get_messages_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_messages_compose', 'compose' ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_messages_compose_screen() );
 	}
 
 	function test_member_messages_notices() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_messages_slug() . '/notices' );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_messages', bp_get_messages_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_messages_notices', 'notices' ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_notices() );
 	}
 }

--- a/tests/phpunit/testcases/routing/settings.php
+++ b/tests/phpunit/testcases/routing/settings.php
@@ -5,36 +5,74 @@
  */
 class BP_Tests_Routing_Settings extends BP_UnitTestCase {
 	protected $old_current_user = 0;
+	protected $permalink_structure = '';
 
 	public function set_up() {
 		parent::set_up();
 
 		$this->old_current_user = get_current_user_id();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
 		$this->set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
 	}
 
 	public function tear_down() {
 		parent::tear_down();
 		$this->set_current_user( $this->old_current_user );
+		$this->set_permalink_structure( $this->permalink_structure );
 	}
 
 	function test_member_settings() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_settings_slug() );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_settings', bp_get_settings_slug() ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_user_settings_general() );
 	}
 
 	function test_member_settings_notifications() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_settings_slug() . '/notifications' );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_settings', bp_get_settings_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_settings_notifications', 'notifications' ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_user_settings_notifications() );
 	}
 
 	// @todo How best to test this?
 	/*function bp_is_user_settings_account_capbilities() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_settings_slug() . '/capabilities' );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_settings', bp_get_settings_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_settings_capabilities', 'capabilities' ),
+				)
+			)
+		);
 	}*/
 
 	function bp_is_user_settings_account_delete() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_settings_slug() . '/delete-account' );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_settings', bp_get_settings_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_settings_delete_account', 'delete-account' ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_user_settings_account_delete() );
 	}
 }

--- a/tests/phpunit/testcases/routing/xprofile.php
+++ b/tests/phpunit/testcases/routing/xprofile.php
@@ -5,31 +5,60 @@
  */
 class BP_Tests_Routing_XProfile extends BP_UnitTestCase {
 	protected $old_current_user = 0;
+	protected $permalink_structure = '';
 
 	public function set_up() {
 		parent::set_up();
 
 		$this->old_current_user = get_current_user_id();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
 		$this->set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
 	}
 
 	public function tear_down() {
 		parent::tear_down();
 		$this->set_current_user( $this->old_current_user );
+		$this->set_permalink_structure( $this->permalink_structure );
 	}
 
 	function test_member_profile() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_profile_slug() );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_profile', bp_get_profile_slug() ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_user_profile() );
 	}
 
 	function test_member_profile_edit() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_profile_slug() . '/edit' );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_profile', bp_get_profile_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_profile_edit', 'edit' ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_user_profile_edit() );
 	}
 
 	function test_member_profile_change_avatar() {
-		$this->go_to( bp_core_get_user_domain( bp_loggedin_user_id() ) . bp_get_profile_slug() . '/change-avatar' );
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to(
+			bp_members_get_user_url(
+				bp_loggedin_user_id(),
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_profile', bp_get_profile_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_profile_change_avatar', 'change-avatar' ),
+				)
+			)
+		);
 		$this->assertTrue( bp_is_user_change_avatar() );
 	}
 }

--- a/tests/phpunit/testcases/xprofile/activity.php
+++ b/tests/phpunit/testcases/xprofile/activity.php
@@ -306,7 +306,13 @@ class BP_Tests_XProfile_Activity extends BP_UnitTestCase {
 			'user_id' => $u,
 		) );
 
-		$expected = sprintf( esc_html__( "%s's profile was updated", 'buddypress' ), '<a href="' . bp_core_get_user_domain( $u ) . bp_get_profile_slug() . '/">' . bp_core_get_user_displayname( $u ) . '</a>' );
+		$link     = bp_members_get_user_url(
+			$u,
+			array(
+				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_profile', bp_get_profile_slug() ),
+			)
+		);
+		$expected = sprintf( esc_html__( "%s's profile was updated", 'buddypress' ), '<a href="' . esc_url( $link ) . '">' . bp_core_get_user_displayname( $u ) . '</a>' );
 
 		$a_obj = new BP_Activity_Activity( $a );
 


### PR DESCRIPTION
`bp_members_get_user_url()` is a wrapper of `bp_rewrites_get_url()`. It replaces `bp_core_get_user_domain()` to build Member URLs using BP Rewrites.

As many URLs are built concatenating `bp_core_get_user_domain()` with URL chunks, the safer way to make sure Developers update the way they build their BuddyPress links is to deprecate this function.
`bp_core_get_username()` has also been deprecated in favor of `bp_members_get_user_slug()`.

This PR also updates some PHPUnit tests!

Trac ticket: https://buddypress.trac.wordpress.org/ticket/4954

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
