### PR TITLE
Make sure the friends count is right in WP-Admin Extended profile

### DIFF
--- a/src/bp-friends/bp-friends-template.php
+++ b/src/bp-friends/bp-friends-template.php
@@ -778,8 +778,8 @@ function bp_friends_get_profile_stats( $args = '' ) {
 			// If friends exist, show some formatted output.
 			$r['output'] = $r['before'];
 
-			/* translators: %d: total friend count */
-			$r['output'] .= sprintf( _n( '%d friend', '%d friends', $r['friends'], 'buddypress' ), '<strong>' . number_format_i18n( $r['friends'] ) . '</strong>' );
+			/* translators: %s: total friend count */
+			$r['output'] .= sprintf( _n( '%s friend', '%s friends', $r['friends'], 'buddypress' ), '<strong>' . number_format_i18n( $r['friends'] ) . '</strong>' );
 			$r['output'] .= $r['after'];
 		}
 	}


### PR DESCRIPTION
Instead of using the `%d `placeholder, we need to use the `%s` placeholder as the friends count is using the `number_format_i18n()` function.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8848

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
