### PR TITLE
Initialise Sitewide Notices REST API endpoint. Fixes #8849

### DIFF
--- a/src/bp-messages/classes/class-bp-messages-component.php
+++ b/src/bp-messages/classes/class-bp-messages-component.php
@@ -438,7 +438,10 @@ class BP_Messages_Component extends BP_Component {
 	 *                           description.
 	 */
 	public function rest_api_init( $controllers = array() ) {
-		parent::rest_api_init( array( 'BP_REST_Messages_Endpoint' ) );
+		parent::rest_api_init( array(
+			'BP_REST_Messages_Endpoint',
+			'BP_REST_Sitewide_Notices_Endpoint'
+		) );
 	}
 
 	/**

--- a/src/class-buddypress.php
+++ b/src/class-buddypress.php
@@ -770,6 +770,7 @@ class BuddyPress {
 			'BP_Members_Invitations_Template'            => 'members',
 
 			'BP_REST_Messages_Endpoint'                  => 'messages',
+			'BP_REST_Sitewide_Notices_Endpoint'          => 'messages',
 
 			'BP_REST_Notifications_Endpoint'             => 'notifications',
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Adds 'BP_REST_Sitewide_Notices_Endpoint' to the list of REST API controllers to initialise for Messages component.
Adds 'BP_REST_Sitewide_Notices_Endpoint' for 'messages' in autoload irregular_map.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8849#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
