### PR TITLE
5th step of the BP Rewrites merge: make more BuddyPress generated links use BP Rewrites

### DIFF
--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -3262,10 +3262,18 @@ function bp_activity_get_permalink( $activity_id, $activity_obj = false ) {
 	if ( false !== array_search( $activity_obj->type, $use_primary_links ) ) {
 		$link = $activity_obj->primary_link;
 	} else {
-		if ( 'activity_comment' == $activity_obj->type ) {
-			$link = bp_get_root_domain() . '/' . bp_get_activity_root_slug() . '/p/' . $activity_obj->item_id . '/#acomment-' . $activity_obj->id;
+		$path_chunks = array(
+			'component_id'                 => 'activity',
+			'single_item_action'           => 'p',
+			'single_item_action_variables' => array( $activity_obj->id ),
+		);
+
+		if ( 'activity_comment' === $activity_obj->type ) {
+			$path_chunks['single_item_action_variables'] = array( $activity_obj->item_id );
+
+			$link = bp_rewrites_get_url( $path_chunks ) . '#acomment-' . $activity_obj->id;
 		} else {
-			$link = bp_get_root_domain() . '/' . bp_get_activity_root_slug() . '/p/' . $activity_obj->id . '/';
+			$link = bp_rewrites_get_url( $path_chunks );
 		}
 	}
 

--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -86,6 +86,11 @@ function bp_activity_directory_permalink() {
 	 * @return string Activity directory permalink.
 	 */
 	function bp_get_activity_directory_permalink() {
+		$url = bp_rewrites_get_url(
+			array(
+				'component_id' => 'activity',
+			)
+		);
 
 		/**
 		 * Filters the activity directory permalink.
@@ -94,7 +99,7 @@ function bp_activity_directory_permalink() {
 		 *
 		 * @param string $url Permalink url for the activity directory.
 		 */
-		return apply_filters( 'bp_get_activity_directory_permalink', trailingslashit( bp_get_root_domain() . '/' . bp_get_activity_root_slug() ) );
+		return apply_filters( 'bp_get_activity_directory_permalink', $url );
 	}
 
 /**
@@ -2392,7 +2397,14 @@ function bp_activity_comment_delete_link() {
 	 *                      activity comment.
 	 */
 	function bp_get_activity_comment_delete_link() {
-		$link = wp_nonce_url( trailingslashit( bp_get_activity_directory_permalink() . 'delete/' . bp_get_activity_comment_id() ) . '?cid=' . bp_get_activity_comment_id(), 'bp_activity_delete_link' );
+		$url  = bp_rewrites_get_url(
+			array(
+				'component_id'                 => 'activity',
+				'single_item_action'           => 'delete',
+				'single_item_action_variables' => array( bp_get_activity_comment_id() ),
+			)
+		);
+		$link = wp_nonce_url( add_query_arg( 'cid', bp_get_activity_comment_id(), $url ), 'bp_activity_delete_link' );
 
 		/**
 		 * Filters the link used for deleting the activity comment currently being displayed.
@@ -2991,7 +3003,13 @@ function bp_activity_delete_url() {
 			$activity_id = (int) $activities_template->activity->id;
 		}
 
-		$url = trailingslashit( bp_get_root_domain() . '/' . bp_get_activity_root_slug() . '/delete/' . $activity_id );
+		$url = bp_rewrites_get_url(
+			array(
+				'component_id'                 => 'activity',
+				'single_item_action'           => 'delete',
+				'single_item_action_variables' => array( $activity_id ),
+			)
+		);
 
 		// Determine if we're on a single activity page, and customize accordingly.
 		if ( bp_is_activity_component() && is_numeric( bp_current_action() ) ) {
@@ -3869,15 +3887,21 @@ function bp_sitewide_activity_feed_link() {
 	 * @return string The sitewide activity feed link.
 	 */
 	function bp_get_sitewide_activity_feed_link() {
+		$url  = bp_rewrites_get_url(
+			array(
+				'component_id'       => 'activity',
+				'single_item_action' => 'feed',
+			)
+		);
 
 		/**
 		 * Filters the sidewide activity feed link.
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param string $value The feed link for sitewide activity.
+		 * @param string $url The feed link for sitewide activity.
 		 */
-		return apply_filters( 'bp_get_sitewide_activity_feed_link', bp_get_root_domain() . '/' . bp_get_activity_root_slug() . '/feed/' );
+		return apply_filters( 'bp_get_sitewide_activity_feed_link', $url );
 	}
 
 /**

--- a/src/bp-activity/classes/class-bp-activity-oembed-extension.php
+++ b/src/bp-activity/classes/class-bp-activity-oembed-extension.php
@@ -85,7 +85,7 @@ class BP_Activity_oEmbed_Extension extends BP_Core_oEmbed_Extension {
 	 */
 	protected function validate_url_to_item_id( $url ) {
 		if ( bp_core_enable_root_profiles() ) {
-			$domain = bp_get_root_domain();
+			$domain = bp_get_root_url();
 		} else {
 			$domain = bp_get_members_directory_permalink();
 		}
@@ -95,19 +95,27 @@ class BP_Activity_oEmbed_Extension extends BP_Core_oEmbed_Extension {
 			return false;
 		}
 
-		// Check for activity slug.
-		if ( false === strpos( $url, '/' . bp_get_activity_slug() . '/' ) ) {
-			return false;
+		if ( ! bp_has_pretty_urls() ) {
+			$url_query = wp_parse_url( $url, PHP_URL_QUERY );
+
+			if ( $url_query ) {
+				$query_vars = bp_parse_args( $url_query, array() );
+
+				if ( isset( $query_vars['bp_member_action'] ) ) {
+					$activity_id = (int) $query_vars['bp_member_action'];
+				}
+			}
+
+		} elseif ( false !== strpos( $url, '/' . bp_get_activity_slug() . '/' ) ) {
+			// Do more checks.
+			$url = trim( untrailingslashit( $url ) );
+
+			// Grab the activity ID.
+			$activity_id = (int) substr(
+				$url,
+				strrpos( $url, '/' ) + 1
+			);
 		}
-
-		// Do more checks.
-		$url = trim( untrailingslashit( $url ) );
-
-		// Grab the activity ID.
-		$activity_id = (int) substr(
-			$url,
-			strrpos( $url, '/' ) + 1
-		);
 
 		if ( ! empty( $activity_id ) ) {
 			// Check if activity item still exists.

--- a/src/bp-activity/classes/class-bp-akismet.php
+++ b/src/bp-activity/classes/class-bp-akismet.php
@@ -191,12 +191,22 @@ class BP_Akismet {
 	 * @since 1.6.0
 	 */
 	public function add_activity_spam_button() {
-		if ( !bp_activity_user_can_mark_spam() )
+		if ( ! bp_activity_user_can_mark_spam() ) {
 			return;
+		}
 
 		// By default, only handle activity updates and activity comments.
-		if ( !in_array( bp_get_activity_type(), BP_Akismet::get_activity_types() ) )
+		if ( ! in_array( bp_get_activity_type(), BP_Akismet::get_activity_types(), true ) ) {
 			return;
+		}
+
+		$spam_link = bp_rewrites_get_url(
+			array(
+				'component_id'                 => 'activity',
+				'single_item_action'           => 'spam',
+				'single_item_action_variables' => array( bp_get_activity_id() ),
+			)
+		);
 
 		bp_button(
 			array(
@@ -204,7 +214,7 @@ class BP_Akismet {
 				'component'  => 'activity',
 				'id'         => 'activity_make_spam_' . bp_get_activity_id(),
 				'link_class' => 'bp-secondary-action spam-activity confirm button item-button',
-				'link_href'  => wp_nonce_url( bp_get_root_domain() . '/' . bp_get_activity_slug() . '/spam/' . bp_get_activity_id() . '/', 'bp_activity_akismet_spam_' . bp_get_activity_id() ),
+				'link_href'  => wp_nonce_url( $spam_link, 'bp_activity_akismet_spam_' . bp_get_activity_id() ),
 				'link_text'  => __( 'Spam', 'buddypress' ),
 				'wrapper'    => false,
 			)
@@ -219,13 +229,27 @@ class BP_Akismet {
 	 * @since 1.6.0
 	 */
 	public function add_activity_comment_spam_button() {
-		if ( !bp_activity_user_can_mark_spam() )
+		if ( ! bp_activity_user_can_mark_spam() ) {
 			return;
+		}
 
 		// By default, only handle activity updates and activity comments.
 		$current_comment = bp_activity_current_comment();
-		if ( empty( $current_comment ) || !in_array( $current_comment->type, BP_Akismet::get_activity_types() ) )
+		if ( empty( $current_comment ) || ! in_array( $current_comment->type, BP_Akismet::get_activity_types(), true ) ) {
 			return;
+		}
+
+		$spam_link = add_query_arg(
+			'cid',
+			bp_get_activity_comment_id(),
+			bp_rewrites_get_url(
+				array(
+					'component_id'                 => 'activity',
+					'single_item_action'           => 'spam',
+					'single_item_action_variables' => array( bp_get_activity_comment_id() ),
+				)
+			)
+		);
 
 		bp_button(
 			array(
@@ -233,7 +257,7 @@ class BP_Akismet {
 				'component'  => 'activity',
 				'id'         => 'activity_make_spam_' . bp_get_activity_comment_id(),
 				'link_class' => 'bp-secondary-action spam-activity-comment confirm',
-				'link_href'  => wp_nonce_url( bp_get_root_domain() . '/' . bp_get_activity_slug() . '/spam/' . bp_get_activity_comment_id() . '/?cid=' . bp_get_activity_comment_id(), 'bp_activity_akismet_spam_' . bp_get_activity_comment_id() ),
+				'link_href'  => wp_nonce_url( $spam_link, 'bp_activity_akismet_spam_' . bp_get_activity_comment_id() ),
 				'link_text'  => __( 'Spam', 'buddypress' ),
 				'wrapper'    => false,
 			)

--- a/src/bp-activity/screens/permalink.php
+++ b/src/bp-activity/screens/permalink.php
@@ -16,12 +16,14 @@
  */
 function bp_activity_action_permalink_router() {
 	// Not viewing activity.
-	if ( ! bp_is_activity_component() || ! bp_is_current_action( 'p' ) )
+	if ( ! bp_is_activity_component() || ! bp_is_current_action( 'p' ) ) {
 		return false;
+	}
 
 	// No activity to display.
-	if ( ! bp_action_variable( 0 ) || ! is_numeric( bp_action_variable( 0 ) ) )
+	if ( ! bp_action_variable( 0 ) || ! is_numeric( bp_action_variable( 0 ) ) ) {
 		return false;
+	}
 
 	// Get the activity details.
 	$activity = bp_activity_get_specific( array( 'activity_ids' => bp_action_variable( 0 ), 'show_hidden' => true ) );
@@ -77,7 +79,7 @@ function bp_activity_action_permalink_router() {
 	 * @param array $value Array with url to redirect to and activity related to the redirect.
 	 */
 	if ( ! $redirect = apply_filters_ref_array( 'bp_activity_permalink_redirect_url', array( $redirect, &$activity ) ) ) {
-		bp_core_redirect( bp_get_root_domain() );
+		bp_core_redirect( bp_get_root_url() );
 	}
 
 	// Redirect to the actual activity permalink page.

--- a/src/bp-blogs/bp-blogs-blocks.php
+++ b/src/bp-blogs/bp-blogs-blocks.php
@@ -32,7 +32,7 @@ function bp_blogs_render_recent_posts_block( $attributes = array() ) {
 
 	$classnames           = 'widget_bp_blogs_widget buddypress widget';
 	$wrapper_attributes   = get_block_wrapper_attributes( array( 'class' => $classnames ) );
-	$blogs_directory_link = bp_get_blogs_directory_permalink();
+	$blogs_directory_link = bp_get_blogs_directory_url();
 	$max_posts            = (int) $block_args['maxPosts'];
 	$no_posts             = __( 'Sorry, there were no posts found.', 'buddypress' );
 

--- a/src/bp-blogs/bp-blogs-filters.php
+++ b/src/bp-blogs/bp-blogs-filters.php
@@ -29,16 +29,21 @@ add_filter( 'bp_blog_latest_post_content', 'prepend_attachment' );
  * @return string The new URL.
  */
 function bp_blogs_creation_location( $url ) {
+	$bp_url = bp_get_blogs_directory_url(
+		array(
+			'create_single_item' => 1,
+		)
+	);
 
 	/**
 	 * Filters the 'Create a new site' link URL.
 	 *
 	 * @since 1.6.0
 	 *
-	 * @param string $permalink URL for the 'Create a new site' signup page.
-	 * @param string $url       The original URL (points to wp-signup.php by default).
+	 * @param string $bp_url URL for the 'Create a new site' signup page.
+	 * @param string $url    The original URL (points to wp-signup.php by default).
 	 */
-	return apply_filters( 'bp_blogs_creation_location', trailingslashit( bp_get_blogs_directory_permalink() . 'create' ), $url );
+	return apply_filters( 'bp_blogs_creation_location', $bp_url, $url );
 }
 add_filter( 'wp_signup_location', 'bp_blogs_creation_location' );
 

--- a/src/bp-blogs/bp-blogs-template.php
+++ b/src/bp-blogs/bp-blogs-template.php
@@ -67,33 +67,52 @@ function bp_blogs_root_slug() {
 	}
 
 /**
- * Output blog directory permalink.
+ * Output Blogs directory's URL.
  *
- * @since 1.5.0
- *
+ * @since 12.0.0
  */
-function bp_blogs_directory_permalink() {
-	echo esc_url( bp_get_blogs_directory_permalink() );
+function bp_blogs_directory_url() {
+	echo esc_url( bp_get_blogs_directory_url() );
 }
-	/**
-	 * Return blog directory permalink.
-	 *
-	 * @since 1.5.0
-	 *
-	 *
-	 * @return string The URL of the Blogs directory.
-	 */
-	function bp_get_blogs_directory_permalink() {
 
-		/**
-		 * Filters the blog directory permalink.
-		 *
-		 * @since 1.5.0
-		 *
-		 * @param string $value Permalink URL for the blog directory.
-		 */
-		return apply_filters( 'bp_get_blogs_directory_permalink', trailingslashit( bp_get_root_domain() . '/' . bp_get_blogs_root_slug() ) );
-	}
+/**
+ * Returns the Blogs directory's URL.
+ *
+ * @since 12.0.0
+ *
+ * @param array $path_chunks {
+ *     An array of arguments. Optional.
+ *
+ *     @type int $create_single_item `1` to get the Blogs create link.
+ * }
+ * @return string The URL built for the BP Rewrites URL parser.
+ */
+function bp_get_blogs_directory_url( $path_chunks = array() ) {
+	$supported_chunks = array_fill_keys( array( 'create_single_item' ), true );
+
+	$path_chunks = bp_parse_args(
+		array_intersect_key( $path_chunks, $supported_chunks ),
+		array(
+			'component_id' => 'blogs'
+		)
+	);
+
+	$url = bp_rewrites_get_url( $path_chunks );
+
+	/**
+	 * Filters the Blogs directory's URL.
+	 *
+	 * @since 12.0.0
+	 *
+	 * @param string  $url      The Blogs directory's URL.
+	 * @param array   $path_chunks {
+	 *     An array of arguments. Optional.
+	 *
+	 *     @type int $create_single_item `1` to get the Blogs create link.
+	 * }
+	 */
+	return apply_filters( 'bp_get_blogs_directory_url', $url, $path_chunks );
+}
 
 /**
  * Rewind the blogs and reset blog index.
@@ -473,12 +492,14 @@ function bp_blog_permalink() {
 	function bp_get_blog_permalink() {
 		global $blogs_template;
 
-		if ( empty( $blogs_template->blog->domain ) )
-			$permalink = bp_get_root_domain() . $blogs_template->blog->path;
-		else {
+		if ( ! empty( $blogs_template->blog->domain ) ) {
+			$permalink = get_site_url( $blogs_template->blog->blog_id );
+
+		} else {
 			$protocol = 'http://';
-			if ( is_ssl() )
+			if ( is_ssl() ) {
 				$protocol = 'https://';
+			}
 
 			$permalink = $protocol . $blogs_template->blog->domain . $blogs_template->blog->path;
 		}
@@ -1348,14 +1369,20 @@ function bp_create_blog_link() {
 		return;
 	}
 
+	$url = bp_get_blogs_directory_url(
+		array(
+			'create_single_item' => 1,
+		)
+	);
+
 	/**
 	 * Filters "Create a Site" links for users viewing their own profiles.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $value HTML link for creating a site.
+	 * @param string $url HTML link for creating a site.
 	 */
-	echo apply_filters( 'bp_create_blog_link', '<a href="' . trailingslashit( bp_get_blogs_directory_permalink() . 'create' ) . '">' . __( 'Create a Site', 'buddypress' ) . '</a>' );
+	echo apply_filters( 'bp_create_blog_link', '<a href="' . $url . '">' . __( 'Create a Site', 'buddypress' ) . '</a>' );
 }
 
 /**
@@ -1459,12 +1486,18 @@ function bp_blog_create_button() {
 			return false;
 		}
 
+		$url = bp_get_blogs_directory_url(
+			array(
+				'create_single_item' => 1,
+			)
+		);
+
 		$button_args = array(
 			'id'         => 'create_blog',
 			'component'  => 'blogs',
 			'link_text'  => __( 'Create a Site', 'buddypress' ),
 			'link_class' => 'blog-create no-ajax',
-			'link_href'  => trailingslashit( bp_get_blogs_directory_permalink() . 'create' ),
+			'link_href'  => $url,
 			'wrapper'    => false,
 			'block_self' => false,
 		);

--- a/src/bp-blogs/classes/class-bp-blogs-recent-posts-widget.php
+++ b/src/bp-blogs/classes/class-bp-blogs-recent-posts-widget.php
@@ -49,7 +49,7 @@ class BP_Blogs_Recent_Posts_Widget extends WP_Widget {
 			: __( 'Recent Networkwide Posts', 'buddypress' );
 
 		if ( ! empty( $instance['link_title'] ) ) {
-			$title = '<a href="' . bp_get_blogs_directory_permalink() . '">' . esc_html( $title ) . '</a>';
+			$title = '<a href="' . bp_get_blogs_directory_url() . '">' . esc_html( $title ) . '</a>';
 		}
 
 		/**

--- a/src/bp-core/bp-core-avatars.php
+++ b/src/bp-core/bp-core-avatars.php
@@ -200,7 +200,7 @@ function bp_core_is_default_gravatar( $d = '' ) {
  *                                   of the user's email address; this argument provides it. If not
  *                                   provided, the function will infer it: for users, by getting the
  *                                   user's email from the database, for groups/blogs, by concatenating
- *                                   "{$item_id}-{$object}@{bp_get_root_domain()}". The user query adds
+ *                                   "{$item_id}-{$object}@{bp_get_domain()}". The user query adds
  *                                   overhead, so it's recommended that wrapper functions provide a
  *                                   value for 'email' when querying user IDs. Default: false.
  *     @type bool       $no_grav     Whether to disable the default Gravatar fallback.
@@ -641,7 +641,7 @@ function bp_core_fetch_avatar( $args = '' ) {
 			if ( 'user' == $params['object'] ) {
 				$params['email'] = bp_core_get_user_email( $params['item_id'] );
 			} elseif ( 'group' == $params['object'] || 'blog' == $params['object'] ) {
-				$params['email'] = $params['item_id'] . '-' . $params['object'] . '@' . bp_get_root_domain();
+				$params['email'] = $params['item_id'] . '-' . $params['object'] . '@' . bp_get_domain();
 			}
 		}
 

--- a/src/bp-core/bp-core-blocks.php
+++ b/src/bp-core/bp-core-blocks.php
@@ -234,7 +234,7 @@ function bp_blocks_get_login_widget_registration_link( $content = '', $args = ar
 		if ( isset( $args['include_pwd_link'] ) && true === $args['include_pwd_link'] ) {
 			$content .= sprintf(
 				'<p class="bp-login-widget-pwd-link"><a href="%1$s">%2$s</a></p>',
-				esc_url( wp_lostpassword_url( bp_get_root_domain() ) ),
+				esc_url( wp_lostpassword_url( bp_get_root_url() ) ),
 				esc_html__( 'Lost your password?', 'buddypress' )
 			);
 		}

--- a/src/bp-core/bp-core-buddybar.php
+++ b/src/bp-core/bp-core-buddybar.php
@@ -779,7 +779,7 @@ function bp_core_maybe_hook_new_subnav_screen_function( $subnav_item, $component
 			// Fall back to the home page.
 			} else {
 				$message     = __( 'You do not have access to this page.', 'buddypress' );
-				$redirect_to = bp_get_root_domain();
+				$redirect_to = bp_get_root_url();
 			}
 
 			$retval['redirect_args'] = array(

--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -631,7 +631,7 @@ add_action( 'bp_template_redirect', 'bp_core_catch_no_access', 1 );
  *     @type string $redirect The URL the user will be redirected to after successfully
  *                            logging in. Default: the URL originally requested.
  *     @type string $root     The root URL of the site, used in case of error or mode 1 redirects.
- *                            Default: the value of {@link bp_get_root_domain()}.
+ *                            Default: the value of {@link bp_get_root_url()}.
  *     @type string $message  An error message to display to the user on the log-in page.
  *                            Default: "You must log in to access the page you requested."
  * }
@@ -646,7 +646,7 @@ function bp_core_no_access( $args = '' ) {
 	$defaults = array(
 		'mode'     => 2,                    // 1 = $root, 2 = wp-login.php.
 		'redirect' => $redirect_url,        // the URL you get redirected to when a user successfully logs in.
-		'root'     => bp_get_root_domain(), // the landing page you get redirected to when a user doesn't have access.
+		'root'     => bp_get_root_url(),    // the landing page you get redirected to when a user doesn't have access.
 		'message'  => __( 'You must log in to access the page you requested.', 'buddypress' )
 	);
 
@@ -907,7 +907,7 @@ function bp_get_canonical_url( $args = array() ) {
 		 * type directory.
 		 */
 		if ( false !== $front_page_component && bp_is_current_component( $front_page_component ) && ! bp_current_action() && ! bp_get_current_member_type() ) {
-			$bp->canonical_stack['canonical_url'] = trailingslashit( bp_get_root_domain() );
+			$bp->canonical_stack['canonical_url'] = bp_get_root_url();
 
 		// Except when the front page is set to the registration page
 		// and the current user is logged in. In this case we send to

--- a/src/bp-core/bp-core-filters.php
+++ b/src/bp-core/bp-core-filters.php
@@ -1235,11 +1235,15 @@ function bp_email_set_default_tokens( $tokens, $property_name, $transform, $emai
 			$tokens['recipient.username'] = $user_obj->user_login;
 
 			if ( bp_is_active( 'settings' ) && empty( $tokens['unsubscribe'] ) ) {
-				$tokens['unsubscribe'] = esc_url( sprintf(
-					'%s%s/notifications/',
-					bp_members_get_user_url( $user_obj->ID ),
-					bp_get_settings_slug()
-				) );
+				$tokens['unsubscribe'] = esc_url(
+					bp_members_get_user_url(
+						$user_obj->ID,
+						array(
+							'single_item_component' => bp_rewrites_get_slug( 'members', 'member_settings', bp_get_settings_slug() ),
+							'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_settings_notifications', 'notifications' ),
+						)
+					)
+				);
 			}
 		}
 	}

--- a/src/bp-core/bp-core-filters.php
+++ b/src/bp-core/bp-core-filters.php
@@ -383,7 +383,7 @@ function bp_core_login_redirect( $redirect_to, $redirect_to_raw, $user ) {
 	 *
 	 * @param string $value URL to redirect to.
 	 */
-	return apply_filters( 'bp_core_login_redirect_to', bp_get_root_domain() );
+	return apply_filters( 'bp_core_login_redirect_to', bp_get_root_url() );
 }
 add_filter( 'bp_login_redirect', 'bp_core_login_redirect', 10, 3 );
 
@@ -1205,7 +1205,7 @@ add_filter( 'bp_email_get_headers', 'bp_email_set_default_headers', 6, 4 );
  */
 function bp_email_set_default_tokens( $tokens, $property_name, $transform, $email ) {
 	$tokens['site.admin-email'] = bp_get_option( 'admin_email' );
-	$tokens['site.url']         = bp_get_root_domain();
+	$tokens['site.url']         = bp_get_root_url();
 	$tokens['email.subject']    = $email->get_subject();
 
 	// These options are escaped with esc_html on the way into the database in sanitize_option().

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -1144,7 +1144,7 @@ function bp_core_redirect( $location = '', $status = 302 ) {
 	// empty value for $location, which results in an error. Ensure that we
 	// have a valid URL.
 	if ( empty( $location ) ) {
-		$location = bp_get_root_domain();
+		$location = bp_get_root_url();
 	}
 
 	// Make sure we don't call status_header() in bp_core_do_catch_uri() as this
@@ -2529,7 +2529,7 @@ function bp_core_action_search_site( $slug = '' ) {
 	}
 
 	if ( empty( $_POST['search-terms'] ) ) {
-		bp_core_redirect( bp_get_root_domain() );
+		bp_core_redirect( bp_get_root_url() );
 		return;
 	}
 
@@ -2573,7 +2573,7 @@ function bp_core_action_search_site( $slug = '' ) {
 		}
 
 		if ( empty( $slug ) && 'posts' != $search_which ) {
-			bp_core_redirect( bp_get_root_domain() );
+			bp_core_redirect( bp_get_root_url() );
 			return;
 		}
 	}

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -4367,10 +4367,12 @@ function bp_email_unsubscribe_handler() {
 	// This is an unsubscribe request from a current member.
 	} else {
 		if ( bp_is_active( 'settings' ) ) {
-			$redirect_to = sprintf(
-				'%s%s/notifications/',
-				bp_members_get_user_url( $raw_user_id ),
-				bp_get_settings_slug()
+			$redirect_to = bp_members_get_user_url(
+				$raw_user_id,
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_settings', bp_get_settings_slug() ),
+					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_settings_notifications', 'notifications' ),
+				)
 			);
 		} else {
 			$redirect_to = bp_members_get_user_url( $raw_user_id );

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -1115,7 +1115,6 @@ function bp_do_register_theme_directory() {
  */
 function bp_core_get_root_domain() {
 	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_rewrites_get_root_url()' );
-
 	$domain = bp_rewrites_get_root_url();
 
 	/**

--- a/src/bp-core/bp-core-rewrites.php
+++ b/src/bp-core/bp-core-rewrites.php
@@ -171,7 +171,9 @@ function bp_rewrites_get_url( $args = array() ) {
 			} elseif ( isset( $r['create_single_item'] ) ) {
 				$create_slug = 'create';
 				if ( 'groups' === $component->id ) {
-					$create_slug = bp_rewrites_get_slug( 'groups', 'bp_group_create', 'create' );
+					$create_slug = bp_rewrites_get_slug( 'groups', 'group_create', 'create' );
+				} elseif ( 'blogs' === $component->id ) {
+					$create_slug = bp_rewrites_get_slug( 'blogs', 'blog_create', 'create' );
 				}
 
 				$url = str_replace( '%' . $component->rewrite_ids['directory'] . '%', $create_slug, $component->directory_permastruct );

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -517,15 +517,20 @@ function bp_styles() {
  * @return string URL action attribute for search forms, eg example.com/search/.
  */
 function bp_search_form_action() {
+	$url = bp_rewrites_get_url(
+		array(
+			'component_id' => bp_get_search_slug(),
+		)
+	);
 
 	/**
 	 * Filters the "action" attribute for search forms.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $value Search form action url.
+	 * @param string $url Search form action url.
 	 */
-	return apply_filters( 'bp_search_form_action', trailingslashit( bp_get_root_domain() . '/' . bp_get_search_slug() ) );
+	return apply_filters( 'bp_search_form_action', $url );
 }
 
 /**
@@ -1396,6 +1401,17 @@ function bp_action_variable( $position = 0 ) {
 	 * @param int         $position        The key of the action variable requested.
 	 */
 	return apply_filters( 'bp_action_variable', $action_variable, $position );
+}
+
+/**
+ * Returns the BP root blog's domain name.
+ *
+ * @since 12.0.0
+ *
+ * @return string The BP root blog's domain name.
+ */
+function bp_get_domain() {
+	return wp_parse_url( bp_get_root_url(), PHP_URL_HOST );
 }
 
 /**

--- a/src/bp-core/deprecated/12.0.php
+++ b/src/bp-core/deprecated/12.0.php
@@ -241,3 +241,37 @@ function bp_core_get_user_domain( $user_id = 0, $user_nicename = false, $user_lo
 	 */
 	return apply_filters_deprecated( 'bp_core_get_user_domain', array( $domain, $user_id, $user_nicename, $user_login), '12.0.0', 'bp_members_get_user_url' );
 }
+
+/**
+ * Output blog directory permalink.
+ *
+ * @since 1.5.0
+ * @deprecated 12.0.0
+ */
+function bp_blogs_directory_permalink() {
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_blogs_directory_url()' );
+	bp_blogs_directory_url();
+}
+
+/**
+ * Return blog directory permalink.
+ *
+ * @since 1.5.0
+ * @deprecated 12.0.0
+ *
+ * @return string The URL of the Blogs directory.
+ */
+function bp_get_blogs_directory_permalink() {
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_get_blogs_directory_url()' );
+	$url = bp_get_blogs_directory_url();
+
+	/**
+	 * Filters the blog directory permalink.
+	 *
+	 * @since 1.5.0
+	 * @deprecated 12.0.0
+	 *
+	 * @param string $value Permalink URL for the blog directory.
+	 */
+	return apply_filters_deprecated( 'bp_get_blogs_directory_permalink', array( $url ), '12.0.0', 'bp_get_blogs_directory_url' );
+}

--- a/src/bp-core/deprecated/12.0.php
+++ b/src/bp-core/deprecated/12.0.php
@@ -243,6 +243,62 @@ function bp_core_get_user_domain( $user_id = 0, $user_nicename = false, $user_lo
 }
 
 /**
+ * Get the link for the logged-in user's profile.
+ *
+ * @since 1.0.0
+ * @deprecated 12.0.0
+ *
+ * @return string
+ */
+function bp_get_loggedin_user_link() {
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_loggedin_user_url()' );
+	$url = bp_loggedin_user_url();
+
+	/**
+	 * Filters the link for the logged-in user's profile.
+	 *
+	 * @since 1.2.4
+	 * @deprecated 12.0.0
+	 *
+	 * @param string $url Link for the logged-in user's profile.
+	 */
+	return apply_filters_depreacated( 'bp_get_loggedin_user_link', array( $url ), '12.0.0', 'bp_loggedin_user_url' );
+}
+
+/**
+ * Get the link for the displayed user's profile.
+ *
+ * @since 1.0.0
+ * @deprecated 12.0.0
+ *
+ * @return string
+ */
+function bp_get_displayed_user_link() {
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_displayed_user_url()' );
+	$url = bp_displayed_user_url();
+
+	/**
+	 * Filters the link for the displayed user's profile.
+	 *
+	 * @since 1.2.4
+	 * @deprecated 12.0.0
+	 *
+	 * @param string $url Link for the displayed user's profile.
+	 */
+	return apply_filters_deprecated( 'bp_get_displayed_user_link', array( $url ), '12.0.0', 'bp_displayed_user_url' );
+}
+
+/**
+ * Alias of {@link bp_displayed_user_domain()}.
+ *
+ * @deprecated 12.0.0
+ */
+function bp_user_link() {
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_displayed_user_url()' );
+	bp_displayed_user_url();
+}
+
+/**
  * Output blog directory permalink.
  *
  * @since 1.5.0
@@ -271,7 +327,7 @@ function bp_get_blogs_directory_permalink() {
 	 * @since 1.5.0
 	 * @deprecated 12.0.0
 	 *
-	 * @param string $value Permalink URL for the blog directory.
+	 * @param string $url Permalink URL for the blog directory.
 	 */
 	return apply_filters_deprecated( 'bp_get_blogs_directory_permalink', array( $url ), '12.0.0', 'bp_get_blogs_directory_url' );
 }

--- a/src/bp-groups/bp-groups-notifications.php
+++ b/src/bp-groups/bp-groups-notifications.php
@@ -340,6 +340,7 @@ function groups_notification_group_invites( &$group, &$member, $inviter_user_id 
 		$invited_user_id,
 		array(
 			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_groups', bp_get_groups_slug() ),
+			'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_groups_invites', 'invites' ),
 		)
 	);
 
@@ -358,7 +359,7 @@ function groups_notification_group_invites( &$group, &$member, $inviter_user_id 
 		$invite_message = current( $invitations )->content;
 	}
 
-	$args         = array(
+	$args = array(
 		'tokens' => array(
 			'group'          => $group,
 			'group.url'      => bp_get_group_permalink( $group ),
@@ -366,7 +367,7 @@ function groups_notification_group_invites( &$group, &$member, $inviter_user_id 
 			'inviter.name'   => bp_core_get_userlink( $inviter_user_id, true, false ),
 			'inviter.url'    => bp_members_get_user_url( $inviter_user_id ),
 			'inviter.id'     => $inviter_user_id,
-			'invites.url'    => esc_url( $invited_link . '/invites/' ),
+			'invites.url'    => esc_url( $invited_link ),
 			'invite.message' => $invite_message,
 			'unsubscribe'    => esc_url( bp_email_get_unsubscribe_link( $unsubscribe_args ) ),
 		),

--- a/src/bp-groups/bp-groups-template.php
+++ b/src/bp-groups/bp-groups-template.php
@@ -95,30 +95,101 @@ function bp_groups_group_type_base() {
 	}
 
 /**
+ * Output Groups directory's URL.
+ *
+ * @since 12.0.0
+ */
+function bp_groups_directory_url() {
+	echo esc_url( bp_get_groups_directory_url() );
+}
+
+/**
+ * Returns the Groups directory's URL.
+ *
+ * @since 12.0.0
+ *
+ * @param array $path_chunks {
+ *     An array of arguments. Optional.
+ *
+ *     @type int   $create_single_item `1` to get the create a group URL.
+ *     @type array $directory_type     The group type slug.
+ * }
+ * @return string The URL built for the BP Rewrites URL parser.
+ */
+function bp_get_groups_directory_url( $path_chunks = array() ) {
+	$supported_chunks = array_fill_keys( array( 'create_single_item', 'directory_type' ), true );
+
+	$path_chunks = bp_parse_args(
+		array_intersect_key( $path_chunks, $supported_chunks ),
+		array(
+			'component_id' => 'groups'
+		)
+	);
+
+	$url = bp_rewrites_get_url( $path_chunks );
+
+	/**
+	 * Filters the Groups directory's URL.
+	 *
+	 * @since 12.0.0
+	 *
+	 * @param string  $url The Groups directory's URL.
+	 * @param array   $path_chunks {
+	 *     An array of arguments. Optional.
+	 *
+	 *      @type int   $create_single_item `1` to get the create a group URL.
+	 *      @type array $directory_type     The group type slug.
+	 * }
+	 */
+	return apply_filters( 'bp_get_groups_directory_url', $url, $path_chunks );
+}
+
+/**
  * Output group directory permalink.
  *
  * @since 1.5.0
+ * @deprecated 12.0.0
  */
 function bp_groups_directory_permalink() {
-	echo esc_url( bp_get_groups_directory_permalink() );
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_groups_directory_url()' );
+	bp_groups_directory_url();
 }
 	/**
 	 * Return group directory permalink.
 	 *
 	 * @since 1.5.0
+	 * @deprecated 12.0.0
 	 *
 	 * @return string
 	 */
 	function bp_get_groups_directory_permalink() {
+		/*
+		 * This function is used at many places and we need to review all this
+		 * places during the 12.0 development cycle. Using BP Rewrites means we
+		 * cannot concatenate URL chunks to build our URL anymore. We now need
+		 * to use `bp_get_groups_directory_url( $array )` and make sure to use
+		 * the right arguments inside this `$array`. Morevover as this function
+		 * is also used to build a single group URL, we need to create a new
+		 * function to create single group URLs using BP Rewrites.
+		 *
+		 * @todo Once every link reviewed, we'll be able to remove this check
+		 *       and let PHPUnit tell us the one we forgot, eventually!
+		 */
+		if ( ! buddypress()->is_phpunit_running ) {
+			_deprecated_function( __FUNCTION__, '12.0.0', 'bp_get_groups_directory_url()' );
+		}
+
+		$url = bp_get_groups_directory_url();
 
 		/**
 		 * Filters the group directory permalink.
 		 *
 		 * @since 1.5.0
+		 * @deprecated 12.0.0
 		 *
-		 * @param string $value Permalink for the group directory.
+		 * @param string $url Permalink for the group directory.
 		 */
-		return apply_filters( 'bp_get_groups_directory_permalink', trailingslashit( bp_get_root_domain() . '/' . bp_get_groups_root_slug() ) );
+		return apply_filters_deprecated( 'bp_get_groups_directory_permalink', array( $url ), '12.0.0', 'bp_get_groups_directory_url' );
 	}
 
 /**

--- a/src/bp-members/bp-members-filters.php
+++ b/src/bp-members/bp-members-filters.php
@@ -238,7 +238,7 @@ function bp_members_invitations_get_registration_welcome_message() {
 			esc_html__( 'Welcome! You are already a member of this site. Please %s to continue.', 'buddypress' ),
 			sprintf(
 				'<a href="%1$s">%2$s</a>',
-				esc_url( wp_login_url( bp_get_root_domain() ) ),
+				esc_url( wp_login_url( bp_get_root_url() ) ),
 				esc_html__( 'log in', 'buddypress' )
 			)
 		);
@@ -310,12 +310,12 @@ function bp_members_invitations_get_modified_registration_disabled_message() {
 				esc_html__( 'Welcome! You are already a member of this site. Please %1$s to continue. If you have forgotten your password, you can %2$s.', 'buddypress' ),
 				sprintf(
 					'<a href="%1$s">%2$s</a>',
-					esc_url( wp_login_url( bp_get_root_domain() ) ),
+					esc_url( wp_login_url( bp_get_root_url() ) ),
 					esc_html__( 'log in', 'buddypress' )
 				),
 				sprintf(
 					'<a href="%1$s">%2$s</a>',
-					esc_url( wp_lostpassword_url( bp_get_root_domain() ) ),
+					esc_url( wp_lostpassword_url( bp_get_root_url() ) ),
 					esc_html__( 'reset it', 'buddypress' )
 				)
 			);

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -2523,7 +2523,13 @@ function bp_core_wpsignup_redirect() {
 
 	if ( $is_site_creation ) {
 		if ( bp_is_active( 'blogs' ) ) {
-			$redirect_to = trailingslashit( bp_get_blogs_directory_permalink() . 'create' );
+			$url = bp_get_blogs_directory_url(
+				array(
+					'create_single_item' => 1,
+				)
+			);
+
+			$redirect_to = trailingslashit( $url );
 		} else {
 			// Perform no redirect in this case.
 			$redirect_to = '';

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -144,7 +144,7 @@ function bp_core_get_users( $args = '' ) {
  * @since 12.0.0
  *
  * @param integer $user_id  The user ID.
- * @param array   $action {
+ * @param array   $path_chunks {
  *     An array of arguments. Optional.
  *
  *     @type string $single_item_component        The component slug the action is relative to.

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -177,19 +177,6 @@ function bp_members_get_user_url( $user_id = 0, $path_chunks = array() ) {
 	/**
 	 * Filters the domain for the passed user.
 	 *
-	 * @since 1.0.1
-	 * @deprecated 12.0.0
-	 *
-	 * @param string $domain        Domain for the passed user.
-	 * @param int    $user_id       ID of the passed user.
-	 * @param string $user_nicename User nicename of the passed user.
-	 * @param string $user_login    User login of the passed user.
-	 */
-	$url = apply_filters_deprecated( 'bp_core_get_user_domain', array( $url, $user_id, false, false ), '12.0.0', 'bp_members_get_user_url' );
-
-	/**
-	 * Filters the domain for the passed user.
-	 *
 	 * @since 12.0.0
 	 *
 	 * @param string  $url      The user url.
@@ -326,16 +313,6 @@ function bp_members_get_user_slug( $user_id = 0 ) {
 			$slug = $user->{$prop};
 		}
 	}
-
-	/**
-	 * Filters the username based on originally provided user ID.
-	 *
-	 * @since 1.0.1
-	 * @deprecated 12.0.0
-	 *
-	 * @param string $slug Username determined by user ID.
-	 */
-	$slug = apply_filters_deprecated( 'bp_core_get_username', array( $slug ), '12.0.0', 'bp_members_get_user_slug' );
 
 	/**
 	 * Filter here to edit the user's slug.

--- a/src/bp-members/bp-members-template.php
+++ b/src/bp-members/bp-members-template.php
@@ -1863,31 +1863,13 @@ function bp_user_firstname() {
 	}
 
 /**
- * Output the link for the logged-in user's profile.
+ * Alias of {@link bp_displayed_user_id()}.
  *
- * @since 1.2.4
+ * @since 1.0.0
  */
-function bp_loggedin_user_link() {
-	echo esc_url( bp_get_loggedin_user_link() );
+function bp_current_user_id() {
+	return bp_displayed_user_id();
 }
-	/**
-	 * Get the link for the logged-in user's profile.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return string
-	 */
-	function bp_get_loggedin_user_link() {
-
-		/**
-		 * Filters the link for the logged-in user's profile.
-		 *
-		 * @since 1.2.4
-		 *
-		 * @param string $value Link for the logged-in user's profile.
-		 */
-		return apply_filters( 'bp_get_loggedin_user_link', bp_loggedin_user_domain() );
-	}
 
 /**
  * Output the link for the displayed user's profile.
@@ -1895,43 +1877,7 @@ function bp_loggedin_user_link() {
  * @since 1.2.4
  */
 function bp_displayed_user_link() {
-	echo esc_url( bp_get_displayed_user_link() );
-}
-	/**
-	 * Get the link for the displayed user's profile.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return string
-	 */
-	function bp_get_displayed_user_link() {
-
-		/**
-		 * Filters the link for the displayed user's profile.
-		 *
-		 * @since 1.2.4
-		 *
-		 * @param string $value Link for the displayed user's profile.
-		 */
-		return apply_filters( 'bp_get_displayed_user_link', bp_displayed_user_domain() );
-	}
-
-	/**
-	 * Alias of {@link bp_displayed_user_domain()}.
-	 *
-	 * @deprecated
-	 */
-	function bp_user_link() {
-		bp_displayed_user_domain();
-	}
-
-/**
- * Alias of {@link bp_displayed_user_id()}.
- *
- * @since 1.0.0
- */
-function bp_current_user_id() {
-	return bp_displayed_user_id();
+	echo esc_url( bp_displayed_user_url() );
 }
 
 /**
@@ -1949,11 +1895,16 @@ function bp_current_user_id() {
  * @return string The logged-in user's profile URL.
  */
 function bp_displayed_user_url( $path_chunks = array() ) {
-	if ( ! isset( buddypress()->displayed_user->domain ) ) {
-		return '';
+	$bp  = buddypress();
+	$url = '';
+
+	if ( isset( $bp->displayed_user->domain ) ) {
+		$url = $bp->displayed_user->domain;
 	}
 
-	$url = bp_members_get_user_url( bp_displayed_user_id(), $path_chunks );
+	if ( $path_chunks ) {
+		$url = bp_members_get_user_url( bp_displayed_user_id(), $path_chunks );
+	}
 
 	/**
 	 * Filter here to edit the displayed user's profile URL.
@@ -1976,35 +1927,33 @@ function bp_displayed_user_url( $path_chunks = array() ) {
  * Generate the link for the displayed user's profile.
  *
  * @since 1.0.0
+ * @since 12.0.0 This function is now an alias of `bp_displayed_user_url()`.
+ *               You should only use it to get the "home" URL of the displayed
+ *               user's profile page. If you need to build an URL to reach another
+ *               page, we strongly advise you to use `bp_displayed_user_url()`.
  *
  * @return string
  */
 function bp_displayed_user_domain() {
-	/*
-	 * This function is used at many places and we need to review all this
-	 * places during the 12.0 development cycle. Using BP Rewrites means we
-	 * cannot concatenate URL chunks to build our URL anymore. We now need
-	 * to use `bp_displayed_user_url( $array )` and make sure to use the right
-	 * arguments inside this `$array`.
-	 *
-	 * @todo Once every link reviewed, we'll be able to remove this check
-	 *       and let PHPUnit tell us the one we forgot, eventually!
-	 */
-	if ( ! buddypress()->is_phpunit_running ) {
-		_deprecated_function( __FUNCTION__, '12.0.0', 'bp_displayed_user_url()' );
-	}
-
 	$url = bp_displayed_user_url();
 
 	/**
 	 * Filters the generated link for the displayed user's profile.
 	 *
 	 * @since 1.0.0
-	 * @deprecated 12.0.0
 	 *
 	 * @param string $url Generated link for the displayed user's profile.
 	 */
-	return apply_filters_deprecated( 'bp_displayed_user_domain', array( $url ), '12.0.0', 'bp_displayed_user_url' );
+	return apply_filters( 'bp_displayed_user_domain',$url );
+}
+
+/**
+ * Output the link for the logged-in user's profile.
+ *
+ * @since 1.2.4
+ */
+function bp_loggedin_user_link() {
+	echo esc_url( bp_loggedin_user_url() );
 }
 
 /**
@@ -2022,11 +1971,16 @@ function bp_displayed_user_domain() {
  * @return string The logged-in user's profile URL.
  */
 function bp_loggedin_user_url( $path_chunks = array() ) {
-	if ( ! isset( buddypress()->loggedin_user->domain ) ) {
-		return '';
+	$bp  = buddypress();
+	$url = '';
+
+	if ( isset( $bp->loggedin_user->domain ) ) {
+		$url = $bp->loggedin_user->domain;
 	}
 
-	$url = bp_members_get_user_url( bp_loggedin_user_id(), $path_chunks );
+	if ( $path_chunks ) {
+		$url = bp_members_get_user_url( bp_loggedin_user_id(), $path_chunks );
+	}
 
 	/**
 	 * Filter here to edit the logged-in user's profile URL.
@@ -2049,35 +2003,24 @@ function bp_loggedin_user_url( $path_chunks = array() ) {
  * Generate the link for the logged-in user's profile.
  *
  * @since 1.0.0
+ * @since 12.0.0 This function is now an alias of `bp_loggedin_user_url()`.
+ *               You should only use it to get the "home" URL of the logged-in
+ *               user's profile page. If you need to build an URL to reach another
+ *               page, we strongly advise you to use `bp_loggedin_user_url()`.
  *
  * @return string
  */
 function bp_loggedin_user_domain() {
-	/*
-	 * This function is used at many places and we need to review all this
-	 * places during the 12.0 development cycle. Using BP Rewrites means we
-	 * cannot concatenate URL chunks to build our URL anymore. We now need
-	 * to use `bp_loggedin_user_url( $array )` and make sure to use the right
-	 * arguments inside this `$array`.
-	 *
-	 * @todo Once every link reviewed, we'll be able to remove this check
-	 *       and let PHPUnit tell us the one we forgot, eventually!
-	 */
-	if ( ! buddypress()->is_phpunit_running ) {
-		_deprecated_function( __FUNCTION__, '12.0.0', 'bp_loggedin_user_url()' );
-	}
-
 	$url = bp_loggedin_user_url();
 
 	/**
 	 * Filters the generated link for the logged-in user's profile.
 	 *
 	 * @since 1.0.0
-	 * @deprecated 12.0.0 Use {@see 'bp_loggedin_user_url'} instead.
 	 *
 	 * @param string $url Generated link for the logged-in user's profile.
 	 */
-	return apply_filters_deprecated( 'bp_loggedin_user_domain', array( $url ), '12.0.0', 'bp_loggedin_user_url' );
+	return apply_filters( 'bp_loggedin_user_domain', $url );
 }
 
 /**

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -814,22 +814,22 @@ class BP_Members_Component extends BP_Component {
 	 */
 	public function add_rewrite_rules( $rewrite_rules = array() ) {
 		$rewrite_rules = array(
-			'directory_type'               => array(
+			'directory_type'      => array(
 				'regex' => $this->root_slug . '/' . bp_get_members_member_type_base() . '/([^/]+)/?$',
 				'order' => 50,
 				'query' => 'index.php?' . $this->rewrite_ids['directory'] . '=1&' . $this->rewrite_ids['directory_type'] . '=$matches[1]',
 			),
-			'member_activate'      => array(
+			'member_activate'     => array(
 				'regex' => bp_get_activate_slug(),
 				'order' => 40,
 				'query' => 'index.php?' . $this->rewrite_ids['member_activate'] . '=1',
 			),
-			'member_activate_key'  => array(
+			'member_activate_key' => array(
 				'regex' => bp_get_activate_slug() . '/([^/]+)/?$',
 				'order' => 30,
 				'query' => 'index.php?' . $this->rewrite_ids['member_activate'] . '=1&' . $this->rewrite_ids['member_activate_key'] . '=$matches[1]',
 			),
-			'member_register'      => array(
+			'member_register'     => array(
 				'regex' => bp_get_signup_slug(),
 				'order' => 20,
 				'query' => 'index.php?' . $this->rewrite_ids['member_register'] . '=1',

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -215,6 +215,10 @@ class BP_Members_Component extends BP_Component {
 	public function setup_additional_globals() {
 		$bp = buddypress();
 
+		// Set-up Extra permastructs for the register and activate pages.
+		$this->register_permastruct = bp_get_signup_slug() . '/%' . $this->rewrite_ids['member_register'] . '%';
+		$this->activate_permastruct = bp_get_activate_slug() . '/%' . $this->rewrite_ids['member_activate'] . '%';
+
 		/** Logged in user ***************************************************
 		 */
 
@@ -780,6 +784,84 @@ class BP_Members_Component extends BP_Component {
 		) );
 
 		parent::setup_cache_groups();
+	}
+
+	/**
+	 * Add the Registration and Activation rewrite tags.
+	 *
+	 * @since 12.0.0
+	 *
+	 * @param array $rewrite_tags Optional. See BP_Component::add_rewrite_tags() for
+	 *                            description.
+	 */
+	public function add_rewrite_tags( $rewrite_tags = array() ) {
+		$rewrite_tags = array(
+			'member_register'     => '([1]{1,})',
+			'member_activate'     => '([1]{1,})',
+			'member_activate_key' => '([^/]+)',
+		);
+
+		parent::add_rewrite_tags( $rewrite_tags );
+	}
+
+	/**
+	 * Add the Registration and Activation rewrite rules.
+	 *
+	 * @since 12.0.0
+	 *
+	 * @param array $rewrite_rules Optional. See BP_Component::add_rewrite_rules() for
+	 *                             description.
+	 */
+	public function add_rewrite_rules( $rewrite_rules = array() ) {
+		$rewrite_rules = array(
+			'directory_type'               => array(
+				'regex' => $this->root_slug . '/' . bp_get_members_member_type_base() . '/([^/]+)/?$',
+				'order' => 50,
+				'query' => 'index.php?' . $this->rewrite_ids['directory'] . '=1&' . $this->rewrite_ids['directory_type'] . '=$matches[1]',
+			),
+			'member_activate'      => array(
+				'regex' => bp_get_activate_slug(),
+				'order' => 40,
+				'query' => 'index.php?' . $this->rewrite_ids['member_activate'] . '=1',
+			),
+			'member_activate_key'  => array(
+				'regex' => bp_get_activate_slug() . '/([^/]+)/?$',
+				'order' => 30,
+				'query' => 'index.php?' . $this->rewrite_ids['member_activate'] . '=1&' . $this->rewrite_ids['member_activate_key'] . '=$matches[1]',
+			),
+			'member_register'      => array(
+				'regex' => bp_get_signup_slug(),
+				'order' => 20,
+				'query' => 'index.php?' . $this->rewrite_ids['member_register'] . '=1',
+			),
+		);
+
+		parent::add_rewrite_rules( $rewrite_rules );
+	}
+
+	/**
+	 * Add the Registration and Activation permastructs.
+	 *
+	 * @since 12.0.0
+	 *
+	 * @param array $permastructs Optional. See BP_Component::add_permastructs() for
+	 *                            description.
+	 */
+	public function add_permastructs( $permastructs = array() ) {
+		$permastructs = array(
+			// Register permastruct.
+			$this->rewrite_ids['member_register'] => array(
+				'permastruct' => $this->register_permastruct,
+				'args'        => array(),
+			),
+			// Activate permastruct.
+			$this->rewrite_ids['member_activate'] => array(
+				'permastruct' => $this->activate_permastruct,
+				'args'        => array(),
+			),
+		);
+
+		parent::add_permastructs( $permastructs );
 	}
 
 	/**

--- a/src/bp-members/screens/activate.php
+++ b/src/bp-members/screens/activate.php
@@ -26,7 +26,7 @@ function bp_core_screen_activation() {
 		// avoid an infinite loop. Otherwise, set to root domain.
 		$redirect_to = bp_is_component_front_page( 'activate' )
 			? bp_get_members_directory_permalink()
-			: bp_get_root_domain();
+			: bp_get_root_url();
 
 		// Trailing slash it, as we expect these URL's to be.
 		$redirect_to = trailingslashit( $redirect_to );

--- a/src/bp-members/screens/register.php
+++ b/src/bp-members/screens/register.php
@@ -27,7 +27,7 @@ function bp_core_screen_signup() {
 
 		$redirect_to = bp_is_component_front_page( 'register' )
 			? bp_get_members_directory_permalink()
-			: bp_get_root_domain();
+			: bp_get_root_url();
 
 		/**
 		 * Filters the URL to redirect logged in users to when visiting registration page.
@@ -157,7 +157,7 @@ function bp_core_screen_signup() {
 
 				// This situation doesn't naturally occur so bounce to website root.
 			} else {
-				bp_core_redirect( bp_get_root_domain() );
+				bp_core_redirect( bp_get_root_url() );
 			}
 		}
 

--- a/src/bp-messages/bp-messages-template.php
+++ b/src/bp-messages/bp-messages-template.php
@@ -337,7 +337,14 @@ function bp_message_thread_view_link( $thread_id = 0, $user_id = null ) {
 			$user_id = bp_loggedin_user_id();
 		}
 
-		$domain = bp_members_get_user_url( $user_id );
+		$url = bp_members_get_user_url(
+			$user_id,
+			array(
+				'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_messages', bp_get_messages_slug() ),
+				'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_messages_view', 'view' ),
+				'single_item_action_variables' => array( $thread_id ),
+			)
+		);
 
 		/**
 		 * Filters the permalink of a particular thread.
@@ -346,11 +353,11 @@ function bp_message_thread_view_link( $thread_id = 0, $user_id = null ) {
 		 * @since 2.6.0 Added the `$thread_id` parameter.
 		 * @since 2.9.0 Added the `$user_id` parameter.
 		 *
-		 * @param string $value     Permalink of a particular thread.
+		 * @param string $url       Permalink of a particular thread.
 		 * @param int    $thread_id ID of the thread.
 		 * @param int    $user_id   ID of the user.
 		 */
-		return apply_filters( 'bp_get_message_thread_view_link', trailingslashit( $domain . bp_get_messages_slug() . '/view/' . $thread_id ), $thread_id, $user_id );
+		return apply_filters( 'bp_get_message_thread_view_link', $url, $thread_id, $user_id );
 	}
 
 /**
@@ -382,17 +389,28 @@ function bp_message_thread_delete_link( $user_id = null ) {
 			$user_id = bp_loggedin_user_id();
 		}
 
-		$domain = bp_members_get_user_url( $user_id );
+		$current_action_slug         = bp_current_action();
+		$current_action_rewrite_id   = 'member_messages_' . $current_action_slug;
+		$action_variable_delete_slug = bp_rewrites_get_slug( 'members', $current_action_rewrite_id . '_delete', 'delete' );
+
+		$url = bp_members_get_user_url(
+			$user_id,
+			array(
+				'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_messages', bp_get_messages_slug() ),
+				'single_item_action'           => bp_rewrites_get_slug( 'members', $current_action_rewrite_id, $current_action_slug ),
+				'single_item_action_variables' => array( $action_variable_delete_slug, $messages_template->thread->thread_id ),
+			)
+		);
 
 		/**
 		 * Filters the URL for deleting the current thread.
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param string $value   URL for deleting the current thread.
+		 * @param string $url   URL for deleting the current thread.
 		 * @param int    $user_id ID of the user relative to whom the link should be generated.
 		 */
-		return apply_filters( 'bp_get_message_thread_delete_link', wp_nonce_url( trailingslashit( $domain . bp_get_messages_slug() . '/' . bp_current_action() . '/delete/' . $messages_template->thread->thread_id ), 'messages_delete_thread' ), $user_id );
+		return apply_filters( 'bp_get_message_thread_delete_link', wp_nonce_url( $url, 'messages_delete_thread' ), $user_id );
 	}
 
 /**
@@ -434,10 +452,19 @@ function bp_the_message_thread_mark_unread_url( $user_id = null ) {
 			$user_id = bp_loggedin_user_id();
 		}
 
-		$domain = bp_members_get_user_url( $user_id );
+		$current_action_slug         = bp_current_action();
+		$current_action_rewrite_id   = 'member_messages_' . $current_action_slug;
+		$action_variable_unread_slug = bp_rewrites_get_slug( 'members', $current_action_rewrite_id . '_unread', 'unread' );
 
 		// Base unread URL.
-		$url = trailingslashit( $domain . bp_get_messages_slug() . '/' . bp_current_action() . '/unread' );
+		$url = bp_members_get_user_url(
+			$user_id,
+			array(
+				'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_messages', bp_get_messages_slug() ),
+				'single_item_action'           => bp_rewrites_get_slug( 'members', $current_action_rewrite_id, $current_action_slug ),
+				'single_item_action_variables' => array( $action_variable_unread_slug ),
+			)
+		);
 
 		// Add the args to the URL.
 		$url = add_query_arg( $args, $url );
@@ -496,10 +523,19 @@ function bp_the_message_thread_mark_read_url( $user_id = null ) {
 			$user_id = bp_loggedin_user_id();
 		}
 
-		$domain = bp_members_get_user_url( $user_id );
+		$current_action_slug         = bp_current_action();
+		$current_action_rewrite_id   = 'member_messages_' . $current_action_slug;
+		$action_variable_read_slug = bp_rewrites_get_slug( 'members', $current_action_rewrite_id . '_read', 'read' );
 
 		// Base read URL.
-		$url = trailingslashit( $domain . bp_get_messages_slug() . '/' . bp_current_action() . '/read' );
+		$url = bp_members_get_user_url(
+			$user_id,
+			array(
+				'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_messages', bp_get_messages_slug() ),
+				'single_item_action'           => bp_rewrites_get_slug( 'members', $current_action_rewrite_id, $current_action_slug ),
+				'single_item_action_variables' => array( $action_variable_read_slug ),
+			)
+		);
 
 		// Add the args to the URL.
 		$url = add_query_arg( $args, $url );

--- a/src/bp-notifications/bp-notifications-template.php
+++ b/src/bp-notifications/bp-notifications-template.php
@@ -60,12 +60,14 @@ function bp_notifications_permalink( $user_id = 0 ) {
 	function bp_get_notifications_permalink( $user_id = 0 ) {
 		if ( 0 === $user_id ) {
 			$user_id = bp_loggedin_user_id();
-			$domain  = bp_loggedin_user_domain();
-		} else {
-			$domain = bp_members_get_user_url( (int) $user_id );
 		}
 
-		$retval = trailingslashit( $domain . bp_get_notifications_slug() );
+		$retval = bp_members_get_user_url(
+			$user_id,
+			array(
+				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_notifications', bp_get_notifications_slug() ),
+			)
+		);
 
 		/**
 		 * Filters the notifications permalink.
@@ -101,12 +103,15 @@ function bp_notifications_unread_permalink( $user_id = 0 ) {
 	function bp_get_notifications_unread_permalink( $user_id = 0 ) {
 		if ( 0 === $user_id ) {
 			$user_id = bp_loggedin_user_id();
-			$domain  = bp_loggedin_user_domain();
-		} else {
-			$domain = bp_members_get_user_url( (int) $user_id );
 		}
 
-		$retval = trailingslashit( $domain . bp_get_notifications_slug() . '/unread' );
+		$retval = bp_members_get_user_url(
+			$user_id,
+			array(
+				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_notifications', bp_get_notifications_slug() ),
+				'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_notifications_unread', 'unread' ),
+			)
+		);
 
 		/**
 		 * Filters the unread notifications permalink.
@@ -141,12 +146,15 @@ function bp_notifications_read_permalink( $user_id = 0 ) {
 	function bp_get_notifications_read_permalink( $user_id = 0 ) {
 		if ( 0 === $user_id ) {
 			$user_id = bp_loggedin_user_id();
-			$domain  = bp_loggedin_user_domain();
-		} else {
-			$domain = bp_members_get_user_url( (int) $user_id );
 		}
 
-		$retval = trailingslashit( $domain . bp_get_notifications_slug() . '/read' );
+		$retval = bp_members_get_user_url(
+			$user_id,
+			array(
+				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_notifications', bp_get_notifications_slug() ),
+				'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_notifications_read', 'read' ),
+			)
+		);
 
 		/**
 		 * Filters the read notifications permalink.

--- a/src/bp-settings/actions/delete-account.php
+++ b/src/bp-settings/actions/delete-account.php
@@ -58,7 +58,7 @@ function bp_settings_action_delete_account() {
 		);
 
 		// Redirect to the root domain.
-		bp_core_redirect( bp_get_root_domain() );
+		bp_core_redirect( bp_get_root_url() );
 	}
 }
 add_action( 'bp_actions', 'bp_settings_action_delete_account' );

--- a/src/bp-templates/bp-legacy/buddypress/members/activate.php
+++ b/src/bp-templates/bp-legacy/buddypress/members/activate.php
@@ -47,7 +47,7 @@
 				<p>
 					<?php
 					/* translators: %s: login url */
-					printf( __( 'Your account was activated successfully! You can now <a href="%s">log in</a> with the username and password you provided when you signed up.', 'buddypress' ), wp_login_url( bp_get_root_domain() ) );
+					printf( __( 'Your account was activated successfully! You can now <a href="%s">log in</a> with the username and password you provided when you signed up.', 'buddypress' ), wp_login_url( bp_get_root_url() ) );
 					?>
 				</p>
 			<?php endif; ?>

--- a/src/bp-templates/bp-nouveau/buddypress/members/activate.php
+++ b/src/bp-templates/bp-nouveau/buddypress/members/activate.php
@@ -26,7 +26,7 @@
 			<?php
 			printf(
 				'<p><a href="%1$s">%2$s</a></p>',
-				esc_url( wp_login_url( bp_get_root_domain() ) ),
+				esc_url( wp_login_url( bp_get_root_url() ) ),
 				esc_html__( 'Log In', 'buddypress' )
 			);
 			?>

--- a/src/bp-templates/bp-nouveau/includes/activity/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/template-tags.php
@@ -552,8 +552,22 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 				$data_element = 'href';
 			}
 
+			$spam_link = bp_rewrites_get_url(
+				array(
+					'component_id'                 => 'activity',
+					'single_item_action'           => 'spam',
+					'single_item_action_variables' => array( bp_get_activity_id() ),
+				)
+			);
+
 			$buttons['activity_spam']['button_attr'][ $data_element ] = wp_nonce_url(
-				bp_get_root_domain() . '/' . bp_nouveau_get_component_slug( 'activity' ) . '/spam/' . $activity_id . '/',
+				bp_rewrites_get_url(
+					array(
+						'component_id'                 => 'activity',
+						'single_item_action'           => 'spam',
+						'single_item_action_variables' => array( $activity_id ),
+					)
+				),
 				'bp_activity_akismet_spam_' . $activity_id
 			);
 		}
@@ -881,7 +895,17 @@ function bp_nouveau_activity_comment_buttons( $args = array() ) {
 			}
 
 			$buttons['activity_comment_spam']['button_attr'][ $data_element ] = wp_nonce_url(
-				bp_get_root_domain() . '/' . bp_nouveau_get_component_slug( 'activity' ) . '/spam/' . $activity_comment_id . '/?cid=' . $activity_comment_id,
+				add_query_arg(
+					'cid',
+					$activity_comment_id,
+					bp_rewrites_get_url(
+						array(
+							'component_id'                 => 'activity',
+							'single_item_action'           => 'spam',
+							'single_item_action_variables' => array( $activity_comment_id ),
+						)
+					)
+				),
 				'bp_activity_akismet_spam_' . $activity_comment_id
 			);
 		}

--- a/src/bp-templates/bp-nouveau/includes/blogs/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/blogs/functions.php
@@ -19,7 +19,7 @@ function bp_nouveau_get_blogs_directory_nav_items() {
 		'component' => 'blogs',
 		'slug'      => 'all', // slug is used because BP_Core_Nav requires it, but it's the scope
 		'li_class'  => array( 'selected' ),
-		'link'      => bp_get_root_domain() . '/' . bp_get_blogs_root_slug(),
+		'link'      => bp_get_blogs_directory_url(),
 		'text'      => __( 'All Sites', 'buddypress' ),
 		'count'     => bp_get_total_blog_count(),
 		'position'  => 5,
@@ -43,11 +43,17 @@ function bp_nouveau_get_blogs_directory_nav_items() {
 
 		// If the user can create blogs, add the create nav
 		if ( bp_blog_signup_enabled() ) {
+			$url = bp_get_blogs_directory_url(
+				array(
+					'create_single_item' => 1,
+				)
+			);
+
 			$nav_items['create'] = array(
 				'component' => 'blogs',
 				'slug'      => 'create', // slug is used because BP_Core_Nav requires it, but it's the scope
 				'li_class'  => array( 'no-ajax', 'site-create', 'create-button' ),
-				'link'      => trailingslashit( bp_get_blogs_directory_permalink() . 'create' ),
+				'link'      => $url,
 				'text'      => __( 'Create a Site', 'buddypress' ),
 				'count'     => false,
 				'position'  => 999,

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -295,7 +295,7 @@ class BP_UnitTestCase extends WP_UnitTestCase {
 	 */
 	public function go_to_root() {
 		$blog_1_url = get_blog_option( 1, 'home' );
-		$this->go_to( str_replace( $blog_1_url, '', trailingslashit( bp_get_root_domain() ) ) );
+		$this->go_to( str_replace( $blog_1_url, '', trailingslashit( bp_get_root_url() ) ) );
 	}
 
 	/**

--- a/tests/phpunit/testcases/activity/class.BP_Activity_Activity.php
+++ b/tests/phpunit/testcases/activity/class.BP_Activity_Activity.php
@@ -329,7 +329,7 @@ class BP_Tests_Activity_Class extends BP_UnitTestCase {
 
 		// bp_activity_new_comment() doesn't allow date_recorded
 		$a3 = bp_activity_add( array(
-			'action'            => sprintf( __( '%s posted a new activity comment', 'buddypress' ), bp_get_loggedin_user_link() ) ,
+			'action'            => sprintf( __( '%s posted a new activity comment', 'buddypress' ), bp_loggedin_user_url() ) ,
 			'content'           => 'Candy is good',
 			'component'         => buddypress()->activity->id,
 			'type'              => 'activity_comment',

--- a/tests/phpunit/testcases/activity/notifications.php
+++ b/tests/phpunit/testcases/activity/notifications.php
@@ -388,6 +388,7 @@ class BP_Tests_Activity_Notifications extends BP_UnitTestCase {
 	 * @group bp_activity_comment_reply_add_notification
 	 */
 	public function test_bp_activity_comment_add_notification() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$a = self::factory()->activity->create( array(
 			'user_id' => $this->u1,
 			'component' => buddypress()->activity->id,

--- a/tests/phpunit/testcases/core/functions/bpCoreGetDirectoryPageId.php
+++ b/tests/phpunit/testcases/core/functions/bpCoreGetDirectoryPageId.php
@@ -6,7 +6,20 @@
  * @covers ::bp_core_get_directory_page_id
  */
 class BP_Tests_Core_BpCoreGetDirectoryPageId extends BP_UnitTestCase {
+	protected $permalink_structure = '';
+
+	public function set_up() {
+		parent::set_up();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+		$this->set_permalink_structure( $this->permalink_structure );
+	}
+
 	public function test_should_fall_back_on_current_component() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$this->go_to( bp_get_activity_directory_permalink() );
 
 		$found = bp_core_get_directory_page_id();
@@ -16,6 +29,7 @@ class BP_Tests_Core_BpCoreGetDirectoryPageId extends BP_UnitTestCase {
 	}
 
 	public function test_should_accept_component_override() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$this->go_to( bp_get_activity_directory_permalink() );
 
 		$found = bp_core_get_directory_page_id( 'members' );

--- a/tests/phpunit/testcases/core/nav/backCompat.php
+++ b/tests/phpunit/testcases/core/nav/backCompat.php
@@ -9,16 +9,19 @@
 class BP_Core_Nav_BackCompat extends BP_UnitTestCase {
 	protected $bp_nav;
 	protected $bp_options_nav;
+	protected $permalink_structure = '';
 
 	public function set_up() {
 		parent::set_up();
 		$this->bp_nav = buddypress()->bp_nav;
 		$this->bp_options_nav = buddypress()->bp_options_nav;
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
 	}
 
 	public function tear_down() {
 		buddypress()->bp_nav = $this->bp_nav;
 		buddypress()->bp_options_nav = $this->bp_options_nav;
+		$this->set_permalink_structure( $this->permalink_structure );
 		parent::tear_down();
 	}
 
@@ -45,6 +48,7 @@ class BP_Core_Nav_BackCompat extends BP_UnitTestCase {
 	 * Create a group, set up nav item, and go to the group.
 	 */
 	protected function set_up_group() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g = self::factory()->group->create( array(
 			'slug' => 'testgroup',
 		) );

--- a/tests/phpunit/testcases/core/nav/bpCoreMaybeHookNewSubnavScreenFunction.php
+++ b/tests/phpunit/testcases/core/nav/bpCoreMaybeHookNewSubnavScreenFunction.php
@@ -206,7 +206,7 @@ class BP_Tests_Core_Nav_BpCoreMaybeHookNewSubnavScreenFunction extends BP_UnitTe
 		// Just test relevant info
 		$found = bp_core_maybe_hook_new_subnav_screen_function( $subnav_item );
 		$this->assertSame( 'failure', $found['status'] );
-		$this->assertSame( bp_get_root_domain(), $found['redirect_args']['root'] );
+		$this->assertSame( bp_get_root_url(), $found['redirect_args']['root'] );
 
 		// Clean up
 		$this->set_current_user( $old_current_user );

--- a/tests/phpunit/testcases/core/nav/bpCoreNewNavItem.php
+++ b/tests/phpunit/testcases/core/nav/bpCoreNewNavItem.php
@@ -73,6 +73,7 @@ class BP_Tests_Core_Nav_BpCoreNewNavItem extends BP_UnitTestCase {
 		$g = self::factory()->group->create();
 		$old_current_user = get_current_user_id();
 		$this->set_current_user( $u );
+		$this->set_permalink_structure( '/%postname%/' );
 
 		$group = groups_get_group( $g );
 

--- a/tests/phpunit/testcases/groups/class-bp-group-extension.php
+++ b/tests/phpunit/testcases/groups/class-bp-group-extension.php
@@ -7,6 +7,18 @@ include_once BP_TESTS_DIR . '/assets/group-extensions.php';
  * @group BP_Group_Extension
  */
 class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
+	protected $permalink_structure = '';
+
+	public function set_up() {
+		parent::set_up();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+		$this->set_permalink_structure( $this->permalink_structure );
+	}
+
 	public function test_parse_legacy_properties() {
 		$class_name = 'BPTest_Group_Extension_Parse_Legacy_Properties';
 		$class_slug = sanitize_title( $class_name );
@@ -221,6 +233,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 */
 	public function test_enable_nav_item_true() {
 		$old_options_nav = buddypress()->bp_options_nav;
+		$this->set_permalink_structure( '/%postname%/' );
 
 		$g = self::factory()->group->create();
 		$g_obj = groups_get_group( $g );
@@ -243,6 +256,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @expectedIncorrectUsage bp_nav
 	 */
 	public function test_enable_nav_item_false() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$old_options_nav = buddypress()->bp_options_nav;
 
 		$g = self::factory()->group->create();
@@ -266,6 +280,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @expectedIncorrectUsage bp_nav
 	 */
 	public function test_visibility_private() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$old_options_nav = buddypress()->bp_options_nav;
 		$old_current_user = get_current_user_id();
 
@@ -310,6 +325,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @see https://buddypress.trac.wordpress.org/ticket/4785
 	 */
 	public function test_visibility_public() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$old_options_nav = buddypress()->bp_options_nav;
 		$old_current_user = get_current_user_id();
 
@@ -347,6 +363,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @group user_can_visit
 	 */
 	public function test_user_can_visit_inferred_from_enable_nav_item() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$old_current_user = get_current_user_id();
 
 		$g = self::factory()->group->create( array(
@@ -372,6 +389,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @group user_can_visit
 	 */
 	public function test_user_can_visit_explicit_for_logged_out_user() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$old_current_user = get_current_user_id();
 		$this->set_current_user( 0 );
 
@@ -412,6 +430,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @group user_can_visit
 	 */
 	public function test_user_can_visit_explicit_for_logged_in_user() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g = self::factory()->group->create( array(
 			'status' => 'public',
 		) );
@@ -454,6 +473,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @group user_can_visit
 	 */
 	public function test_user_can_visit_explicit_for_group_member() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g = self::factory()->group->create( array(
 			'status' => 'public',
 		) );
@@ -498,6 +518,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @group user_can_visit
 	 */
 	public function test_user_can_visit_explicit_for_group_mod() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g = self::factory()->group->create( array(
 			'status' => 'public',
 		) );
@@ -544,6 +565,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @group user_can_visit
 	 */
 	public function test_user_can_visit_explicit_for_group_admin() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g = self::factory()->group->create( array(
 			'status' => 'public',
 		) );
@@ -590,6 +612,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @group user_can_see_nav_item
 	 */
 	public function test_user_can_see_nav_item_implied() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g = self::factory()->group->create( array(
 			'status' => 'public',
 		) );
@@ -631,6 +654,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @group user_can_see_nav_item
 	 */
 	public function test_user_can_see_nav_item_explicit_for_logged_out_user() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g = self::factory()->group->create( array(
 			'status' => 'public',
 		) );
@@ -672,6 +696,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @group user_can_see_nav_item
 	 */
 	public function test_user_can_see_nav_item_explicit_for_logged_in_user() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g = self::factory()->group->create( array(
 			'status' => 'public',
 		) );
@@ -714,6 +739,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @group user_can_see_nav_item
 	 */
 	public function test_user_can_see_nav_item_explicit_for_group_member() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g = self::factory()->group->create( array(
 			'status' => 'public',
 		) );
@@ -758,6 +784,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @group user_can_see_nav_item
 	 */
 	public function test_user_can_see_nav_item_explicit_for_group_mod() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g = self::factory()->group->create( array(
 			'status' => 'public',
 		) );
@@ -804,6 +831,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @group user_can_see_nav_item
 	 */
 	public function test_user_can_see_nav_item_explicit_for_group_admin() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g = self::factory()->group->create( array(
 			'status' => 'public',
 		) );
@@ -850,6 +878,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @ticket BP7131
 	 */
 	public function test_widget_on_group_home_page() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g = self::factory()->group->create( array(
 			'status' => 'public',
 		) );
@@ -871,6 +900,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @ticket BP7131
 	 */
 	public function test_widget_on_group_members_page() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$g = self::factory()->group->create( array(
 			'status' => 'public',
 		) );
@@ -892,6 +922,7 @@ class BP_Tests_Group_Extension_TestCases extends BP_UnitTestCase {
 	 * @ticket BP8558
 	 */
 	public function test_adding_multiple_extension_classes() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$old_options_nav = buddypress()->bp_options_nav;
 
 		$g = self::factory()->group->create();

--- a/tests/phpunit/testcases/groups/class-bp-groups-member.php
+++ b/tests/phpunit/testcases/groups/class-bp-groups-member.php
@@ -6,6 +6,17 @@
 class BP_Tests_BP_Groups_Member_TestCases extends BP_UnitTestCase {
 	static public $user_ids;
 	static public $group_ids;
+	protected $permalink_structure = '';
+
+	public function set_up() {
+		parent::set_up();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+		$this->set_permalink_structure( $this->permalink_structure );
+	}
 
 	public static function wpSetUpBeforeClass( $factory ) {
 		global $wpdb, $bp;
@@ -160,6 +171,7 @@ class BP_Tests_BP_Groups_Member_TestCases extends BP_UnitTestCase {
 	 * @group bp_groups_user_can_send_invites
 	 */
 	public function test_bp_groups_user_can_send_invites() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$u_nonmembers = self::factory()->user->create();
 		$u_members    = self::factory()->user->create();
 		$u_mods       = self::factory()->user->create();

--- a/tests/phpunit/testcases/members/template/bpGetMemberTypeDirectoryPermalink.php
+++ b/tests/phpunit/testcases/members/template/bpGetMemberTypeDirectoryPermalink.php
@@ -5,16 +5,27 @@
  * @group member_types
  */
 class BP_Tests_Members_Template_BpGetMemberTypeDirectoryPermalink extends BP_UnitTestCase {
+	protected $permalink_structure = '';
+
 	public function set_up() {
 		parent::set_up();
 
 		buddypress()->members->types = array();
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+
+		$this->set_permalink_structure( $this->permalink_structure );
 	}
 
 	/**
 	 * @ticket BP6840
 	 */
 	public function test_should_default_to_current_member_type() {
+		$this->set_permalink_structure( '/%postname%/' );
+
 		bp_register_member_type( 'foo', array(
 			'has_directory' => true,
 		) );
@@ -30,6 +41,8 @@ class BP_Tests_Members_Template_BpGetMemberTypeDirectoryPermalink extends BP_Uni
 	 * @ticket BP6840
 	 */
 	public function test_member_type_param_should_override_current_member_type() {
+		$this->set_permalink_structure( '/%postname%/' );
+
 		bp_register_member_type( 'foo', array(
 			'has_directory' => true,
 		) );
@@ -70,6 +83,8 @@ class BP_Tests_Members_Template_BpGetMemberTypeDirectoryPermalink extends BP_Uni
 	 * @ticket BP6840
 	 */
 	public function test_successful_format() {
+		$this->set_permalink_structure( '/%postname%/' );
+
 		bp_register_member_type( 'foo', array(
 			'has_directory' => true,
 		) );


### PR DESCRIPTION
- Improve the Members component adding permastructs and custom rewrite rules for registration and activation pages.
- Improve the Blogs component adding custom rewrite rule to handle the Blogs create page.
- Make a huge progress about replacing all occurrences of `bp_get_root_domain()` (45 replacements were performed). There might be some last ones inside PHPUnit tests.
- Deprecate `bp_displayed_user_domain()`, `bp_loggedin_user_domain()`, `bp_groups_directory_permalink()`, `bp_get_groups_directory_permalink()`,  `bp_blogs_directory_permalink()` & `bp_get_blogs_directory_permalink()` and replace them with these new functions: `bp_displayed_user_url()`, `bp_loggedin_user_url()`, `bp_groups_directory_url()`, `bp_get_groups_directory_url()`, `bp_blogs_directory_url()` & `bp_get_blogs_directory_url()`. These deprecations are required because these functions were used to build some BuddyPress URLs concatenating URL chunks.
- Start replacing `bp_loggedin_user_domain()` & `bp_displayed_user_domain()` with the new functions.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/4954

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
