### PR TITLE
BP Rewrites merge step 10

### DIFF
--- a/src/bp-activity/screens/permalink.php
+++ b/src/bp-activity/screens/permalink.php
@@ -55,7 +55,8 @@ function bp_activity_action_permalink_router() {
 
 			// Set redirect to group activity stream.
 			if ( $group = groups_get_group( $activity->item_id ) ) {
-				$redirect = bp_get_group_permalink( $group ) . bp_get_activity_slug() . '/' . $activity->id . '/';
+				$path_chunks = bp_groups_get_path_chunks( array( bp_get_activity_slug(), $activity->id ) );
+				$redirect    = bp_get_group_url( $group, $path_chunks );
 			}
 		}
 

--- a/src/bp-core/deprecated/12.0.php
+++ b/src/bp-core/deprecated/12.0.php
@@ -299,6 +299,88 @@ function bp_user_link() {
 }
 
 /**
+ * Output the permalink for the group.
+ *
+ * @since 1.0.0
+ * @deprecated 12.0.0
+ *
+ * @param false|int|string|BP_Groups_Group $group (Optional) The Group ID, the Group Slug or the Group object.
+ *                                                Default: false.
+ */
+function bp_group_permalink( $group = false ) {
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_group_url' );
+	bp_group_url( $group );
+}
+/**
+ * Return the permalink for the group.
+ *
+ * @since 1.0.0
+ * @since 10.0.0 Updated to use `bp_get_group`.
+ * @deprecated 12.0.0
+ *
+ * @param false|int|string|BP_Groups_Group $group (Optional) The Group ID, the Group Slug or the Group object.
+ *                                                Default: false.
+ * @return string
+ */
+function bp_get_group_permalink( $group = false ) {
+	$url = bp_get_group_url( $group );
+
+	/**
+	 * Filters the permalink for the group.
+	 *
+	 * @since 1.0.0
+	 * @since 2.5.0 Added the `$group` parameter.
+	 * @deprecated 12.0.0
+	 *
+	 * @param string          $url   Permalink for the group.
+	 * @param BP_Groups_Group $group The group object.
+	 */
+	return apply_filters_deprecated( 'bp_get_group_permalink', array( $url, $group ), '12.0.0', 'bp_get_group_url' );
+}
+
+/**
+ * Output the permalink for the admin section of the group.
+ *
+ * @since 1.0.0
+ * @deprecated 12.0.0
+ *
+ * @param false|int|string|BP_Groups_Group $group (Optional) The Group ID, the Group Slug or the Group object.
+ *                                                Default: false.
+ */
+function bp_group_admin_permalink( $group = false ) {
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_group_manage_url' );
+	bp_group_manage_url( $group );
+}
+
+/**
+ * Return the permalink for the admin section of the group.
+ *
+ * @since 1.0.0
+ * @since 10.0.0 Updated to use `bp_get_group`.
+ * @deprecated 12.0.0
+ *
+ * @param false|int|string|BP_Groups_Group $group (Optional) The Group ID, the Group Slug or the Group object.
+ *                                                Default: false.
+ * @return string
+ */
+function bp_get_group_admin_permalink( $group = false ) {
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_get_group_manage_url' );
+	$permalink = bp_get_group_manage_url( $group );
+
+	/**
+	 * Filters the permalink for the admin section of the group.
+	 *
+	 * @since 1.0.0
+	 * @since 2.5.0 Added the `$group` parameter.
+	 * @deprecated 12.0.0
+	 *
+	 * @param string          $permalink Permalink for the admin section of the group.
+	 * @param BP_Groups_Group $group     The group object.
+	 */
+	return apply_filters_deprecated( 'bp_get_group_admin_permalink', array( $permalink, $group ), '12.0.0', 'bp_get_group_manage_url' );
+}
+
+/**
  * Output blog directory permalink.
  *
  * @since 1.5.0

--- a/src/bp-groups/actions/access.php
+++ b/src/bp-groups/actions/access.php
@@ -32,7 +32,10 @@ function bp_groups_group_access_protection() {
 		} elseif ( is_user_logged_in() ) {
 			$no_access_args = array(
 				'message'  => __( 'You do not have access to this group.', 'buddypress' ),
-				'root'     => bp_get_group_permalink( $current_group ) . 'home/',
+				'root'     => bp_get_group_url(
+					$current_group,
+					bp_groups_get_path_chunks( array( 'home' ) )
+				),
 				'redirect' => false
 			);
 		}

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -3836,6 +3836,16 @@ function bp_get_group_screens( $context = 'read' ) {
 				'position'        => 10,
 				'item_css_id'     => 'home',
 			),
+			'activity'            => array(
+				'rewrite_id'      => 'bp_group_read_activity',
+				'slug'            => 'activity',
+				'name'            => _x( 'Activity', 'Group read screen', 'buddypress' ),
+				'screen_function' => 'groups_screen_group_activity',
+				'position'        => 11,
+				'user_has_access' => false,
+				'no_access_url'   => '',
+				'item_css_id'     => 'activity',
+			),
 			'request-membership' => array(
 				'rewrite_id'      => 'bp_group_read_request_membership',
 				'slug'            => 'request-membership',
@@ -3978,4 +3988,46 @@ function bp_get_group_screens( $context = 'read' ) {
 	}
 
 	return $context_screens;
+}
+
+/**
+ * Get single group's path chunks using an array of URL slugs.
+ *
+ * @since 12.0.0
+ *
+ * @param array $chunks An array of URL slugs.
+ * @return array An array of BP Rewrites URL arguments.
+ */
+function bp_groups_get_path_chunks( $chunks = array(), $context = 'read' ) {
+	$path_chunks   = array();
+	$group_screens = bp_get_group_screens( $context );
+
+	if ( 'read' === $context ) {
+		$single_item_action = array_shift( $chunks );
+		if ( $single_item_action ) {
+			if ( isset( $group_screens[ $single_item_action ]['rewrite_id'] ) ) {
+				$item_action_rewrite_id            = $group_screens[ $single_item_action ]['rewrite_id'];
+				$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'groups', $item_action_rewrite_id, $single_item_action );
+			} else {
+				$path_chunks['single_item_action'] = $single_item_action;
+			}
+		}
+	}
+
+	if ( $chunks ) {
+		foreach ( $chunks as $chunk ) {
+			if ( is_numeric( $chunk ) ) {
+				$path_chunks['single_item_action_variables'][] = $chunk;
+			} else {
+				if ( isset( $group_screens[ $chunk ]['rewrite_id'] ) ) {
+					$item_action_variable_rewrite_id               = $group_screens[ $chunk ]['rewrite_id'];
+					$path_chunks['single_item_action_variables'][] = bp_rewrites_get_slug( 'groups', $item_action_variable_rewrite_id, $chunk );
+				} else {
+					$path_chunks['single_item_action_variables'][] = $chunk;
+				}
+			}
+		}
+	}
+
+	return $path_chunks;
 }

--- a/src/bp-groups/bp-groups-notifications.php
+++ b/src/bp-groups/bp-groups-notifications.php
@@ -160,14 +160,15 @@ function groups_notification_new_membership_request( $requesting_user_id = 0, $a
 		}
 	}
 
-	$group = groups_get_group( $group_id );
-	$args  = array(
+	$group       = groups_get_group( $group_id );
+	$path_chunks = bp_groups_get_path_chunks( array( 'membership-requests' ), 'manage' );
+	$args        = array(
 		'tokens' => array(
 			'admin.id'             => $admin_id,
 			'group'                => $group,
 			'group.name'           => $group->name,
 			'group.id'             => $group_id,
-			'group-requests.url'   => esc_url( bp_get_group_permalink( $group ) . 'admin/membership-requests' ),
+			'group-requests.url'   => esc_url( bp_get_group_manage_url( $group, $path_chunks ) ),
 			'profile.url'          => esc_url( bp_members_get_user_url( $requesting_user_id ) ),
 			'requesting-user.id'   => $requesting_user_id,
 			'requesting-user.name' => bp_core_get_user_displayname( $requesting_user_id ),

--- a/src/bp-groups/classes/class-bp-group-extension.php
+++ b/src/bp-groups/classes/class-bp-group-extension.php
@@ -869,8 +869,11 @@ class BP_Group_Extension {
 		if ( ! $user_can_visit && is_user_logged_in() ) {
 			$current_group = groups_get_group( $this->group_id );
 
-			$no_access_args['message'] = __( 'You do not have access to this content.', 'buddypress' );
-			$no_access_args['root'] = bp_get_group_permalink( $current_group ) . 'home/';
+			$no_access_args['message']  = __( 'You do not have access to this content.', 'buddypress' );
+			$no_access_args['root']     = bp_get_group_url(
+				$current_group,
+				bp_groups_get_path_chunks( array( 'home' ) )
+			);
 			$no_access_args['redirect'] = false;
 		}
 

--- a/src/bp-groups/classes/class-bp-groups-group-members-template.php
+++ b/src/bp-groups/classes/class-bp-groups-group-members-template.php
@@ -168,10 +168,15 @@ class BP_Groups_Group_Members_Template {
 		}
 
 		// Assemble the base URL for pagination.
-		$base_url = trailingslashit( bp_get_group_permalink( $current_group ) . bp_current_action() );
+		$chunks = array( bp_current_action() );
 		if ( bp_action_variable() ) {
-			$base_url = trailingslashit( $base_url . bp_action_variable() );
+			$chunks[] = bp_action_variable();
 		}
+
+		$base_url = bp_get_group_url(
+			$current_group,
+			bp_groups_get_path_chunks( $chunks )
+		);
 
 		$members_args = $r;
 

--- a/src/bp-groups/screens/single/admin.php
+++ b/src/bp-groups/screens/single/admin.php
@@ -13,11 +13,18 @@
  * @since 1.0.0
  */
 function groups_screen_group_admin() {
-	if ( !bp_is_groups_component() || !bp_is_current_action( 'admin' ) )
+	if ( ! bp_is_groups_component() || ! bp_is_current_action( 'admin' ) ) {
 		return false;
+	}
 
-	if ( bp_action_variables() )
+	if ( bp_action_variables() ) {
 		return false;
+	}
 
-	bp_core_redirect( bp_get_group_permalink( groups_get_current_group() ) . 'admin/edit-details/' );
+	$redirect = bp_get_group_manage_url(
+		groups_get_current_group(),
+		bp_groups_get_path_chunks( array( 'edit-details' ), 'manage' )
+	);
+
+	bp_core_redirect( $redirect );
 }

--- a/src/bp-groups/screens/single/admin/edit-details.php
+++ b/src/bp-groups/screens/single/admin/edit-details.php
@@ -53,7 +53,12 @@ function groups_screen_group_admin_edit_details() {
 			 */
 			do_action( 'groups_group_details_edited', $bp->groups->current_group->id );
 
-			bp_core_redirect( bp_get_group_permalink( groups_get_current_group() ) . 'admin/edit-details/' );
+			$redirect = bp_get_group_manage_url(
+				groups_get_current_group(),
+				bp_groups_get_path_chunks( array( 'edit-details' ), 'manage' )
+			);
+
+			bp_core_redirect( $redirect );
 		}
 
 		/**

--- a/src/bp-groups/screens/single/admin/group-settings.php
+++ b/src/bp-groups/screens/single/admin/group-settings.php
@@ -83,7 +83,12 @@ function groups_screen_group_admin_settings() {
 		 */
 		do_action( 'groups_group_settings_edited', $bp->groups->current_group->id );
 
-		bp_core_redirect( bp_get_group_permalink( groups_get_current_group() ) . 'admin/group-settings/' );
+		$redirect = bp_get_group_manage_url(
+			groups_get_current_group(),
+			bp_groups_get_path_chunks( array( 'group-settings' ), 'manage' )
+		);
+
+		bp_core_redirect( $redirect );
 	}
 
 	/**

--- a/src/bp-groups/screens/single/admin/manage-members.php
+++ b/src/bp-groups/screens/single/admin/manage-members.php
@@ -14,13 +14,19 @@
  */
 function groups_screen_group_admin_manage_members() {
 
-	if ( 'manage-members' != bp_get_group_current_admin_tab() )
+	if ( 'manage-members' != bp_get_group_current_admin_tab() ) {
 		return false;
+	}
 
-	if ( ! bp_is_item_admin() )
+	if ( ! bp_is_item_admin() ) {
 		return false;
+	}
 
-	$bp = buddypress();
+	$bp       = buddypress();
+	$redirect = bp_get_group_manage_url(
+		groups_get_current_group(),
+		bp_groups_get_path_chunks( array( 'manage-members' ), 'manage' )
+	);
 
 	if ( bp_action_variable( 1 ) && bp_action_variable( 2 ) && bp_action_variable( 3 ) ) {
 		if ( bp_is_action_variable( 'promote', 1 ) && ( bp_is_action_variable( 'mod', 2 ) || bp_is_action_variable( 'admin', 2 ) ) && is_numeric( bp_action_variable( 3 ) ) ) {
@@ -28,14 +34,16 @@ function groups_screen_group_admin_manage_members() {
 			$status  = bp_action_variable( 2 );
 
 			// Check the nonce first.
-			if ( !check_admin_referer( 'groups_promote_member' ) )
+			if ( ! check_admin_referer( 'groups_promote_member' ) ) {
 				return false;
+			}
 
 			// Promote a user.
-			if ( !groups_promote_member( $user_id, $bp->groups->current_group->id, $status ) )
+			if ( ! groups_promote_member( $user_id, $bp->groups->current_group->id, $status ) ) {
 				bp_core_add_message( __( 'There was an error when promoting that user. Please try again.', 'buddypress' ), 'error' );
-			else
+			} else {
 				bp_core_add_message( __( 'User promoted successfully', 'buddypress' ) );
+			}
 
 			/**
 			 * Fires before the redirect after a group member has been promoted.
@@ -47,7 +55,7 @@ function groups_screen_group_admin_manage_members() {
 			 */
 			do_action( 'groups_promoted_member', $user_id, $bp->groups->current_group->id );
 
-			bp_core_redirect( bp_get_group_permalink( groups_get_current_group() ) . 'admin/manage-members/' );
+			bp_core_redirect( $redirect );
 		}
 	}
 
@@ -56,19 +64,21 @@ function groups_screen_group_admin_manage_members() {
 			$user_id = bp_action_variable( 2 );
 
 			// Check the nonce first.
-			if ( !check_admin_referer( 'groups_demote_member' ) )
+			if ( ! check_admin_referer( 'groups_demote_member' ) ) {
 				return false;
+			}
 
 			// Stop sole admins from abandoning their group.
 			$group_admins = groups_get_group_admins( $bp->groups->current_group->id );
-			if ( 1 == count( $group_admins ) && $group_admins[0]->user_id == $user_id )
+			if ( 1 == count( $group_admins ) && $group_admins[0]->user_id == $user_id ) {
 				bp_core_add_message( __( 'This group must have at least one admin', 'buddypress' ), 'error' );
 
-			// Demote a user.
-			elseif ( !groups_demote_member( $user_id, $bp->groups->current_group->id ) )
+				// Demote a user.
+			} elseif ( ! groups_demote_member( $user_id, $bp->groups->current_group->id ) ) {
 				bp_core_add_message( __( 'There was an error when demoting that user. Please try again.', 'buddypress' ), 'error' );
-			else
+			} else {
 				bp_core_add_message( __( 'User demoted successfully', 'buddypress' ) );
+			}
 
 			/**
 			 * Fires before the redirect after a group member has been demoted.
@@ -80,21 +90,23 @@ function groups_screen_group_admin_manage_members() {
 			 */
 			do_action( 'groups_demoted_member', $user_id, $bp->groups->current_group->id );
 
-			bp_core_redirect( bp_get_group_permalink( groups_get_current_group() ) . 'admin/manage-members/' );
+			bp_core_redirect( $redirect );
 		}
 
 		if ( bp_is_action_variable( 'ban', 1 ) && is_numeric( bp_action_variable( 2 ) ) ) {
 			$user_id = bp_action_variable( 2 );
 
 			// Check the nonce first.
-			if ( !check_admin_referer( 'groups_ban_member' ) )
+			if ( ! check_admin_referer( 'groups_ban_member' ) ) {
 				return false;
+			}
 
 			// Ban a user.
-			if ( !groups_ban_member( $user_id, $bp->groups->current_group->id ) )
+			if ( ! groups_ban_member( $user_id, $bp->groups->current_group->id ) ) {
 				bp_core_add_message( __( 'There was an error when banning that user. Please try again.', 'buddypress' ), 'error' );
-			else
+			} else {
 				bp_core_add_message( __( 'User banned successfully', 'buddypress' ) );
+			}
 
 			/**
 			 * Fires before the redirect after a group member has been banned.
@@ -106,21 +118,23 @@ function groups_screen_group_admin_manage_members() {
 			 */
 			do_action( 'groups_banned_member', $user_id, $bp->groups->current_group->id );
 
-			bp_core_redirect( bp_get_group_permalink( groups_get_current_group() ) . 'admin/manage-members/' );
+			bp_core_redirect( $redirect );
 		}
 
 		if ( bp_is_action_variable( 'unban', 1 ) && is_numeric( bp_action_variable( 2 ) ) ) {
 			$user_id = bp_action_variable( 2 );
 
 			// Check the nonce first.
-			if ( !check_admin_referer( 'groups_unban_member' ) )
+			if ( ! check_admin_referer( 'groups_unban_member' ) ) {
 				return false;
+			}
 
 			// Remove a ban for user.
-			if ( !groups_unban_member( $user_id, $bp->groups->current_group->id ) )
+			if ( ! groups_unban_member( $user_id, $bp->groups->current_group->id ) ) {
 				bp_core_add_message( __( 'There was an error when unbanning that user. Please try again.', 'buddypress' ), 'error' );
-			else
+			} else {
 				bp_core_add_message( __( 'User ban removed successfully', 'buddypress' ) );
+			}
 
 			/**
 			 * Fires before the redirect after a group member has been unbanned.
@@ -132,21 +146,23 @@ function groups_screen_group_admin_manage_members() {
 			 */
 			do_action( 'groups_unbanned_member', $user_id, $bp->groups->current_group->id );
 
-			bp_core_redirect( bp_get_group_permalink( groups_get_current_group() ) . 'admin/manage-members/' );
+			bp_core_redirect( $redirect );
 		}
 
 		if ( bp_is_action_variable( 'remove', 1 ) && is_numeric( bp_action_variable( 2 ) ) ) {
 			$user_id = bp_action_variable( 2 );
 
 			// Check the nonce first.
-			if ( !check_admin_referer( 'groups_remove_member' ) )
+			if ( ! check_admin_referer( 'groups_remove_member' ) ) {
 				return false;
+			}
 
 			// Remove a user.
-			if ( !groups_remove_member( $user_id, $bp->groups->current_group->id ) )
+			if ( ! groups_remove_member( $user_id, $bp->groups->current_group->id ) ) {
 				bp_core_add_message( __( 'There was an error removing that user from the group. Please try again.', 'buddypress' ), 'error' );
-			else
+			} else {
 				bp_core_add_message( __( 'User removed successfully', 'buddypress' ) );
+			}
 
 			/**
 			 * Fires before the redirect after a group member has been removed.
@@ -158,7 +174,7 @@ function groups_screen_group_admin_manage_members() {
 			 */
 			do_action( 'groups_removed_member', $user_id, $bp->groups->current_group->id );
 
-			bp_core_redirect( bp_get_group_permalink( groups_get_current_group() ) . 'admin/manage-members/' );
+			bp_core_redirect( $redirect );
 		}
 	}
 

--- a/src/bp-groups/screens/single/admin/membership-requests.php
+++ b/src/bp-groups/screens/single/admin/membership-requests.php
@@ -71,7 +71,13 @@ function groups_screen_group_admin_requests() {
 		 * @param int    $group_id       The ID of the requested group.
 		 */
 		do_action( 'groups_group_request_managed', $bp->groups->current_group->id, $request_action, $membership_id, $user_id, $group_id );
-		bp_core_redirect( bp_get_group_permalink( groups_get_current_group() ) . 'admin/membership-requests/' );
+
+		$redirect = bp_get_group_manage_url(
+			groups_get_current_group(),
+			bp_groups_get_path_chunks( array( 'membership-requests' ), 'manage' )
+		);
+
+		bp_core_redirect( $redirect );
 	}
 
 	/**

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -139,7 +139,7 @@ function bp_core_get_users( $args = '' ) {
 }
 
 /**
- * Get members path chunks using an array of URL slugs.
+ * Get single member's path chunks using an array of URL slugs.
  *
  * @since 12.0.0
  *
@@ -163,10 +163,14 @@ function bp_members_get_path_chunks( $chunks = array() ) {
 		$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'members', 'member_' . $item_component_rewrite_id_suffix . '_' . $item_action_rewrite_id_suffix, $single_item_action );
 	}
 
-	if ( $chunks && $item_component_rewrite_id_suffix && $item_component_rewrite_id_suffix ) {
+	if ( $chunks && $item_component_rewrite_id_suffix && $item_action_rewrite_id_suffix ) {
 		foreach ( $chunks as $chunk ) {
-			$item_action_variable_rewrite_id_suffix        =  str_replace( '-', '_', $chunk );
-			$path_chunks['single_item_action_variables'][] = bp_rewrites_get_slug( 'members', 'member_' . $item_component_rewrite_id_suffix . '_' . $item_action_rewrite_id_suffix . '_' . $item_action_variable_rewrite_id_suffix, $chunk );
+			if ( is_numeric( $chunk ) ) {
+				$path_chunks['single_item_action_variables'][] = $chunk;
+			} else {
+				$item_action_variable_rewrite_id_suffix        =  str_replace( '-', '_', $chunk );
+				$path_chunks['single_item_action_variables'][] = bp_rewrites_get_slug( 'members', 'member_' . $item_component_rewrite_id_suffix . '_' . $item_action_rewrite_id_suffix . '_' . $item_action_variable_rewrite_id_suffix, $chunk );
+			}
 		}
 	}
 

--- a/src/bp-templates/bp-legacy/buddypress-functions.php
+++ b/src/bp-templates/bp-legacy/buddypress-functions.php
@@ -1422,9 +1422,12 @@ function bp_legacy_theme_ajax_invite_user() {
 
 		$user = new BP_Core_User( $friend_id );
 
-		$uninvite_url = bp_is_current_action( 'create' )
-			? bp_get_groups_directory_permalink() . 'create/step/group-invites/?user_id=' . $friend_id
-			: bp_get_group_permalink( $group )    . 'send-invites/remove/' . $friend_id;
+		if ( bp_is_current_action( 'create' ) ) {
+			$uninvite_url = bp_get_groups_directory_permalink() . 'create/step/group-invites/?user_id=' . $friend_id;
+		} else {
+			$path_chunks  = bp_groups_get_path_chunks( array( 'send-invites', 'remove', $friend_id ) );
+			$uninvite_url = bp_get_group_url( $group, $path_chunks );
+		}
 
 		echo '<li id="uid-' . esc_attr( $user->id ) . '">';
 		echo $user->avatar_thumb;
@@ -1640,7 +1643,14 @@ function bp_legacy_theme_ajax_joinleave_group() {
 			if ( ! groups_join_group( $group->id ) ) {
 				_e( 'Error joining group', 'buddypress' );
 			} else {
-				echo '<a id="group-' . esc_attr( $group->id ) . '" class="group-button leave-group" rel="leave" href="' . wp_nonce_url( bp_get_group_permalink( $group ) . 'leave-group', 'groups_leave_group' ) . '">' . __( 'Leave Group', 'buddypress' ) . '</a>';
+				$leave_url = wp_nonce_url(
+					bp_get_group_url(
+						$group,
+						bp_groups_get_path_chunks( array( 'leave-group' ) )
+					),
+					'groups_leave_group'
+				);
+				echo '<a id="group-' . esc_attr( $group->id ) . '" class="group-button leave-group" rel="leave" href="' . esc_url( $leave_url ) . '">' . __( 'Leave Group', 'buddypress' ) . '</a>';
 			}
 		break;
 
@@ -1654,7 +1664,14 @@ function bp_legacy_theme_ajax_joinleave_group() {
 			if ( ! groups_accept_invite( bp_loggedin_user_id(), $group->id ) ) {
 				_e( 'Error requesting membership', 'buddypress' );
 			} else {
-				echo '<a id="group-' . esc_attr( $group->id ) . '" class="group-button leave-group" rel="leave" href="' . wp_nonce_url( bp_get_group_permalink( $group ) . 'leave-group', 'groups_leave_group' ) . '">' . __( 'Leave Group', 'buddypress' ) . '</a>';
+				$leave_url = wp_nonce_url(
+					bp_get_group_url(
+						$group,
+						bp_groups_get_path_chunks( array( 'leave-group' ) )
+					),
+					'groups_leave_group'
+				);
+				echo '<a id="group-' . esc_attr( $group->id ) . '" class="group-button leave-group" rel="leave" href="' . esc_url( $leave_url ) . '">' . __( 'Leave Group', 'buddypress' ) . '</a>';
 			}
 		break;
 
@@ -1674,9 +1691,23 @@ function bp_legacy_theme_ajax_joinleave_group() {
 			if ( ! groups_leave_group( $group->id ) ) {
 				_e( 'Error leaving group', 'buddypress' );
 			} elseif ( 'public' === $group->status ) {
-				echo '<a id="group-' . esc_attr( $group->id ) . '" class="group-button join-group" rel="join" href="' . wp_nonce_url( bp_get_group_permalink( $group ) . 'join', 'groups_join_group' ) . '">' . __( 'Join Group', 'buddypress' ) . '</a>';
+				$join_url = wp_nonce_url(
+					bp_get_group_url(
+						$group,
+						bp_groups_get_path_chunks( array( 'join' ) )
+					),
+					'groups_join_group'
+				);
+				echo '<a id="group-' . esc_attr( $group->id ) . '" class="group-button join-group" rel="join" href="' . esc_url( $join_url ) . '">' . __( 'Join Group', 'buddypress' ) . '</a>';
 			} else {
-				echo '<a id="group-' . esc_attr( $group->id ) . '" class="group-button request-membership" rel="join" href="' . wp_nonce_url( bp_get_group_permalink( $group ) . 'request-membership', 'groups_request_membership' ) . '">' . __( 'Request Membership', 'buddypress' ) . '</a>';
+				$request_url = wp_nonce_url(
+					bp_get_group_url(
+						$group,
+						bp_groups_get_path_chunks( array( 'request-membership' ) )
+					),
+					'groups_request_membership'
+				);
+				echo '<a id="group-' . esc_attr( $group->id ) . '" class="group-button request-membership" rel="join" href="' . esc_url( $request_url ) . '">' . __( 'Request Membership', 'buddypress' ) . '</a>';
 			}
 		break;
 	}


### PR DESCRIPTION
- Introduce the `bp_groups_get_path_chunks()` function to build BP Rewrites arguments using a regular array.
- Improve `bp_members_get_path_chunks()` so that it avoids looking for a custom slug when the chunk is a numeric value.
- Introduce the `bp_get_group_manage_url()` function to build Group's front-end Admin URLs using BP Rewrites.
- Deprecate `bp_group_admin_permalink()` & `bp_get_group_admin_permalink()` in favor of `bp_group_manage_url()` & `bp_get_group_manage_url()`.
- Replace all remaining usage of `bp_get_group_permalink()` in favor of `bp_get_group_url()` or `bp_get_group_manage_url()`.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/4954

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
