### PR TITLE
Introduce a new `$metadata` arg to the supported BP Blocks registration args

### DIFF
--- a/src/bp-core/bp-core-blocks.php
+++ b/src/bp-core/bp-core-blocks.php
@@ -161,6 +161,16 @@ add_filter( 'block_editor_rest_api_preload_paths', 'bp_blocks_preload_paths' );
  * @return BP_Block   The BuddyPress block type object.
  */
 function bp_register_block( $args = array() ) {
+	if ( isset( $args['metadata'] ) && is_string( $args['metadata'] ) && file_exists( $args['metadata'] ) ) {
+		$callback = array();
+
+		if ( isset( $args['render_callback'] ) ) {
+			$callback['render_callback'] = $args['render_callback'];
+		}
+
+		return register_block_type_from_metadata( $args['metadata'], $callback );
+	}
+
 	return new BP_Block( $args );
 }
 


### PR DESCRIPTION
This `$metadata` argument will be used to determine whether or not to use the v2 of the WP Block API.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8855

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
