### PR TITLE
Make sure trying to filter groups directory with an unregistered group type ends up as a 404

### DIFF
--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -2779,11 +2779,13 @@ function bp_is_user_members_invitations_send_screen() {
  * @return bool True if the current page is the groups directory.
  */
 function bp_is_groups_directory() {
-	if ( bp_is_groups_component() && ! bp_is_group() && ( ! bp_current_action() || ( bp_action_variable() && bp_is_current_action( bp_get_groups_group_type_base() ) ) ) ) {
-		return true;
+	$return = false;
+
+	if ( bp_is_groups_component() && ! bp_is_group() ) {
+		$return = ! bp_current_action() || ! empty( buddypress()->groups->current_directory_type );
 	}
 
-	return false;
+	return $return;
 }
 
 /**

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -323,19 +323,21 @@ class BP_Groups_Component extends BP_Component {
 
 		// Set group type if available.
 		if ( bp_is_groups_directory() && bp_is_current_action( bp_get_groups_group_type_base() ) && bp_action_variable() ) {
-			$matched_types = bp_groups_get_group_types( array(
-				'has_directory'  => true,
-				'directory_slug' => bp_action_variable(),
-			) );
+			$matched_type  = '';
+			$matched_types = bp_groups_get_group_types(
+				array(
+					'has_directory'  => true,
+					'directory_slug' => bp_action_variable(),
+				)
+			);
 
 			// Set 404 if we do not have a valid group type.
-			if ( empty( $matched_types ) ) {
-				bp_do_404();
-				return;
+			if ( ! empty( $matched_types ) ) {
+				$matched_type = reset( $matched_types );
 			}
 
 			// Set our directory type marker.
-			$this->current_directory_type = reset( $matched_types );
+			$this->current_directory_type = $matched_type;
 		}
 
 		// Set up variables specific to the group creation process.
@@ -365,10 +367,11 @@ class BP_Groups_Component extends BP_Component {
 			'avatar',
 			$this->slug,
 			$this->root_slug,
+			bp_get_groups_group_type_base(),
 		) );
 
 		// If the user was attempting to access a group, but no group by that name was found, 404.
-		if ( bp_is_groups_component() && empty( $this->current_group ) && empty( $this->current_directory_type ) && bp_current_action() && ! in_array( bp_current_action(), $this->forbidden_names ) ) {
+		if ( bp_is_groups_component() && empty( $this->current_group ) && bp_current_action() && ! in_array( bp_current_action(), $this->forbidden_names ) ) {
 			bp_do_404();
 			return;
 		}

--- a/src/bp-groups/classes/class-bp-groups-theme-compat.php
+++ b/src/bp-groups/classes/class-bp-groups-theme-compat.php
@@ -36,8 +36,9 @@ class BP_Groups_Theme_Compat {
 	public function is_group() {
 
 		// Bail if not looking at a group.
-		if ( ! bp_is_groups_component() )
+		if ( ! bp_is_groups_component() ) {
 			return;
+		}
 
 		// Group Directory.
 		if ( bp_is_groups_directory() ) {

--- a/tests/phpunit/testcases/routing/groups.php
+++ b/tests/phpunit/testcases/routing/groups.php
@@ -74,9 +74,9 @@ class BP_Tests_Routing_Groups extends BP_UnitTestCase {
 	 */
 	public function test_group_directory_should_404_for_group_types_that_have_no_directory() {
 		$this->set_permalink_structure( '/%postname%/' );
-		bp_register_member_type( 'foo', array( 'has_directory' => false ) );
-		$this->go_to( bp_get_members_directory_permalink() . 'type/foo/' );
-		$this->assertTrue( is_404() );
+		bp_groups_register_group_type( 'taz', array( 'has_directory' => false ) );
+		$this->go_to( bp_get_groups_directory_permalink() . 'type/taz/' );
+		$this->assertEmpty( bp_get_current_group_directory_type() );
 	}
 
 	/**
@@ -84,8 +84,8 @@ class BP_Tests_Routing_Groups extends BP_UnitTestCase {
 	 */
 	public function test_group_directory_should_404_for_invalid_group_types() {
 		$this->set_permalink_structure( '/%postname%/' );
-		$this->go_to( bp_get_members_directory_permalink() . 'type/foo/' );
-		$this->assertTrue( is_404() );
+		$this->go_to( bp_get_groups_directory_permalink() . 'type/zat/' );
+		$this->assertEmpty( bp_get_current_group_directory_type() );
 	}
 
 	/**


### PR DESCRIPTION
After more thoughts, I believe we should maintain the way to handle this case as it was first designed. This PR changes how to check a loaded groups directory page is about displaying groups having a specific type to make sure we end up to a 404 if the corresponding group type is not registered or do not support directory filtering.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8866

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
