### PR TITLE
BP Rewrites 9th step

### DIFF
--- a/src/bp-activity/actions/feeds.php
+++ b/src/bp-activity/actions/feeds.php
@@ -24,15 +24,17 @@ function bp_activity_action_sitewide_feed() {
 	$link = bp_get_activity_directory_permalink();
 
 	// Setup the feed.
-	buddypress()->activity->feed = new BP_Activity_Feed( array(
-		'id'            => 'sitewide',
+	buddypress()->activity->feed = new BP_Activity_Feed(
+		array(
+			'id'            => 'sitewide',
 
-		/* translators: %s Site Name */
-		'title'         => sprintf( __( '%s | Site-Wide Activity', 'buddypress' ), bp_get_site_name() ),
-		'link'          => $link,
-		'description'   => __( 'Activity feed for the entire site.', 'buddypress' ),
-		'activity_args' => 'display_comments=threaded'
-	) );
+			/* translators: %s Site Name */
+			'title'         => sprintf( __( '%s | Site-Wide Activity', 'buddypress' ), bp_get_site_name() ),
+			'link'          => $link,
+			'description'   => __( 'Activity feed for the entire site.', 'buddypress' ),
+			'activity_args' => 'display_comments=threaded'
+		)
+	);
 
 	if ( ! buddypress()->activity->feed->enabled ) {
 		bp_core_redirect( $link );
@@ -52,20 +54,27 @@ function bp_activity_action_personal_feed() {
 		return false;
 	}
 
-	$link = trailingslashit( bp_displayed_user_domain() . bp_get_activity_slug() );
+	$activity_slug = bp_get_activity_slug();
+	$link          = bp_displayed_user_url(
+		array(
+			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
+		)
+	);
 
 	// Setup the feed.
-	buddypress()->activity->feed = new BP_Activity_Feed( array(
-		'id'            => 'personal',
+	buddypress()->activity->feed = new BP_Activity_Feed(
+		array(
+			'id'            => 'personal',
 
-		/* translators: 1: Site Name. 2: User Display Name. */
-		'title'         => sprintf( _x( '%1$s | %2$s | Activity', 'Personal activity feed title', 'buddypress' ), bp_get_site_name(), bp_get_displayed_user_fullname() ),
-		'link'          => $link,
+			/* translators: 1: Site Name. 2: User Display Name. */
+			'title'         => sprintf( _x( '%1$s | %2$s | Activity', 'Personal activity feed title', 'buddypress' ), bp_get_site_name(), bp_get_displayed_user_fullname() ),
+			'link'          => $link,
 
-		/* translators: %s: User Display Name */
-		'description'   => sprintf( __( 'Activity feed for %s.', 'buddypress' ), bp_get_displayed_user_fullname() ),
-		'activity_args' => 'user_id=' . bp_displayed_user_id()
-	) );
+			/* translators: %s: User Display Name */
+			'description'   => sprintf( __( 'Activity feed for %s.', 'buddypress' ), bp_get_displayed_user_fullname() ),
+			'activity_args' => 'user_id=' . bp_displayed_user_id()
+		)
+	);
 
 	if ( ! buddypress()->activity->feed->enabled ) {
 		bp_core_redirect( $link );
@@ -85,20 +94,29 @@ function bp_activity_action_friends_feed() {
 		return false;
 	}
 
-	$link = trailingslashit( bp_displayed_user_domain() . bp_get_activity_slug() . '/' . bp_get_friends_slug() );
+	$activity_slug = bp_get_activity_slug();
+	$friends_slug  = bp_get_friends_slug();
+	$link          = bp_displayed_user_url(
+		array(
+			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
+			'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_' . $friends_slug, $friends_slug ),
+		)
+	);
 
 	// Setup the feed.
-	buddypress()->activity->feed = new BP_Activity_Feed( array(
-		'id'            => 'friends',
+	buddypress()->activity->feed = new BP_Activity_Feed(
+		array(
+			'id'            => 'friends',
 
-		/* translators: 1: Site Name 2: User Display Name */
-		'title'         => sprintf( __( '%1$s | %2$s | Friends Activity', 'buddypress' ), bp_get_site_name(), bp_get_displayed_user_fullname() ),
-		'link'          => $link,
+			/* translators: 1: Site Name 2: User Display Name */
+			'title'         => sprintf( __( '%1$s | %2$s | Friends Activity', 'buddypress' ), bp_get_site_name(), bp_get_displayed_user_fullname() ),
+			'link'          => $link,
 
-		/* translators: %s: User Display Name */
-		'description'   => sprintf( __( "Activity feed for %s's friends.", 'buddypress' ), bp_get_displayed_user_fullname() ),
-		'activity_args' => 'scope=friends'
-	) );
+			/* translators: %s: User Display Name */
+			'description'   => sprintf( __( "Activity feed for %s's friends.", 'buddypress' ), bp_get_displayed_user_fullname() ),
+			'activity_args' => 'scope=friends'
+		)
+	);
 
 	if ( ! buddypress()->activity->feed->enabled ) {
 		bp_core_redirect( $link );
@@ -119,26 +137,35 @@ function bp_activity_action_my_groups_feed() {
 	}
 
 	// Get displayed user's group IDs.
-	$groups    = groups_get_user_groups();
-	$group_ids = implode( ',', $groups['groups'] );
-	$link      = trailingslashit( bp_displayed_user_domain() . bp_get_activity_slug() . '/' . bp_get_groups_slug() );
+	$groups        = groups_get_user_groups();
+	$group_ids     = implode( ',', $groups['groups'] );
+	$activity_slug = bp_get_activity_slug();
+	$groups_slug   = bp_get_groups_slug();
+	$link          = bp_displayed_user_url(
+		array(
+			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
+			'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_' . $groups_slug, $groups_slug ),
+		)
+	);
 
 	// Setup the feed.
-	buddypress()->activity->feed = new BP_Activity_Feed( array(
-		'id'            => 'mygroups',
+	buddypress()->activity->feed = new BP_Activity_Feed(
+		array(
+			'id'            => 'mygroups',
 
-		/* translators: 1: Site Name 2: User Display Name */
-		'title'         => sprintf( __( '%1$s | %2$s | Group Activity', 'buddypress' ), bp_get_site_name(), bp_get_displayed_user_fullname() ),
-		'link'          => $link,
+			/* translators: 1: Site Name 2: User Display Name */
+			'title'         => sprintf( __( '%1$s | %2$s | Group Activity', 'buddypress' ), bp_get_site_name(), bp_get_displayed_user_fullname() ),
+			'link'          => $link,
 
-		/* translators: %s: User Display Name */
-		'description'   => sprintf( __( "Public group activity feed of which %s is a member.", 'buddypress' ), bp_get_displayed_user_fullname() ),
-		'activity_args' => array(
-			'object'           => buddypress()->groups->id,
-			'primary_id'       => $group_ids,
-			'display_comments' => 'threaded'
+			/* translators: %s: User Display Name */
+			'description'   => sprintf( __( 'Public group activity feed of which %s is a member.', 'buddypress' ), bp_get_displayed_user_fullname() ),
+			'activity_args' => array(
+				'object'           => buddypress()->groups->id,
+				'primary_id'       => $group_ids,
+				'display_comments' => 'threaded'
+			)
 		)
-	) );
+	);
 
 	if ( ! buddypress()->activity->feed->enabled ) {
 		bp_core_redirect( $link );
@@ -162,22 +189,30 @@ function bp_activity_action_mentions_feed() {
 		return false;
 	}
 
-	$link = trailingslashit( bp_displayed_user_domain() . bp_get_activity_slug() . '/mentions' );
+	$activity_slug = bp_get_activity_slug();
+	$link          = bp_displayed_user_url(
+		array(
+			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
+			'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_mentions', 'mentions' ),
+		)
+	);
 
 	// Setup the feed.
-	buddypress()->activity->feed = new BP_Activity_Feed( array(
-		'id'            => 'mentions',
+	buddypress()->activity->feed = new BP_Activity_Feed(
+		array(
+			'id'            => 'mentions',
 
-		/* translators: 1: Site Name 2: User Display Name */
-		'title'         => sprintf( __( '%1$s | %2$s | Mentions', 'buddypress' ), bp_get_site_name(), bp_get_displayed_user_fullname() ),
-		'link'          => $link,
+			/* translators: 1: Site Name 2: User Display Name */
+			'title'         => sprintf( __( '%1$s | %2$s | Mentions', 'buddypress' ), bp_get_site_name(), bp_get_displayed_user_fullname() ),
+			'link'          => $link,
 
-		/* translators: %s: User Display Name */
-		'description'   => sprintf( __( "Activity feed mentioning %s.", 'buddypress' ), bp_get_displayed_user_fullname() ),
-		'activity_args' => array(
-			'search_terms' => '@' . bp_members_get_user_slug( bp_displayed_user_id() )
+			/* translators: %s: User Display Name */
+			'description'   => sprintf( __( "Activity feed mentioning %s.", 'buddypress' ), bp_get_displayed_user_fullname() ),
+			'activity_args' => array(
+				'search_terms' => '@' . bp_members_get_user_slug( bp_displayed_user_id() )
+			)
 		)
-	) );
+	);
 
 	if ( ! buddypress()->activity->feed->enabled ) {
 		bp_core_redirect( $link );
@@ -198,22 +233,30 @@ function bp_activity_action_favorites_feed() {
 	}
 
 	// Get displayed user's favorite activity IDs.
-	$favs    = bp_activity_get_user_favorites( bp_displayed_user_id() );
-	$fav_ids = implode( ',', (array) $favs );
-	$link    = trailingslashit( bp_displayed_user_domain() . bp_get_activity_slug() . '/favorites' );
+	$favs          = bp_activity_get_user_favorites( bp_displayed_user_id() );
+	$fav_ids       = implode( ',', (array) $favs );
+	$activity_slug = bp_get_activity_slug();
+	$link          = bp_displayed_user_url(
+		array(
+			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
+			'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_favorites', 'favorites' ),
+		)
+	);
 
 	// Setup the feed.
-	buddypress()->activity->feed = new BP_Activity_Feed( array(
-		'id'            => 'favorites',
+	buddypress()->activity->feed = new BP_Activity_Feed(
+		array(
+			'id'            => 'favorites',
 
-		/* translators: 1: Site Name 2: User Display Name */
-		'title'         => sprintf( __( '%1$s | %2$s | Favorites', 'buddypress' ), bp_get_site_name(), bp_get_displayed_user_fullname() ),
-		'link'          => $link,
+			/* translators: 1: Site Name 2: User Display Name */
+			'title'         => sprintf( __( '%1$s | %2$s | Favorites', 'buddypress' ), bp_get_site_name(), bp_get_displayed_user_fullname() ),
+			'link'          => $link,
 
-		/* translators: %s: User Display Name */
-		'description'   => sprintf( __( "Activity feed of %s's favorites.", 'buddypress' ), bp_get_displayed_user_fullname() ),
-		'activity_args' => 'include=' . $fav_ids
-	) );
+			/* translators: %s: User Display Name */
+			'description'   => sprintf( __( "Activity feed of %s's favorites.", 'buddypress' ), bp_get_displayed_user_fullname() ),
+			'activity_args' => 'include=' . $fav_ids
+		)
+	);
 
 	if ( ! buddypress()->activity->feed->enabled ) {
 		bp_core_redirect( $link );

--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -3908,52 +3908,54 @@ function bp_sitewide_activity_feed_link() {
  * Output the member activity feed link.
  *
  * @since 1.2.0
- *
  */
 function bp_member_activity_feed_link() {
-	echo bp_get_member_activity_feed_link();
+	echo esc_url( bp_get_member_activity_feed_link() );
 }
-
-/**
- * Output the member activity feed link.
- *
- * @since 1.0.0
- * @deprecated 1.2.0
- *
- * @todo properly deprecate in favor of bp_member_activity_feed_link().
- *
- */
-function bp_activities_member_rss_link() { echo bp_get_member_activity_feed_link(); }
 
 	/**
 	 * Return the member activity feed link.
 	 *
 	 * @since 1.2.0
 	 *
-	 *
 	 * @return string $link The member activity feed link.
 	 */
 	function bp_get_member_activity_feed_link() {
+		$activity_slug = bp_get_activity_slug();
+		$path_chunks   = array(
+			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
+		);
 
 		// Single member activity feed link.
 		if ( bp_is_profile_component() || bp_is_current_action( 'just-me' ) ) {
-			$link = bp_displayed_user_domain() . bp_get_activity_slug() . '/feed/';
+			$path_chunks['single_item_action'] = 'feed';
+			$link                              = bp_displayed_user_url( $path_chunks );
 
 		// Friend feed link.
 		} elseif ( bp_is_active( 'friends' ) && bp_is_current_action( bp_get_friends_slug() ) ) {
-			$link = bp_displayed_user_domain() . bp_get_activity_slug() . '/' . bp_get_friends_slug() . '/feed/';
+			$friends_slug                                = bp_get_friends_slug();
+			$path_chunks['single_item_action']           = bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_' . $friends_slug, $friends_slug );
+			$path_chunks['single_item_action_variables'] = array( 'feed' );
+			$link                                        = bp_displayed_user_url( $path_chunks );
 
 		// Group feed link.
 		} elseif ( bp_is_active( 'groups'  ) && bp_is_current_action( bp_get_groups_slug()  ) ) {
-			$link = bp_displayed_user_domain() . bp_get_activity_slug() . '/' . bp_get_groups_slug() . '/feed/';
+			$groups_slug                                 = bp_get_groups_slug();
+			$path_chunks['single_item_action']           = bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_' . $groups_slug, $groups_slug );
+			$path_chunks['single_item_action_variables'] = array( 'feed' );
+			$link                                        = bp_displayed_user_url( $path_chunks );
 
 		// Favorites activity feed link.
 		} elseif ( 'favorites' === bp_current_action() ) {
-			$link = bp_displayed_user_domain() . bp_get_activity_slug() . '/favorites/feed/';
+			$path_chunks['single_item_action']           = bp_rewrites_get_slug( 'members', 'member_'  . $activity_slug . '_favorites', 'favorites' );
+			$path_chunks['single_item_action_variables'] = array( 'feed' );
+			$link                                        = bp_displayed_user_url( $path_chunks );
 
 		// Mentions activity feed link.
 		} elseif ( ( 'mentions' === bp_current_action() ) && bp_activity_do_mentions() ) {
-			$link = bp_displayed_user_domain() . bp_get_activity_slug() . '/mentions/feed/';
+			$path_chunks['single_item_action']           = bp_rewrites_get_slug( 'members', 'member_'  . $activity_slug . '_mentions', 'mentions' );
+			$path_chunks['single_item_action_variables'] = array( 'feed' );
+			$link                                        = bp_displayed_user_url( $path_chunks );
 
 		// No feed link.
 		} else {

--- a/src/bp-blogs/bp-blogs-template.php
+++ b/src/bp-blogs/bp-blogs-template.php
@@ -1386,56 +1386,9 @@ function bp_create_blog_link() {
 }
 
 /**
- * Output navigation tabs for a user Blogs page.
- *
- * Currently unused by BuddyPress.
- */
-function bp_blogs_blog_tabs() {
-
-	// Don't show these tabs on a user's own profile.
-	if ( bp_is_my_profile() ) {
-		return false;
-	} ?>
-
-	<ul class="content-header-nav">
-		<li<?php if ( bp_is_current_action( 'my-blogs' ) || !bp_current_action() ) : ?> class="current"<?php endif; ?>>
-			<a href="<?php echo trailingslashit( bp_displayed_user_domain() . bp_get_blogs_slug() . '/my-blogs' ); ?>">
-				<?php
-				/* translators: %s: the User Display Name */
-				printf( __( "%s's Sites", 'buddypress' ), bp_get_displayed_user_fullname() );
-				?>
-			</a>
-		</li>
-		<li<?php if ( bp_is_current_action( 'recent-posts' ) ) : ?> class="current"<?php endif; ?>>
-			<a href="<?php echo trailingslashit( bp_displayed_user_domain() . bp_get_blogs_slug() . '/recent-posts'    ); ?>">
-				<?php
-				/* translators: %s: the User Display Name */
-				printf( __( "%s's Recent Posts", 'buddypress' ), bp_get_displayed_user_fullname() );
-				?>
-			</a>
-		</li>
-		<li<?php if ( bp_is_current_action( 'recent-comments' ) ) : ?> class="current"<?php endif; ?>>
-			<a href="<?php echo trailingslashit( bp_displayed_user_domain() . bp_get_blogs_slug() . '/recent-comments' ); ?>">
-				<?php
-				/* translators: %s: the User Display Name */
-				printf( __( "%s's Recent Comments", 'buddypress' ), bp_get_displayed_user_fullname() );
-				?>
-			</a>
-		</li>
-	</ul>
-
-<?php
-
-	/**
-	 * Fires after the markup for the navigation tabs for a user Blogs page.
-	 *
-	 * @since 1.0.0
-	 */
-	do_action( 'bp_blogs_blog_tabs' );
-}
-
-/**
  * Output the blog directory search form.
+ *
+ * @since 1.9.0
  */
 function bp_directory_blogs_search_form() {
 

--- a/src/bp-core/bp-core-buddybar.php
+++ b/src/bp-core/bp-core-buddybar.php
@@ -750,7 +750,7 @@ function bp_core_maybe_hook_new_subnav_screen_function( $subnav_item, $component
 				// publicly accessible.
 				if ( bp_is_my_profile() || ( isset( $parent_nav_default_item ) && $parent_nav_default_item->show_for_displayed_user ) ) {
 					$message     = __( 'You do not have access to that page.', 'buddypress' );
-					$redirect_to = bp_displayed_user_domain();
+					$redirect_to = bp_displayed_user_url();
 
 				// In some cases, the default tab is not accessible to
 				// the logged-in user. So we fall back on a tab that we
@@ -758,13 +758,23 @@ function bp_core_maybe_hook_new_subnav_screen_function( $subnav_item, $component
 				} else {
 					// Try 'activity' first.
 					if ( bp_is_active( 'activity' ) && isset( $bp->pages->activity ) ) {
-						$redirect_to = trailingslashit( bp_displayed_user_domain() . bp_get_activity_slug() );
+						$activity_slug = bp_get_activity_slug();
+						$redirect_to   = bp_displayed_user_url(
+							array(
+								'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
+							)
+						);
 					// Then try 'profile'.
 					} else {
-						$redirect_to = trailingslashit( bp_displayed_user_domain() . ( 'xprofile' == $bp->profile->id ? 'profile' : $bp->profile->id ) );
+						$profile_slug  = bp_get_profile_slug();
+						$redirect_to   = bp_displayed_user_url(
+							array(
+								'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug, $profile_slug ),
+							)
+						);
 					}
 
-					$message     = '';
+					$message = '';
 				}
 
 			// Fall back to the home page.

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -3204,7 +3204,7 @@ function bp_get_title_parts( $seplocation = 'right' ) {
 		}
 
 		// If on the user profile's landing page, just use the fullname.
-		if ( bp_is_current_component( $bp->default_component ) && ( bp_get_requested_url() === bbp_displayed_user_url() ) ) {
+		if ( bp_is_current_component( $bp->default_component ) && ( bp_get_requested_url() === bp_displayed_user_url() ) ) {
 			$bp_title_parts[] = $displayed_user_name;
 
 		// Use component name on member pages.

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -3204,7 +3204,7 @@ function bp_get_title_parts( $seplocation = 'right' ) {
 		}
 
 		// If on the user profile's landing page, just use the fullname.
-		if ( bp_is_current_component( $bp->default_component ) && ( bp_get_requested_url() === bp_displayed_user_domain() ) ) {
+		if ( bp_is_current_component( $bp->default_component ) && ( bp_get_requested_url() === bbp_displayed_user_url() ) ) {
 			$bp_title_parts[] = $displayed_user_name;
 
 		// Use component name on member pages.

--- a/src/bp-core/deprecated/1.2.php
+++ b/src/bp-core/deprecated/1.2.php
@@ -52,4 +52,13 @@ function bp_activity_get_sitewide( $args = '' ) {
 	return apply_filters( 'bp_activity_get_sitewide', BP_Activity_Activity::get( $args ), $r );
 }
 
-
+/**
+ * Output the member activity feed link.
+ *
+ * @since 1.0.0
+ * @deprecated 1.2.0
+ */
+function bp_activities_member_rss_link() {
+	_deprecated_function( __FUNCTION__, '1.2', 'bp_member_activity_feed_link()' );
+	bp_member_activity_feed_link();
+}

--- a/src/bp-core/deprecated/12.0.php
+++ b/src/bp-core/deprecated/12.0.php
@@ -342,3 +342,83 @@ function bp_nouveau_group_creation_tabs() {
 	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_group_creation_tabs()' );
 	bp_group_creation_tabs();
 }
+
+/**
+ * Displays group header tabs.
+ *
+ * @since 1.0.0
+ * @deprecated 12.0.0
+ */
+function bp_groups_header_tabs() {
+	_deprecated_function( __FUNCTION__, '12.0.0' );
+	$user_groups = bp_displayed_user_url() . bp_get_groups_slug(); ?>
+
+	<li<?php if ( !bp_action_variable( 0 ) || bp_is_action_variable( 'recently-active', 0 ) ) : ?> class="current"<?php endif; ?>><a href="<?php echo trailingslashit( $user_groups . '/my-groups/recently-active' ); ?>"><?php _e( 'Recently Active', 'buddypress' ); ?></a></li>
+	<li<?php if ( bp_is_action_variable( 'recently-joined', 0 ) ) : ?> class="current"<?php endif; ?>><a href="<?php echo trailingslashit( $user_groups . '/my-groups/recently-joined' ); ?>"><?php _e( 'Recently Joined',  'buddypress' ); ?></a></li>
+	<li<?php if ( bp_is_action_variable( 'most-popular',    0 ) ) : ?> class="current"<?php endif; ?>><a href="<?php echo trailingslashit( $user_groups . '/my-groups/most-popular'    ); ?>"><?php _e( 'Most Popular',     'buddypress' ); ?></a></li>
+	<li<?php if ( bp_is_action_variable( 'admin-of',        0 ) ) : ?> class="current"<?php endif; ?>><a href="<?php echo trailingslashit( $user_groups . '/my-groups/admin-of'        ); ?>"><?php _e( 'Administrator Of', 'buddypress' ); ?></a></li>
+	<li<?php if ( bp_is_action_variable( 'mod-of',          0 ) ) : ?> class="current"<?php endif; ?>><a href="<?php echo trailingslashit( $user_groups . '/my-groups/mod-of'          ); ?>"><?php _e( 'Moderator Of',     'buddypress' ); ?></a></li>
+	<li<?php if ( bp_is_action_variable( 'alphabetically'     ) ) : ?> class="current"<?php endif; ?>><a href="<?php echo trailingslashit( $user_groups . '/my-groups/alphabetically'  ); ?>"><?php _e( 'Alphabetically',   'buddypress' ); ?></a></li>
+
+<?php
+	/**
+	 * Fires after the markup for the navigation tabs for a user Groups page.
+	 *
+	 * @since 1.0.0
+	 * @deprecated 12.0.0
+	 */
+	do_action_deprecated( 'groups_header_tabs', array(), '12.0.0' );
+}
+
+/**
+ * Output navigation tabs for a user Blogs page.
+ *
+ * Currently unused by BuddyPress.
+ *
+ * @since 1.0.0
+ * @deprecated 12.0.0
+ */
+function bp_blogs_blog_tabs() {
+
+	// Don't show these tabs on a user's own profile.
+	if ( bp_is_my_profile() ) {
+		return false;
+	} ?>
+
+	<ul class="content-header-nav">
+		<li<?php if ( bp_is_current_action( 'my-blogs' ) || !bp_current_action() ) : ?> class="current"<?php endif; ?>>
+			<a href="<?php bp_displayed_user_link( array( bp_get_blogs_slug(), 'my-blogs' ) ); ?>">
+				<?php
+				/* translators: %s: the User Display Name */
+				printf( esc_html__( "%s's Sites", 'buddypress' ), bp_get_displayed_user_fullname() );
+				?>
+			</a>
+		</li>
+		<li<?php if ( bp_is_current_action( 'recent-posts' ) ) : ?> class="current"<?php endif; ?>>
+			<a href="<?php bp_displayed_user_link( array( bp_get_blogs_slug(), 'recent-posts' ) ); ?>">
+				<?php
+				/* translators: %s: the User Display Name */
+				printf( esc_html__( "%s's Recent Posts", 'buddypress' ), bp_get_displayed_user_fullname() );
+				?>
+			</a>
+		</li>
+		<li<?php if ( bp_is_current_action( 'recent-comments' ) ) : ?> class="current"<?php endif; ?>>
+			<a href="<?php bp_displayed_user_link( array( bp_get_blogs_slug(), 'recent-comments' ) ); ?>">
+				<?php
+				/* translators: %s: the User Display Name */
+				printf( esc_html__( "%s's Recent Comments", 'buddypress' ), bp_get_displayed_user_fullname() );
+				?>
+			</a>
+		</li>
+	</ul>
+
+<?php
+
+	/**
+	 * Fires after the markup for the navigation tabs for a user Blogs page.
+	 *
+	 * @since 1.0.0
+	 * @deprecated 12.0.0
+	 */
+	do_action_deprecated( 'bp_blogs_blog_tabs', array(), '12.0.0' );
+}

--- a/src/bp-friends/bp-friends-template.php
+++ b/src/bp-friends/bp-friends-template.php
@@ -88,7 +88,7 @@ function bp_friends_random_friends() {
 			(<?php echo BP_Friends_Friendship::total_friend_count( bp_displayed_user_id() ); ?>)
 			&nbsp;
 			<span>
-				<a href="<?php echo trailingslashit( bp_displayed_user_domain() . bp_get_friends_slug() ) ?>">
+				<a href="<?php bp_displayed_user_link( array( bp_get_friends_slug() ) ); ?>">
 					<?php esc_html_e( 'See All', 'buddypress' ) ?>
 				</a>
 			</span>
@@ -202,14 +202,21 @@ function bp_friends_random_members( $total_members = 5 ) {
  * @todo Deprecate
  */
 function bp_friend_search_form() {
+	$label        = __( 'Filter Friends', 'buddypress' );
+	$friends_slug = bp_get_friends_slug();
+	$action       = bp_displayed_user_url(
+		array(
+			'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug, $friends_slug ),
+			'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_my_friends', 'my-friends' ),
+			'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_search', 'search' ) ),
+		)
+	);
+	?>
 
-	$action = bp_displayed_user_domain() . bp_get_friends_slug() . '/my-friends/search/';
-	$label  = __( 'Filter Friends', 'buddypress' ); ?>
+		<form action="<?php echo esc_url( $action ) ?>" id="friend-search-form" method="post">
 
-		<form action="<?php echo $action ?>" id="friend-search-form" method="post">
-
-			<label for="friend-search-box" id="friend-search-label"><?php echo $label ?></label>
-			<input type="search" name="friend-search-box" id="friend-search-box" value="<?php echo $value ?>"<?php echo $disabled ?> />
+			<label for="friend-search-box" id="friend-search-label"><?php echo esc_html( $label ); ?></label>
+			<input type="search" name="friend-search-box" id="friend-search-box" value="" />
 
 			<?php wp_nonce_field( 'friends_search', '_wpnonce_friend_search' ) ?>
 

--- a/src/bp-friends/classes/class-bp-core-friends-widget.php
+++ b/src/bp-friends/classes/class-bp-core-friends-widget.php
@@ -67,7 +67,12 @@ class BP_Core_Friends_Widget extends WP_Widget {
 		}
 
 		$user_id           = bp_displayed_user_id();
-		$link              = trailingslashit( bp_displayed_user_domain() . bp_get_friends_slug() );
+		$friends_slug      = bp_get_friends_slug();
+		$link              = bp_displayed_user_url(
+			array(
+				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug, $friends_slug ),
+			)
+		);
 		$instance['title'] = sprintf( __( "%s's Friends", 'buddypress' ), bp_get_displayed_user_fullname() );
 
 		if ( empty( $instance['friend_default'] ) ) {

--- a/src/bp-groups/bp-groups-template.php
+++ b/src/bp-groups/bp-groups-template.php
@@ -2167,14 +2167,20 @@ function bp_group_all_members_permalink( $group = false ) {
  * @todo Deprecate.
  */
 function bp_group_search_form() {
+	$label       = __('Filter Groups', 'buddypress');
+	$name        = 'group-filter-box';
+	$groups_slug = bp_get_groups_slug();
+	$action      = bp_displayed_user_url(
+		array(
+			'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $groups_slug, $groups_slug ),
+			'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $groups_slug . '_my_groups', 'my-groups' ),
+			'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $groups_slug . '_search', 'search' ) ),
+		)
+	);
 
-	$action = bp_displayed_user_domain() . bp_get_groups_slug() . '/my-groups/search/';
-	$label = __('Filter Groups', 'buddypress');
-	$name = 'group-filter-box';
-
-	$search_form_html = '<form action="' . $action . '" id="group-search-form" method="post">
-		<label for="'. $name .'" id="'. $name .'-label">'. $label .'</label>
-		<input type="search" name="'. $name . '" id="'. $name .'" value="'. $value .'"'.  $disabled .' />
+	$search_form_html = '<form action="' . esc_url( $action ) . '" id="group-search-form" method="post">
+		<label for="'. $name .'" id="'. $name .'-label">'. esc_html( $label ) .'</label>
+		<input type="search" name="'. $name . '" id="'. $name .'" value=""/>
 
 		'. wp_nonce_field( 'group-filter-box', '_wpnonce_group_filter', true, false ) .'
 		</form>';
@@ -5734,27 +5740,6 @@ function bp_directory_groups_search_form() {
 	 */
 	echo apply_filters( 'bp_directory_groups_search_form', $search_form_html );
 
-}
-
-/**
- * Displays group header tabs.
- *
- * @since 1.0.0
- *
- * @todo Deprecate?
- */
-function bp_groups_header_tabs() {
-	$user_groups = bp_displayed_user_domain() . bp_get_groups_slug(); ?>
-
-	<li<?php if ( !bp_action_variable( 0 ) || bp_is_action_variable( 'recently-active', 0 ) ) : ?> class="current"<?php endif; ?>><a href="<?php echo trailingslashit( $user_groups . '/my-groups/recently-active' ); ?>"><?php _e( 'Recently Active', 'buddypress' ); ?></a></li>
-	<li<?php if ( bp_is_action_variable( 'recently-joined', 0 ) ) : ?> class="current"<?php endif; ?>><a href="<?php echo trailingslashit( $user_groups . '/my-groups/recently-joined' ); ?>"><?php _e( 'Recently Joined',  'buddypress' ); ?></a></li>
-	<li<?php if ( bp_is_action_variable( 'most-popular',    0 ) ) : ?> class="current"<?php endif; ?>><a href="<?php echo trailingslashit( $user_groups . '/my-groups/most-popular'    ); ?>"><?php _e( 'Most Popular',     'buddypress' ); ?></a></li>
-	<li<?php if ( bp_is_action_variable( 'admin-of',        0 ) ) : ?> class="current"<?php endif; ?>><a href="<?php echo trailingslashit( $user_groups . '/my-groups/admin-of'        ); ?>"><?php _e( 'Administrator Of', 'buddypress' ); ?></a></li>
-	<li<?php if ( bp_is_action_variable( 'mod-of',          0 ) ) : ?> class="current"<?php endif; ?>><a href="<?php echo trailingslashit( $user_groups . '/my-groups/mod-of'          ); ?>"><?php _e( 'Moderator Of',     'buddypress' ); ?></a></li>
-	<li<?php if ( bp_is_action_variable( 'alphabetically'     ) ) : ?> class="current"<?php endif; ?>><a href="<?php echo trailingslashit( $user_groups . '/my-groups/alphabetically'  ); ?>"><?php _e( 'Alphabetically',   'buddypress' ); ?></a></li>
-
-<?php
-	do_action( 'groups_header_tabs' );
 }
 
 /**

--- a/src/bp-groups/screens/user/invites.php
+++ b/src/bp-groups/screens/user/invites.php
@@ -41,7 +41,8 @@ function groups_screen_group_invites() {
 		if ( isset( $_GET['redirect_to'] ) ) {
 			$redirect_to = urldecode( $_GET['redirect_to'] );
 		} else {
-			$redirect_to = trailingslashit( bp_displayed_user_domain() . bp_get_groups_slug() . '/' . bp_current_action() );
+			$path_chunks = bp_members_get_path_chunks( array( bp_get_groups_slug(), bp_current_action() ) );
+			$redirect_to = bp_displayed_user_url( $path_chunks );
 		}
 
 		bp_core_redirect( $redirect_to );
@@ -60,7 +61,8 @@ function groups_screen_group_invites() {
 		if ( isset( $_GET['redirect_to'] ) ) {
 			$redirect_to = urldecode( $_GET['redirect_to'] );
 		} else {
-			$redirect_to = trailingslashit( bp_displayed_user_domain() . bp_get_groups_slug() . '/' . bp_current_action() );
+			$path_chunks = bp_members_get_path_chunks( array( bp_get_groups_slug(), bp_current_action() ) );
+			$redirect_to = bp_displayed_user_url( $path_chunks );
 		}
 
 		bp_core_redirect( $redirect_to );

--- a/src/bp-members/actions/invitations-bulk-manage.php
+++ b/src/bp-members/actions/invitations-bulk-manage.php
@@ -76,7 +76,16 @@ function bp_members_invitations_action_bulk_manage() {
 			break;
 	}
 
+	$invite_slug       = bp_get_members_invitations_slug();
+	$action_slug       = bp_current_action();
+	$action_rewrite_id = str_replace( '-', '_', $action_slug );
+
+	$path_chunks = array(
+		'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $invite_slug, $invite_slug ),
+		'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $invite_slug . '_' . $action_rewrite_id, $action_slug ),
+	);
+
 	// Redirect.
-	bp_core_redirect( bp_displayed_user_domain() . bp_get_members_invitations_slug() . '/' . bp_current_action() . '/' );
+	bp_core_redirect( bp_displayed_user_url( $path_chunks ) );
 }
 add_action( 'bp_actions', 'bp_members_invitations_action_bulk_manage' );

--- a/src/bp-members/bp-members-adminbar.php
+++ b/src/bp-members/bp-members-adminbar.php
@@ -82,12 +82,14 @@ function bp_members_admin_bar_user_admin_menu() {
 	global $wp_admin_bar;
 
 	// Only show if viewing a user.
-	if ( !bp_is_user() )
+	if ( ! bp_is_user() ) {
 		return false;
+	}
 
 	// Don't show this menu to non site admins or if you're viewing your own profile.
-	if ( !current_user_can( 'edit_users' ) || bp_is_my_profile() )
+	if ( ! current_user_can( 'edit_users' ) || bp_is_my_profile() ) {
 		return false;
+	}
 
 	$bp = buddypress();
 
@@ -95,62 +97,72 @@ function bp_members_admin_bar_user_admin_menu() {
 	$bp->user_admin_menu_id = 'user-admin';
 
 	// Add the top-level User Admin button.
-	$wp_admin_bar->add_node( array(
-		'id'    => $bp->user_admin_menu_id,
-		'title' => __( 'Edit Member', 'buddypress' ),
-		'href'  => bp_displayed_user_domain()
-	) );
+	$wp_admin_bar->add_node(
+		array(
+			'id'    => $bp->user_admin_menu_id,
+			'title' => __( 'Edit Member', 'buddypress' ),
+			'href'  => bp_displayed_user_url()
+		)
+	);
 
 	if ( bp_is_active( 'xprofile' ) ) {
 		// User Admin > Edit this user's profile.
-		$wp_admin_bar->add_node( array(
-			'parent' => $bp->user_admin_menu_id,
-			'id'     => $bp->user_admin_menu_id . '-edit-profile',
-			'title'  => __( "Edit Profile", 'buddypress' ),
-			'href'   => bp_get_members_component_link( $bp->profile->id, 'edit' )
-		) );
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => $bp->user_admin_menu_id,
+				'id'     => $bp->user_admin_menu_id . '-edit-profile',
+				'title'  => __( "Edit Profile", 'buddypress' ),
+				'href'   => bp_get_members_component_link( $bp->profile->id, 'edit' ),
+			)
+		);
 
 		// User Admin > Edit this user's avatar.
 		if ( buddypress()->avatar->show_avatars ) {
-			$wp_admin_bar->add_node( array(
-				'parent' => $bp->user_admin_menu_id,
-				'id'     => $bp->user_admin_menu_id . '-change-avatar',
-				'title'  => __( "Edit Profile Photo", 'buddypress' ),
-				'href'   => bp_get_members_component_link( $bp->profile->id, 'change-avatar' )
-			) );
+			$wp_admin_bar->add_node(
+				array(
+					'parent' => $bp->user_admin_menu_id,
+					'id'     => $bp->user_admin_menu_id . '-change-avatar',
+					'title'  => __( "Edit Profile Photo", 'buddypress' ),
+					'href'   => bp_get_members_component_link( $bp->profile->id, 'change-avatar' ),
+				)
+			);
 		}
 
 		// User Admin > Edit this user's cover image.
 		if ( bp_displayed_user_use_cover_image_header() ) {
-			$wp_admin_bar->add_node( array(
-				'parent' => $bp->user_admin_menu_id,
-				'id'     => $bp->user_admin_menu_id . '-change-cover-image',
-				'title'  => __( 'Edit Cover Image', 'buddypress' ),
-				'href'   => bp_get_members_component_link( $bp->profile->id, 'change-cover-image' )
-			) );
+			$wp_admin_bar->add_node(
+				array(
+					'parent' => $bp->user_admin_menu_id,
+					'id'     => $bp->user_admin_menu_id . '-change-cover-image',
+					'title'  => __( 'Edit Cover Image', 'buddypress' ),
+					'href'   => bp_get_members_component_link( $bp->profile->id, 'change-cover-image' ),
+				)
+			);
 		}
 
 	}
 
 	if ( bp_is_active( 'settings' ) ) {
 		// User Admin > Spam/unspam.
-		$wp_admin_bar->add_node( array(
-			'parent' => $bp->user_admin_menu_id,
-			'id'     => $bp->user_admin_menu_id . '-user-capabilities',
-			'title'  => __( 'User Capabilities', 'buddypress' ),
-			'href'   => bp_displayed_user_domain() . 'settings/capabilities/'
-		) );
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => $bp->user_admin_menu_id,
+				'id'     => $bp->user_admin_menu_id . '-user-capabilities',
+				'title'  => __( 'User Capabilities', 'buddypress' ),
+				'href'   => bp_get_members_component_link( $bp->settings->id, 'capabilities' ),
+			)
+		);
 
 		// User Admin > Delete Account.
-		$wp_admin_bar->add_node( array(
-			'parent' => $bp->user_admin_menu_id,
-			'id'     => $bp->user_admin_menu_id . '-delete-user',
-			'title'  => __( 'Delete Account', 'buddypress' ),
-			'href'   => bp_displayed_user_domain() . 'settings/delete-account/'
-		) );
-
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => $bp->user_admin_menu_id,
+				'id'     => $bp->user_admin_menu_id . '-delete-user',
+				'title'  => __( 'Delete Account', 'buddypress' ),
+				'href'   => bp_get_members_component_link( $bp->settings->id, 'delete-account' ),
+			)
+		);
 	}
-
 }
 add_action( 'admin_bar_menu', 'bp_members_admin_bar_user_admin_menu', 99 );
 

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -139,6 +139,41 @@ function bp_core_get_users( $args = '' ) {
 }
 
 /**
+ * Get members path chunks using an array of URL slugs.
+ *
+ * @since 12.0.0
+ *
+ * @param array $chunks An array of URL slugs.
+ * @return array An array of BP Rewrites URL arguments.
+ */
+function bp_members_get_path_chunks( $chunks = array() ) {
+	$path_chunks = array();
+
+	$single_item_component            = array_shift( $chunks );
+	$item_component_rewrite_id_suffix = '';
+	if ( $single_item_component ) {
+		$item_component_rewrite_id_suffix     = str_replace( '-', '_', $single_item_component );
+		$path_chunks['single_item_component'] = bp_rewrites_get_slug( 'members', 'member_' . $item_component_rewrite_id_suffix, $single_item_component );
+	}
+
+	$single_item_action            = array_shift( $chunks );
+	$item_action_rewrite_id_suffix = '';
+	if ( $single_item_action ) {
+		$item_action_rewrite_id_suffix     = str_replace( '-', '_', $single_item_action );
+		$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'members', 'member_' . $item_component_rewrite_id_suffix . '_' . $item_action_rewrite_id_suffix, $single_item_action );
+	}
+
+	if ( $chunks && $item_component_rewrite_id_suffix && $item_component_rewrite_id_suffix ) {
+		foreach ( $chunks as $chunk ) {
+			$item_action_variable_rewrite_id_suffix        =  str_replace( '-', '_', $chunk );
+			$path_chunks['single_item_action_variables'][] = bp_rewrites_get_slug( 'members', 'member_' . $item_component_rewrite_id_suffix . '_' . $item_action_rewrite_id_suffix . '_' . $item_action_variable_rewrite_id_suffix, $chunk );
+		}
+	}
+
+	return $path_chunks;
+}
+
+/**
  * Return the Mmbers single item's URL.
  *
  * @since 12.0.0

--- a/src/bp-members/bp-members-template.php
+++ b/src/bp-members/bp-members-template.php
@@ -1875,9 +1875,19 @@ function bp_current_user_id() {
  * Output the link for the displayed user's profile.
  *
  * @since 1.2.4
+ * @since 12.0.0 Introduced the `$chunk` argument.
+ *
+ * @param array $chunk A list of slugs to append to the URL.
  */
-function bp_displayed_user_link() {
-	echo esc_url( bp_displayed_user_url() );
+function bp_displayed_user_link( $chunks = array() ) {
+	$path_chunks = array();
+	$chunks      = (array) $chunks;
+
+	if ( $chunks ) {
+		$path_chunks = bp_members_get_path_chunks( $chunks );
+	}
+
+	echo esc_url( bp_displayed_user_url( $path_chunks ) );
 }
 
 /**
@@ -1961,21 +1971,7 @@ function bp_loggedin_user_link( $chunks = array() ) {
 	$chunks      = (array) $chunks;
 
 	if ( $chunks ) {
-		$single_item_component = array_shift( $chunks );
-		if ( $single_item_component ) {
-			$path_chunks['single_item_component'] = bp_rewrites_get_slug( 'members', 'member_' . $single_item_component, $single_item_component );
-		}
-
-		$single_item_action = array_shift( $chunks );
-		if ( $single_item_action ) {
-			$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'members', 'member_' . $single_item_component . '_' . $single_item_action, $single_item_action );
-		}
-
-		if ( $chunks ) {
-			foreach ( $chunks as $chunk ) {
-				$path_chunks['single_item_action_variables'][] = bp_rewrites_get_slug( 'members', 'member_' . $single_item_component . '_' . $single_item_action . '_' . $chunk, $chunk );
-			}
-		}
+		$path_chunks = bp_members_get_path_chunks( $chunks );
 	}
 
 	echo esc_url( bp_loggedin_user_url( $path_chunks ) );

--- a/src/bp-members/bp-members-template.php
+++ b/src/bp-members/bp-members-template.php
@@ -3093,15 +3093,18 @@ function bp_members_component_link( $component, $action = '', $query_args = '', 
 			$component = 'profile';
 		}
 
+		$path_chunks = array(
+			'single_item_component' => $bp->{$component}->slug,
+		);
+
 		// Append $action to $url if there is no $type.
 		if ( ! empty( $action ) ) {
-			$url = bp_displayed_user_domain() . $bp->{$component}->slug . '/' . $action;
-		} else {
-			$url = bp_displayed_user_domain() . $bp->{$component}->slug;
+			$action_rewrite_id                 = 'member_' . str_replace( '-', '_', $action );
+			$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'members', $action_rewrite_id, $action );
 		}
 
 		// Add a slash at the end of our user url.
-		$url = trailingslashit( $url );
+		$url = bp_displayed_user_url( $path_chunks );
 
 		// Add possible query arg.
 		if ( ! empty( $query_args ) && is_array( $query_args ) ) {
@@ -3140,15 +3143,26 @@ function bp_avatar_delete_link() {
 	 * @return string
 	 */
 	function bp_get_avatar_delete_link() {
+		$profile_slug = bp_get_profile_slug();
+		$url          = wp_nonce_url(
+			bp_displayed_user_url(
+				array(
+					'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug, $profile_slug ),
+					'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_change_avatar', 'change-avatar' ),
+					'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_delete_avatar', 'delete-avatar' ) ),
+				)
+			),
+			'bp_delete_avatar_link'
+		);
 
 		/**
 		 * Filters the link used for deleting an avatar.
 		 *
 		 * @since 1.1.0
 		 *
-		 * @param string $value Nonced URL used for deleting an avatar.
+		 * @param string $url Nonced URL used for deleting an avatar.
 		 */
-		return apply_filters( 'bp_get_avatar_delete_link', wp_nonce_url( bp_displayed_user_domain() . bp_get_profile_slug() . '/change-avatar/delete-avatar/', 'bp_delete_avatar_link' ) );
+		return apply_filters( 'bp_get_avatar_delete_link', $url );
 	}
 
 

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -383,7 +383,7 @@ class BP_Members_Component extends BP_Component {
 		 */
 
 		if ( bp_displayed_user_id() ) {
-			$bp->canonical_stack['base_url'] = bp_displayed_user_domain();
+			$bp->canonical_stack['base_url'] = bp_displayed_user_url();
 
 			if ( bp_current_component() ) {
 				$bp->canonical_stack['component'] = bp_current_component();

--- a/src/bp-members/screens/change-avatar.php
+++ b/src/bp-members/screens/change-avatar.php
@@ -85,7 +85,7 @@ function bp_members_screen_change_avatar() {
 			do_action( 'bp_members_avatar_uploaded', (int) $args['item_id'], 'crop', $args, $cropped_avatar );
 
 			bp_core_add_message( __( 'Your new profile photo was uploaded successfully.', 'buddypress' ) );
-			bp_core_redirect( bp_displayed_user_domain() );
+			bp_core_redirect( bp_displayed_user_url() );
 		}
 	}
 

--- a/src/bp-messages/actions/bulk-delete.php
+++ b/src/bp-messages/actions/bulk-delete.php
@@ -18,10 +18,12 @@ function messages_action_bulk_delete() {
 		return false;
 	}
 
-	$thread_ids = $_POST['thread_ids'];
+	$thread_ids  = $_POST['thread_ids'];
+	$path_chunks = bp_members_get_path_chunks( array( bp_get_messages_slug(), bp_current_action() ) );
+	$redirect    = bp_displayed_user_url( $path_chunks );
 
 	if ( ! $thread_ids || ! messages_check_thread_access( $thread_ids ) ) {
-		bp_core_redirect( trailingslashit( bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() ) );
+		bp_core_redirect( $redirect );
 	} else {
 		if ( ! check_admin_referer( 'messages_delete_thread' ) ) {
 			return false;
@@ -33,7 +35,7 @@ function messages_action_bulk_delete() {
 			bp_core_add_message( __( 'Messages deleted.', 'buddypress' ) );
 		}
 
-		bp_core_redirect( trailingslashit( bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() ) );
+		bp_core_redirect( $redirect );
 	}
 }
 add_action( 'bp_actions', 'messages_action_bulk_delete' );

--- a/src/bp-messages/actions/bulk-manage-star.php
+++ b/src/bp-messages/actions/bulk-manage-star.php
@@ -72,8 +72,11 @@ function bp_messages_star_bulk_manage_handler() {
 			break;
 	}
 
+	$path_chunks = bp_members_get_path_chunks( array( bp_get_messages_slug(), bp_current_action() ) );
+	$redirect    = bp_displayed_user_url( $path_chunks );
+
 	// Redirect back to message box.
-	bp_core_redirect( bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() . '/' );
+	bp_core_redirect( $redirect );
 	die();
 }
 add_action( 'bp_actions', 'bp_messages_star_bulk_manage_handler', 5 );

--- a/src/bp-messages/actions/bulk-manage.php
+++ b/src/bp-messages/actions/bulk-manage.php
@@ -21,14 +21,16 @@ function bp_messages_action_bulk_manage() {
 		return false;
 	}
 
-	$action   = ! empty( $_POST['messages_bulk_action'] ) ? $_POST['messages_bulk_action'] : '';
-	$nonce    = ! empty( $_POST['messages_bulk_nonce'] ) ? $_POST['messages_bulk_nonce'] : '';
-	$messages = ! empty( $_POST['message_ids'] ) ? $_POST['message_ids'] : '';
-	$messages = wp_parse_id_list( $messages );
+	$action      = ! empty( $_POST['messages_bulk_action'] ) ? $_POST['messages_bulk_action'] : '';
+	$nonce       = ! empty( $_POST['messages_bulk_nonce'] ) ? $_POST['messages_bulk_nonce'] : '';
+	$messages    = ! empty( $_POST['message_ids'] ) ? $_POST['message_ids'] : '';
+	$messages    = wp_parse_id_list( $messages );
+	$path_chunks = bp_members_get_path_chunks( array( bp_get_messages_slug(), bp_current_action() ) );
+	$redirect    = bp_displayed_user_url( $path_chunks );
 
 	// Bail if no action or no IDs.
 	if ( ( ! in_array( $action, array( 'delete', 'read', 'unread' ), true ) ) || empty( $messages ) || empty( $nonce ) ) {
-		bp_core_redirect( bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() . '/' );
+		bp_core_redirect( $redirect );
 	}
 
 	// Check the nonce.
@@ -40,7 +42,7 @@ function bp_messages_action_bulk_manage() {
 	foreach ( $messages as $message ) {
 		if ( ! messages_check_thread_access( $message ) && ! bp_current_user_can( 'bp_moderate' ) ) {
 			bp_core_add_message( __( 'There was a problem managing your messages.', 'buddypress' ), 'error' );
-			bp_core_redirect( bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() . '/' );
+			bp_core_redirect( $redirect );
 		}
 	}
 
@@ -69,6 +71,6 @@ function bp_messages_action_bulk_manage() {
 	}
 
 	// Redirect back to message box.
-	bp_core_redirect( bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() . '/' );
+	bp_core_redirect( $redirect );
 }
 add_action( 'bp_actions', 'bp_messages_action_bulk_manage' );

--- a/src/bp-messages/actions/delete.php
+++ b/src/bp-messages/actions/delete.php
@@ -18,10 +18,12 @@ function messages_action_delete_message() {
 		return false;
 	}
 
-	$thread_id = bp_action_variable( 1 );
+	$thread_id   = bp_action_variable( 1 );
+	$path_chunks = bp_members_get_path_chunks( array( bp_get_messages_slug(), bp_current_action() ) );
+	$redirect    = bp_displayed_user_url( $path_chunks );
 
 	if ( ! $thread_id || ! is_numeric( $thread_id ) || ! messages_check_thread_access( $thread_id ) ) {
-		bp_core_redirect( trailingslashit( bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() ) );
+		bp_core_redirect( $redirect );
 	} else {
 		if ( ! check_admin_referer( 'messages_delete_thread' ) ) {
 			return false;
@@ -33,7 +35,7 @@ function messages_action_delete_message() {
 		} else {
 			bp_core_add_message( __('Message deleted.', 'buddypress') );
 		}
-		bp_core_redirect( trailingslashit( bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() ) );
+		bp_core_redirect( $redirect );
 	}
 }
 add_action( 'bp_actions', 'messages_action_delete_message' );

--- a/src/bp-messages/actions/exit.php
+++ b/src/bp-messages/actions/exit.php
@@ -18,10 +18,12 @@ function bp_messages_action_exit_thread() {
 		return false;
 	}
 
-	$thread_id = bp_action_variable( 1 );
+	$thread_id   = bp_action_variable( 1 );
+	$path_chunks = bp_members_get_path_chunks( array( bp_get_messages_slug(), bp_current_action() ) );
+	$redirect    = bp_displayed_user_url( $path_chunks );
 
 	if ( ! $thread_id || ! is_numeric( $thread_id ) || ! messages_check_thread_access( $thread_id ) ) {
-		bp_core_redirect( trailingslashit( bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() ) );
+		bp_core_redirect( $redirect );
 	} else {
 		if ( ! check_admin_referer( 'bp_messages_exit_thread' ) ) {
 			return false;
@@ -34,7 +36,7 @@ function bp_messages_action_exit_thread() {
 			bp_core_add_message( __('You have left the message thread.', 'buddypress') );
 		}
 
-		bp_core_redirect( trailingslashit( bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() ) );
+		bp_core_redirect( $redirect );
 	}
 }
 add_action( 'bp_actions', 'bp_messages_action_exit_thread' );

--- a/src/bp-messages/actions/read.php
+++ b/src/bp-messages/actions/read.php
@@ -43,7 +43,10 @@ function bp_messages_action_mark_read() {
 		bp_core_add_message( __( 'There was a problem marking that message.', 'buddypress' ), 'error' );
 	}
 
+	$path_chunks = bp_members_get_path_chunks( array( bp_get_messages_slug(), bp_current_action() ) );
+	$redirect    = bp_displayed_user_url( $path_chunks );
+
 	// Redirect back to the message box.
-	bp_core_redirect( bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() );
+	bp_core_redirect( $redirect );
 }
 add_action( 'bp_actions', 'bp_messages_action_mark_read' );

--- a/src/bp-messages/actions/star.php
+++ b/src/bp-messages/actions/star.php
@@ -38,7 +38,17 @@ function bp_messages_star_action_handler() {
 	) );
 
 	// Redirect back to previous screen.
-	$redirect = wp_get_referer() ? wp_get_referer() : bp_displayed_user_domain() . bp_get_messages_slug();
+	$redirect = wp_get_referer();
+
+	if ( ! $redirect ) {
+		$messages_slug = bp_get_messages_slug();
+		$redirect      = bp_displayed_user_url(
+			array(
+				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $messages_slug, $messages_slug ),
+			)
+		);
+	}
+
 	bp_core_redirect( $redirect );
 	die();
 }

--- a/src/bp-messages/actions/unread.php
+++ b/src/bp-messages/actions/unread.php
@@ -43,7 +43,10 @@ function bp_messages_action_mark_unread() {
 		bp_core_add_message( __( 'There was a problem marking that message.', 'buddypress' ), 'error' );
 	}
 
+	$path_chunks = bp_members_get_path_chunks( array( bp_get_messages_slug(), bp_current_action() ) );
+	$redirect    = bp_displayed_user_url( $path_chunks );
+
 	// Redirect back to the message box URL.
-	bp_core_redirect( bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() );
+	bp_core_redirect( $redirect );
 }
 add_action( 'bp_actions', 'bp_messages_action_mark_unread' );

--- a/src/bp-messages/actions/view.php
+++ b/src/bp-messages/actions/view.php
@@ -45,7 +45,10 @@ function messages_action_conversation() {
 			bp_core_add_message( __( 'There was a problem sending your reply. Please try again.', 'buddypress' ), 'error' );
 		}
 
-		bp_core_redirect( bp_displayed_user_domain() . bp_get_messages_slug() . '/view/' . $thread_id . '/' );
+		$path_chunks = bp_members_get_path_chunks( array( bp_get_messages_slug(), 'view', $thread_id ) );
+		$redirect    = bp_displayed_user_url( $path_chunks );
+
+		bp_core_redirect( $redirect );
 	}
 
 	/*

--- a/src/bp-messages/bp-messages-template.php
+++ b/src/bp-messages/bp-messages-template.php
@@ -972,15 +972,17 @@ function bp_messages_form_action() {
 	 * @return string The form action.
 	 */
 	function bp_get_messages_form_action() {
+		$path_chunks = bp_members_get_path_chunks( array( bp_get_messages_slug(), bp_current_action(), bp_action_variable( 0 ) ) );
+		$url         = bp_displayed_user_url( $path_chunks );
 
 		/**
 		 * Filters the form action for Messages HTML forms.
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param string $value The form action.
+		 * @param string $url The form action.
 		 */
-		return apply_filters( 'bp_get_messages_form_action', trailingslashit( bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() . '/' . bp_action_variable( 0 ) ) );
+		return apply_filters( 'bp_get_messages_form_action',$url );
 	}
 
 /**
@@ -2298,16 +2300,17 @@ function bp_the_thread_delete_link() {
 	 * @return string URL
 	 */
 	function bp_get_the_thread_delete_link() {
+		$path_chunks = bp_members_get_path_chunks( array( bp_get_messages_slug(), 'inbox', 'delete', bp_get_the_thread_id() ) );
+		$url         = wp_nonce_url( bp_displayed_user_url( $path_chunks ), 'messages_delete_thread' );
 
 		/**
 		 * Filters the URL for deleting the current thread.
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param string $value URL for deleting the current thread.
-		 * @param string $value Text indicating action being executed.
+		 * @param string $url URL for deleting the current thread.
 		 */
-		return apply_filters( 'bp_get_message_thread_delete_link', wp_nonce_url( bp_displayed_user_domain() . bp_get_messages_slug() . '/inbox/delete/' . bp_get_the_thread_id(), 'messages_delete_thread' ) );
+		return apply_filters( 'bp_get_message_thread_delete_link', $url );
 	}
 
 /**
@@ -2326,16 +2329,17 @@ function bp_the_thread_exit_link() {
 	 * @return string URL
 	 */
 	function bp_get_the_thread_exit_link() {
+		$path_chunks = bp_members_get_path_chunks( array( bp_get_messages_slug(), 'inbox', 'exit', bp_get_the_thread_id() ) );
+		$url         = wp_nonce_url( bp_displayed_user_url( $path_chunks ), 'bp_messages_exit_thread' );
 
 		/**
 		 * Filters the URL to exit the current thread.
 		 *
-		 * @since 1.0.0
+		 * @since 10.0.0
 		 *
-		 * @param string $value URL to exit the current thread.
-		 * @param string $value Text indicating action being executed.
+		 * @param string $url URL to exit the current thread.
 		 */
-		return apply_filters( 'bp_get_the_thread_exit_link', wp_nonce_url( bp_displayed_user_domain() . bp_get_messages_slug() . '/inbox/exit/' . bp_get_the_thread_id(), 'bp_messages_exit_thread' ) );
+		return apply_filters( 'bp_get_the_thread_exit_link', $url );
 	}
 
 /**

--- a/src/bp-settings/actions/capabilities.php
+++ b/src/bp-settings/actions/capabilities.php
@@ -77,7 +77,10 @@ function bp_settings_action_capabilities() {
 	 */
 	do_action( 'bp_settings_capabilities_after_save' );
 
-	// Redirect to the root domain.
-	bp_core_redirect( bp_displayed_user_domain() . bp_get_settings_slug() . '/capabilities/' );
+	$path_chunks = bp_members_get_path_chunks( array( bp_get_settings_slug(), 'capabilities' ) );
+	$redirect    = bp_displayed_user_url( $path_chunks );
+
+	// Redirect to the settings capability page.
+	bp_core_redirect( $redirect );
 }
 add_action( 'bp_actions', 'bp_settings_action_capabilities' );

--- a/src/bp-settings/actions/general.php
+++ b/src/bp-settings/actions/general.php
@@ -50,6 +50,10 @@ function bp_settings_action_general() {
 	$feedback_type = 'error';                // success|error
 	$feedback      = array();                // array of strings for feedback.
 	$user_id       = bp_displayed_user_id(); // The ID of the user being displayed.
+	$settings_slug = bp_get_settings_slug();
+	$path_chunks   = array(
+		'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug, $settings_slug ),
+	);
 
 	// Nonce check.
 	check_admin_referer( 'bp_settings_general' );
@@ -99,7 +103,11 @@ function bp_settings_action_general() {
 					);
 
 					bp_update_user_meta( $user_id, 'pending_email_change', $pending_email );
-					$verify_link = bp_displayed_user_domain() . bp_get_settings_slug() . '/?verify_email_change=' . $hash;
+					$verify_link = add_query_arg(
+						'verify_email_change',
+						$hash,
+						bp_displayed_user_url( $path_chunks )
+					);
 
 					// Send the verification email.
 					$args = array(
@@ -226,7 +234,8 @@ function bp_settings_action_general() {
 	}
 
 	// Set the URL to redirect the user to.
-	$redirect_to = trailingslashit( bp_displayed_user_domain() . bp_get_settings_slug() . '/general' );
+	$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'members', 'member_' . $settings_slug . '_general', 'general' );
+	$redirect_to = bp_displayed_user_url( $path_chunks );
 
 	/**
 	 * Fires after the general settings have been saved, and before redirect.
@@ -261,7 +270,11 @@ function bp_settings_verify_email_change() {
 		return;
 	}
 
-	$redirect_to = trailingslashit( bp_displayed_user_domain() . bp_get_settings_slug() );
+	$settings_slug = bp_get_settings_slug();
+	$path_chunks   = array(
+		'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug, $settings_slug )
+	);
+	$redirect_to = bp_displayed_user_url( $path_chunks );
 
 	// Email change is being verified.
 	if ( isset( $_GET['verify_email_change'] ) ) {

--- a/src/bp-settings/actions/notifications.php
+++ b/src/bp-settings/actions/notifications.php
@@ -53,6 +53,12 @@ function bp_settings_action_notifications() {
 	 */
 	do_action( 'bp_core_notification_settings_after_save' );
 
-	bp_core_redirect( bp_displayed_user_domain() . bp_get_settings_slug() . '/notifications/' );
+	$settings_slug = bp_get_settings_slug();
+	$path_chunks   = array(
+		'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug, $settings_slug ),
+		'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug . '_notifications', 'notifications' ),
+	);
+
+	bp_core_redirect( bp_displayed_user_url( $path_chunks ) );
 }
 add_action( 'bp_actions', 'bp_settings_action_notifications' );

--- a/src/bp-settings/bp-settings-template.php
+++ b/src/bp-settings/bp-settings-template.php
@@ -80,6 +80,19 @@ function bp_settings_pending_email_notice() {
 		return;
 	}
 
+	$settings_slug = bp_get_settings_slug();
+	$dismiss_url   = wp_nonce_url(
+		add_query_arg(
+			'dismiss_email_change',
+			1,
+			bp_displayed_user_url(
+				array(
+					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug, $settings_slug ),
+				)
+			)
+		),
+		'bp_dismiss_email_change'
+	);
 	?>
 
 	<div id="message" class="bp-template-notice error">
@@ -97,7 +110,7 @@ function bp_settings_pending_email_notice() {
 				/* translators: 1: email address. 2: cancel email change url. */
 				__( 'Check your email (%1$s) for the verification link, or <a href="%2$s">cancel the pending change</a>.', 'buddypress' ),
 				'<code>' . esc_html( $pending_email['newemail'] ) . '</code>',
-				esc_url( wp_nonce_url( bp_displayed_user_domain() . bp_get_settings_slug() . '/?dismiss_email_change=1', 'bp_dismiss_email_change' ) )
+				esc_url( $dismiss_url )
 			);
 			?>
 		</p>

--- a/src/bp-templates/bp-legacy/buddypress/members/single/messages/messages-loop.php
+++ b/src/bp-templates/bp-legacy/buddypress/members/single/messages/messages-loop.php
@@ -4,7 +4,7 @@
  *
  * @package BuddyPress
  * @subpackage bp-legacy
- * @version 3.0.0
+ * @version 12.0.0
  */
 
 /**
@@ -51,7 +51,7 @@ do_action( 'bp_before_member_messages_loop' ); ?>
 	 */
 	do_action( 'bp_before_member_messages_threads' ); ?>
 
-	<form action="<?php echo bp_displayed_user_domain() . bp_get_messages_slug() . '/' . bp_current_action() ?>/bulk-manage/" method="post" id="messages-bulk-management">
+	<form action="<?php bp_displayed_user_link( array( bp_get_messages_slug(), bp_current_action(), 'bulk-manage' ) ); ?>" method="post" id="messages-bulk-management">
 
 		<table id="message-threads" class="messages-notices">
 

--- a/src/bp-templates/bp-legacy/buddypress/members/single/settings/capabilities.php
+++ b/src/bp-templates/bp-legacy/buddypress/members/single/settings/capabilities.php
@@ -4,13 +4,13 @@
  *
  * @package BuddyPress
  * @subpackage bp-legacy
- * @version 3.0.0
+ * @version 12.0.0
  */
 
 /** This action is documented in bp-templates/bp-legacy/buddypress/members/single/settings/profile.php */
 do_action( 'bp_before_member_settings_template' ); ?>
 
-<form action="<?php echo bp_displayed_user_domain() . bp_get_settings_slug() . '/capabilities/'; ?>" name="account-capabilities-form" id="account-capabilities-form" class="standard-form" method="post">
+<form action="<?php bp_displayed_user_link( array( bp_get_settings_slug(), 'capabilities' ) ); ?>" name="account-capabilities-form" id="account-capabilities-form" class="standard-form" method="post">
 
 	<?php
 

--- a/src/bp-templates/bp-legacy/buddypress/members/single/settings/data.php
+++ b/src/bp-templates/bp-legacy/buddypress/members/single/settings/data.php
@@ -4,7 +4,7 @@
  *
  * @package BuddyPress
  * @subpackage bp-legacy
- * @version 11.0.0
+ * @version 12.0.0
  */
 
 /** This action is documented in bp-templates/bp-legacy/buddypress/members/single/settings/profile.php */
@@ -84,7 +84,7 @@ do_action( 'bp_before_member_settings_template' ); ?>
 				esc_html__( 'You may delete your account by visiting the %s page.', 'buddypress' ),
 				sprintf(
 					'<a href="%1$s">%2$s</a>',
-					esc_url( bp_displayed_user_domain() . bp_get_settings_slug() . '/delete-account/' ),
+					esc_url( bp_displayed_user_url( array( bp_get_settings_slug(), 'delete-account' ) ) ),
 					esc_html__( 'Delete Account', 'buddypress' )
 				)
 			);

--- a/src/bp-templates/bp-legacy/buddypress/members/single/settings/delete-account.php
+++ b/src/bp-templates/bp-legacy/buddypress/members/single/settings/delete-account.php
@@ -24,7 +24,7 @@ do_action( 'bp_before_member_settings_template' ); ?>
 
 </div>
 
-<form action="<?php echo bp_displayed_user_domain() . bp_get_settings_slug() . '/delete-account'; ?>" name="account-delete-form" id="account-delete-form" class="standard-form" method="post">
+<form action="<?php bp_displayed_user_link( array( bp_get_settings_slug(), 'delete-account' ) ); ?>" name="account-delete-form" id="account-delete-form" class="standard-form" method="post">
 
 	<?php
 

--- a/src/bp-templates/bp-legacy/buddypress/members/single/settings/general.php
+++ b/src/bp-templates/bp-legacy/buddypress/members/single/settings/general.php
@@ -4,7 +4,7 @@
  *
  * @package BuddyPress
  * @subpackage bp-legacy
- * @version 3.0.0
+ * @version 12.0.0
  */
 
 /** This action is documented in bp-templates/bp-legacy/buddypress/members/single/settings/profile.php */
@@ -15,9 +15,9 @@ do_action( 'bp_before_member_settings_template' ); ?>
 	_e( 'Account settings', 'buddypress' );
 ?></h2>
 
-<form action="<?php echo bp_displayed_user_domain() . bp_get_settings_slug() . '/general'; ?>" method="post" class="standard-form" id="settings-form">
+<form action="<?php bp_displayed_user_link( array( bp_get_settings_slug(), 'general' ) ); ?>" method="post" class="standard-form" id="settings-form">
 
-	<?php if ( !is_super_admin() ) : ?>
+	<?php if ( ! is_super_admin() ) : ?>
 
 		<label for="pwd"><?php _e( 'Current Password <span>(required to update email or change current password)</span>', 'buddypress' ); ?></label>
 		<input type="password" name="pwd" id="pwd" size="16" value="" class="settings-input small" <?php bp_form_field_attributes( 'password' ); ?>/> &nbsp;<a href="<?php echo wp_lostpassword_url(); ?>"><?php _e( 'Lost your password?', 'buddypress' ); ?></a>

--- a/src/bp-templates/bp-legacy/buddypress/members/single/settings/notifications.php
+++ b/src/bp-templates/bp-legacy/buddypress/members/single/settings/notifications.php
@@ -4,7 +4,7 @@
  *
  * @package BuddyPress
  * @subpackage bp-legacy
- * @version 3.0.0
+ * @version 12.0.0
  */
 
 /** This action is documented in bp-templates/bp-legacy/buddypress/members/single/settings/profile.php */
@@ -15,7 +15,7 @@ do_action( 'bp_before_member_settings_template' ); ?>
 	_e( 'Notification settings', 'buddypress' );
 ?></h2>
 
-<form action="<?php echo bp_displayed_user_domain() . bp_get_settings_slug() . '/notifications'; ?>" method="post" class="standard-form" id="settings-form">
+<form action="<?php bp_displayed_user_link( array( bp_get_settings_slug(), 'notifications' ) ); ?>" method="post" class="standard-form" id="settings-form">
 	<p><?php _e( 'Send an email notice when:', 'buddypress' ); ?></p>
 
 	<?php

--- a/src/bp-templates/bp-legacy/buddypress/members/single/settings/profile.php
+++ b/src/bp-templates/bp-legacy/buddypress/members/single/settings/profile.php
@@ -4,7 +4,7 @@
  *
  * @package BuddyPress
  * @subpackage bp-legacy
- * @version 3.0.0
+ * @version 12.0.0
  */
 
 /**
@@ -19,7 +19,7 @@ do_action( 'bp_before_member_settings_template' ); ?>
 	_e( 'Profile visibility settings', 'buddypress' );
 ?></h2>
 
-<form action="<?php echo trailingslashit( bp_displayed_user_domain() . bp_get_settings_slug() . '/profile' ); ?>" method="post" class="standard-form" id="settings-form">
+<form action="<?php bp_displayed_user_link( array( bp_get_settings_slug(), 'profile' ) ); ?>" method="post" class="standard-form" id="settings-form">
 
 	<?php if ( bp_xprofile_get_settings_fields() ) : ?>
 

--- a/src/bp-templates/bp-nouveau/buddypress/members/single/settings/capabilities.php
+++ b/src/bp-templates/bp-nouveau/buddypress/members/single/settings/capabilities.php
@@ -3,7 +3,7 @@
  * BuddyPress - Members Settings ( Capabilities )
  *
  * @since 3.0.0
- * @version 8.0.0
+ * @version 12.0.0
  */
 
 bp_nouveau_member_hook( 'before', 'settings_template' ); ?>
@@ -12,7 +12,7 @@ bp_nouveau_member_hook( 'before', 'settings_template' ); ?>
 	<?php esc_html_e( 'Members Capabilities', 'buddypress' ); ?>
 </h2>
 
-<form action="<?php echo esc_url( bp_displayed_user_domain() . bp_nouveau_get_component_slug( 'settings' ) . '/capabilities/' ); ?>" name="account-capabilities-form" id="account-capabilities-form" class="standard-form" method="post">
+<form action="<?php bp_displayed_user_link( array( bp_nouveau_get_component_slug( 'settings' ), 'capabilities' ) ); ?>" name="account-capabilities-form" id="account-capabilities-form" class="standard-form" method="post">
 
 	<label for="user-spammer">
 		<input type="checkbox" name="user-spammer" id="user-spammer" value="1" <?php checked( bp_is_user_spammer( bp_displayed_user_id() ) ); ?> />

--- a/src/bp-templates/bp-nouveau/buddypress/members/single/settings/data.php
+++ b/src/bp-templates/bp-nouveau/buddypress/members/single/settings/data.php
@@ -3,7 +3,7 @@
  * BuddyPress - Members Settings (Export Data)
  *
  * @since 3.1.0
- * @version 11.0.0
+ * @version 12.0.0
  */
 
 bp_nouveau_member_hook( 'before', 'settings_template' ); ?>
@@ -77,7 +77,7 @@ bp_nouveau_member_hook( 'before', 'settings_template' ); ?>
 				esc_html__( 'You may delete your account by visiting the %s page.', 'buddypress' ),
 				sprintf(
 					'<a href="%1$s">%2$s</a>',
-					esc_url( bp_displayed_user_domain() . bp_nouveau_get_component_slug( 'settings' ) . '/delete-account/' ),
+					esc_url( bp_displayed_user_url( array( bp_nouveau_get_component_slug( 'settings' ), 'delete-account' ) ) ),
 					esc_html__( 'Delete Account', 'buddypress' )
 				)
 			);

--- a/src/bp-templates/bp-nouveau/buddypress/members/single/settings/delete-account.php
+++ b/src/bp-templates/bp-nouveau/buddypress/members/single/settings/delete-account.php
@@ -3,7 +3,7 @@
  * BuddyPress - Members Settings ( Delete Account )
  *
  * @since 3.0.0
- * @version 8.0.0
+ * @version 12.0.0
  */
 
 bp_nouveau_member_hook( 'before', 'settings_template' ); ?>
@@ -14,7 +14,7 @@ bp_nouveau_member_hook( 'before', 'settings_template' ); ?>
 
 <?php bp_nouveau_user_feedback( 'member-delete-account' ); ?>
 
-<form action="<?php echo esc_url( bp_displayed_user_domain() . bp_nouveau_get_component_slug( 'settings' ) . '/delete-account' ); ?>" name="account-delete-form" id="account-delete-form" class="standard-form" method="post">
+<form action="<?php bp_displayed_user_link( array( bp_nouveau_get_component_slug( 'settings' ), 'delete-account' ) ); ?>" name="account-delete-form" id="account-delete-form" class="standard-form" method="post">
 
 	<label id="delete-account-understand" class="warn" for="delete-account-understand">
 		<input class="disabled" type="checkbox" name="delete-account-understand" value="1" data-bp-disable-input="delete-account-button" />

--- a/src/bp-templates/bp-nouveau/buddypress/members/single/settings/general.php
+++ b/src/bp-templates/bp-nouveau/buddypress/members/single/settings/general.php
@@ -3,7 +3,7 @@
  * BuddyPress - Members Settings ( General )
  *
  * @since 3.0.0
- * @version 8.0.0
+ * @version 12.0.0
  */
 
 bp_nouveau_member_hook( 'before', 'settings_template' ); ?>
@@ -16,7 +16,7 @@ bp_nouveau_member_hook( 'before', 'settings_template' ); ?>
 	<?php esc_html_e( 'Update your email and or password.', 'buddypress' ); ?>
 </p>
 
-<form action="<?php echo esc_url( bp_displayed_user_domain() . bp_nouveau_get_component_slug( 'settings' ) . '/general' ); ?>" method="post" class="standard-form" id="your-profile">
+<form action="<?php bp_displayed_user_link( array( bp_nouveau_get_component_slug( 'settings' ), 'general' ) ); ?>" method="post" class="standard-form" id="your-profile">
 
 	<?php if ( ! is_super_admin() ) : ?>
 

--- a/src/bp-templates/bp-nouveau/buddypress/members/single/settings/group-invites.php
+++ b/src/bp-templates/bp-nouveau/buddypress/members/single/settings/group-invites.php
@@ -3,7 +3,7 @@
  * BuddyPress - Members Settings ( Group Invites )
  *
  * @since 3.0.0
- * @version 8.0.0
+ * @version 12.0.0
  */
 ?>
 
@@ -20,7 +20,7 @@ if ( 1 === bp_nouveau_groups_get_group_invites_setting() ) {
 ?>
 
 
-<form action="<?php echo esc_url( bp_displayed_user_domain() . bp_nouveau_get_component_slug( 'settings' ) . '/invites/' ); ?>" name="account-group-invites-form" id="account-group-invites-form" class="standard-form" method="post">
+<form action="<?php bp_displayed_user_link( array( bp_nouveau_get_component_slug( 'settings' ), 'invites' ) ); ?>" name="account-group-invites-form" id="account-group-invites-form" class="standard-form" method="post">
 
 	<label for="account-group-invites-preferences">
 		<input type="checkbox" name="account-group-invites-preferences" id="account-group-invites-preferences" value="1" <?php checked( 1, bp_nouveau_groups_get_group_invites_setting() ); ?>/>

--- a/src/bp-templates/bp-nouveau/buddypress/members/single/settings/notifications.php
+++ b/src/bp-templates/bp-nouveau/buddypress/members/single/settings/notifications.php
@@ -3,7 +3,7 @@
  * BuddyPress - Members Settings ( Notifications )
  *
  * @since 3.0.0
- * @version 3.0.0
+ * @version 12.0.0
  */
 
 bp_nouveau_member_hook( 'before', 'settings_template' ); ?>
@@ -16,7 +16,7 @@ bp_nouveau_member_hook( 'before', 'settings_template' ); ?>
 	<?php _e( 'Set your email notification preferences.', 'buddypress' ); ?>
 </p>
 
-<form action="<?php echo esc_url( bp_displayed_user_domain() . bp_nouveau_get_component_slug( 'settings' ) . '/notifications' ); ?>" method="post" class="standard-form" id="settings-form">
+<form action="<?php bp_displayed_user_link( array( bp_nouveau_get_component_slug( 'settings' ), 'notifications' ) ); ?>" method="post" class="standard-form" id="settings-form">
 
 	<?php bp_nouveau_member_email_notice_settings(); ?>
 

--- a/src/bp-templates/bp-nouveau/buddypress/members/single/settings/profile.php
+++ b/src/bp-templates/bp-nouveau/buddypress/members/single/settings/profile.php
@@ -16,7 +16,7 @@ bp_nouveau_member_hook( 'before', 'settings_template' ); ?>
 	<?php esc_html_e( 'Select who may see your profile details.', 'buddypress' ); ?>
 </p>
 
-<form action="<?php echo esc_url( bp_displayed_user_domain() . bp_nouveau_get_component_slug( 'settings' ) . '/profile/' ); ?>" method="post" class="standard-form" id="settings-form">
+<form action="<?php bp_displayed_user_link( array( bp_nouveau_get_component_slug( 'settings' ), 'profile' ) ); ?>" method="post" class="standard-form" id="settings-form">
 
 	<?php if ( bp_xprofile_get_settings_fields() ) : ?>
 

--- a/src/bp-templates/bp-nouveau/includes/groups/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/functions.php
@@ -502,7 +502,7 @@ function bp_nouveau_groups_screen_invites_restriction() {
 			bp_core_add_message( __( 'You are not allowed to perform this action.', 'buddypress' ), 'error' );
 		}
 
-		bp_core_redirect( trailingslashit( bp_displayed_user_domain() . bp_nouveau_get_component_slug( 'settings' ) ) . 'invites/' );
+		bp_core_redirect( bp_displayed_user_url( array( bp_nouveau_get_component_slug( 'settings' ), 'invites' ) ) );
 	}
 
 	/**

--- a/src/bp-templates/bp-nouveau/includes/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/template-tags.php
@@ -2258,7 +2258,7 @@ function bp_nouveau_get_customizer_link( $args = array() ) {
 	$url = '';
 
 	if ( bp_is_user() ) {
-		$url = rawurlencode( bp_displayed_user_domain() );
+		$url = rawurlencode( bp_displayed_user_url() );
 
 	} elseif ( bp_is_group() ) {
 		$url = rawurlencode( bp_get_group_url( groups_get_current_group() ) );
@@ -2698,32 +2698,32 @@ function bp_nouveau_is_feed_enable() {
 				$retval = bp_activity_is_feed_enable( 'personal' );
 
 				if ( $retval ) {
-					$bp_nouveau->activity->current_rss_feed['link'] = trailingslashit( bp_displayed_user_domain() . bp_nouveau_get_component_slug( 'activity' ) . '/feed' );
+					$bp_nouveau->activity->current_rss_feed['link'] = bp_displayed_user_url( array( bp_nouveau_get_component_slug( 'activity' ), 'feed' ) );
 				}
 
 				if ( bp_is_active( 'friends' ) && bp_is_current_action( bp_nouveau_get_component_slug( 'friends' ) ) ) {
 					$retval = bp_activity_is_feed_enable( 'friends' );
 
 					if ( $retval ) {
-						$bp_nouveau->activity->current_rss_feed['link'] = trailingslashit( bp_displayed_user_domain() . bp_nouveau_get_component_slug( 'activity' ) . '/' . bp_nouveau_get_component_slug( 'friends' ) . '/feed' );
+						$bp_nouveau->activity->current_rss_feed['link'] = bp_displayed_user_url( array( bp_nouveau_get_component_slug( 'activity' ), bp_nouveau_get_component_slug( 'friends' ), 'feed' ) );
 					}
 				} elseif ( bp_is_active( 'groups' ) && bp_is_current_action( bp_nouveau_get_component_slug( 'groups' ) ) ) {
 					$retval = bp_activity_is_feed_enable( 'mygroups' );
 
 					if ( $retval ) {
-						$bp_nouveau->activity->current_rss_feed['link'] = trailingslashit( bp_displayed_user_domain() . bp_nouveau_get_component_slug( 'activity' ) . '/' . bp_nouveau_get_component_slug( 'groups' ) . '/feed' );
+						$bp_nouveau->activity->current_rss_feed['link'] = bp_displayed_user_url( array( bp_nouveau_get_component_slug( 'activity' ), bp_nouveau_get_component_slug( 'groups' ), 'feed' ) );
 					}
 				} elseif ( bp_activity_do_mentions() && bp_is_current_action( 'mentions' ) ) {
 					$retval = bp_activity_is_feed_enable( 'mentions' );
 
 					if ( $retval ) {
-						$bp_nouveau->activity->current_rss_feed['link'] = trailingslashit( bp_displayed_user_domain() . bp_nouveau_get_component_slug( 'activity' ) . '/mentions/feed' );
+						$bp_nouveau->activity->current_rss_feed['link'] = bp_displayed_user_url( array( bp_nouveau_get_component_slug( 'activity' ), 'mentions', 'feed' ) );
 					}
 				} elseif ( bp_activity_can_favorite() && bp_is_current_action( 'favorites' ) ) {
 					$retval = bp_activity_is_feed_enable( 'mentions' );
 
 					if ( $retval ) {
-						$bp_nouveau->activity->current_rss_feed['link'] = trailingslashit( bp_displayed_user_domain() . bp_nouveau_get_component_slug( 'activity' ) . '/favorites/feed' );
+						$bp_nouveau->activity->current_rss_feed['link'] = bp_displayed_user_url( array( bp_nouveau_get_component_slug( 'activity' ), 'favorites', 'feed' ) );
 					}
 				}
 			}

--- a/src/bp-xprofile/bp-xprofile-template.php
+++ b/src/bp-xprofile/bp-xprofile-template.php
@@ -389,7 +389,13 @@ function bp_the_profile_group_edit_form_action() {
 		global $group;
 
 		// Build the form action URL.
-		$form_action = trailingslashit( bp_displayed_user_domain() . bp_get_profile_slug() . '/edit/group/' . $group->id );
+		$profile_slug = bp_get_profile_slug();
+		$path_chunks  = array(
+			'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug, $profile_slug ),
+			'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit', 'edit' ),
+			'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit_group', 'group' ), $group->id ),
+		);
+		$form_action = bp_displayed_user_url( $path_chunks );
 
 		/**
 		 * Filters the action for the XProfile group edit form.
@@ -1073,7 +1079,13 @@ function bp_get_profile_group_tabs() {
 		}
 
 		// Build the profile field group link.
-		$link   = trailingslashit( bp_displayed_user_domain() . bp_get_profile_slug() . '/edit/group/' . $groups[ $i ]->id );
+		$profile_slug = bp_get_profile_slug();
+		$path_chunks  = array(
+			'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug, $profile_slug ),
+			'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit', 'edit' ),
+			'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit_group', 'group' ), $groups[ $i ]->id ),
+		);
+		$link         = bp_displayed_user_url( $path_chunks );
 
 		// Add tab to end of tabs array.
 		$tabs[] = sprintf(
@@ -1231,12 +1243,18 @@ function bp_current_profile_group_id() {
  * @since 1.0.0
  */
 function bp_edit_profile_button() {
+	$profile_slug = bp_get_profile_slug();
+	$path_chunks  = array(
+		'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug, $profile_slug ),
+		'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit', 'edit' ),
+	);
+
 	bp_button( array(
 		'id'                => 'edit_profile',
 		'component'         => 'xprofile',
 		'must_be_logged_in' => true,
 		'block_self'        => true,
-		'link_href'         => trailingslashit( bp_displayed_user_domain() . bp_get_profile_slug() . '/edit' ),
+		'link_href'         => bp_displayed_user_url( $path_chunks ),
 		'link_class'        => 'edit',
 		'link_text'         => __( 'Edit Profile', 'buddypress' ),
 	) );

--- a/src/bp-xprofile/screens/edit.php
+++ b/src/bp-xprofile/screens/edit.php
@@ -20,9 +20,17 @@ function xprofile_screen_edit_profile() {
 		return false;
 	}
 
+	$profile_slug = bp_get_profile_slug();
+	$path_chunks  = array(
+		'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug, $profile_slug ),
+		'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit', 'edit' ),
+	);
+
+
 	// Make sure a group is set.
 	if ( ! bp_action_variable( 1 ) ) {
-		bp_core_redirect( trailingslashit( bp_displayed_user_domain() . bp_get_profile_slug() . '/edit/group/1' ) );
+		$path_chunks['single_item_action_variables'] = array( bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit_group', 'group' ), 1 );
+		bp_core_redirect( bp_displayed_user_url( $path_chunks ) );
 	}
 
 	// Check the field group exists.
@@ -42,7 +50,8 @@ function xprofile_screen_edit_profile() {
 
 		// Check we have field ID's.
 		if ( empty( $_POST['field_ids'] ) ) {
-			bp_core_redirect( trailingslashit( bp_displayed_user_domain() . bp_get_profile_slug() . '/edit/group/' . bp_action_variable( 1 ) ) );
+			$path_chunks['single_item_action_variables'] = array( bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit_group', 'group' ), bp_action_variable( 1 ) );
+			bp_core_redirect( bp_displayed_user_url( $path_chunks ) );
 		}
 
 		// Explode the posted field IDs into an array so we know which
@@ -155,7 +164,8 @@ function xprofile_screen_edit_profile() {
 			}
 
 			// Redirect back to the edit screen to display the updates and message.
-			bp_core_redirect( trailingslashit( bp_displayed_user_domain() . bp_get_profile_slug() . '/edit/group/' . bp_action_variable( 1 ) ) );
+			$path_chunks['single_item_action_variables'] = array( bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit_group', 'group' ), bp_action_variable( 1 ) );
+			bp_core_redirect( bp_displayed_user_url( $path_chunks ) );
 		}
 	}
 

--- a/src/bp-xprofile/screens/settings-profile.php
+++ b/src/bp-xprofile/screens/settings-profile.php
@@ -110,6 +110,11 @@ function bp_xprofile_action_settings() {
 	do_action( 'bp_xprofile_settings_after_save' );
 
 	// Redirect to the root domain.
-	bp_core_redirect( bp_displayed_user_domain() . bp_get_settings_slug() . '/profile' );
+	$settings_slug = bp_get_settings_slug();
+	$path_chunks   = array(
+		'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug, $settings_slug ),
+		'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug . '_profile', 'profile' ),
+	);
+	bp_core_redirect( bp_displayed_user_url( $path_chunks ) );
 }
 add_action( 'bp_actions', 'bp_xprofile_action_settings' );


### PR DESCRIPTION
- Replace all remaining `bp_displayed_user_domain()` usage in favor of `bp_displayed_user_url()`.
- Introduce the `bp_members_get_path_chunks()` function to quickly build BP Rewrites argument for member's URL using an array of slugs.
- Deprecate `bp_activities_member_rss_link()`, `bp_blogs_blog_tabs()` & `bp_groups_header_tabs()`,
- Improve `bp_displayed_user_link()` so that it's possible to pass an array of slugs to output an escaped BP Rewrites ready URL.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/4954

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
