### PR TITLE
BP Rewrites merge, step 11.

### DIFF
--- a/src/bp-blogs/actions/random.php
+++ b/src/bp-blogs/actions/random.php
@@ -25,7 +25,7 @@ function bp_blogs_redirect_to_random_blog() {
 
 	// No multisite and still called, always redirect to root.
 	} else {
-		bp_core_redirect( bp_core_get_root_domain() );
+		bp_core_redirect( bp_get_root_url() );
 	}
 }
 add_action( 'bp_actions', 'bp_blogs_redirect_to_random_blog' );

--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -512,7 +512,12 @@ function bp_core_get_admin_settings_tabs( $apply_filters = true ) {
 	 *
 	 * @param array $settings_tabs The BP Admin settings tabs.
 	 */
-	return apply_filters( 'bp_core_get_admin_settings_tabs', $settings_tabs );
+	$settings_tabs = apply_filters( 'bp_core_get_admin_settings_tabs', $settings_tabs );
+
+	// Sort tabs before returning it.
+	ksort( $settings_tabs );
+
+	return $settings_tabs;
 }
 
 /**
@@ -558,7 +563,12 @@ function bp_core_get_admin_tools_tabs( $apply_filters = true ) {
 	 *
 	 * @param array $tools_tabs The BP Admin tools tabs.
 	 */
-	return apply_filters( 'bp_core_get_admin_tools_tabs', $tools_tabs );
+	$tools_tabs = apply_filters( 'bp_core_get_admin_tools_tabs', $tools_tabs );
+
+	// Sort tabs before returning it.
+	ksort( $tools_tabs );
+
+	return $tools_tabs;
 }
 
 /**

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -1104,31 +1104,6 @@ function bp_do_register_theme_directory() {
 /** URI ***********************************************************************/
 
 /**
- * Return the domain for the root blog.
- *
- * Eg: http://example.com OR https://example.com
- *
- * @since 1.0.0
- * @deprecated 12.0.0
- *
- * @return string The domain URL for the blog.
- */
-function bp_core_get_root_domain() {
-	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_rewrites_get_root_url()' );
-	$domain = bp_rewrites_get_root_url();
-
-	/**
-	 * Filters the domain for the root blog.
-	 *
-	 * @since 1.0.1
-	 * @deprecated 12.0.0 Use {@see 'bp_rewrites_get_root_url'} instead.
-	 *
-	 * @param string $domain The domain URL for the blog.
-	 */
-	return apply_filters_deprecated( 'bp_core_get_root_domain', array( $domain ), '12.0.0', 'bp_rewrites_get_root_url' );
-}
-
-/**
  * Perform a status-safe wp_redirect() that is compatible with BP's URI parser.
  *
  * @since 1.0.0

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -1452,52 +1452,6 @@ function bp_root_url() {
 }
 
 /**
- * Output the "root domain", the URL of the BP root blog.
- *
- * @since 1.1.0
- * @deprecated 12.0.0
- */
-function bp_root_domain() {
-	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_root_url()' );
-	bp_root_url();
-}
-	/**
-	 * Return the "root domain", the URL of the BP root blog.
-	 *
-	 * @since 1.1.0
-	 * @deprecated 12.0.0
-	 *
-	 * @return string URL of the BP root blog.
-	 */
-	function bp_get_root_domain() {
-		/*
-		 * This function is used at many places and we need to review all this
-		 * places during the 12.0 development cycle. Using BP Rewrites means we
-		 * cannot concatenate URL chunks to build our URL anymore. We now need
-		 * to use `bp_rewrites_get_url( $array )` and make sure to use the right
-		 * arguments inside this `$array`.
-		 *
-		 * @todo Once every link reviewed, we'll be able to remove this check
-		 *       and let PHPUnit tell us the one we forgot, eventually!
-		 */
-		if ( ! buddypress()->is_phpunit_running ) {
-			_deprecated_function( __FUNCTION__, '12.0.0', 'bp_get_root_url()' );
-		}
-
-		$domain = bp_get_root_url();
-
-		/**
-		 *  Filters the "root domain", the URL of the BP root blog.
-		 *
-		 * @since 1.2.4
-		 * @deprecated 12.0.0 Use {@see 'bp_get_root_url'} instead.
-		 *
-		 * @param string $domain URL of the BP root blog.
-		 */
-		return apply_filters_deprecated( 'bp_core_get_root_domain', array( $domain ), '12.0.0', 'bp_get_root_url' );
-	}
-
-/**
  * Output the root slug for a given component.
  *
  * @since 1.5.0

--- a/src/bp-core/deprecated/12.0.php
+++ b/src/bp-core/deprecated/12.0.php
@@ -11,21 +11,155 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
- * Add support for a top-level ("root") component.
- *
- * This function originally (pre-1.5) let plugins add support for pages in the
- * root of the install. These root level pages are now handled by actual
- * WordPress pages and this function is now a convenience for compatibility
- * with the new method.
- *
- * @since 1.0.0
- * @deprecated 12.0.0
- *
- * @param string $slug The slug of the component being added to the root list.
- */
-function bp_core_add_root_component( $slug ) {
-	_deprecated_function( __FUNCTION__, '12.0.0' );
+// These functions has been moved to the BP Classic plugin.
+if ( ! function_exists( 'bp_classic' ) ) {
+	/**
+	 * Add support for a top-level ("root") component.
+	 *
+	 * This function originally (pre-1.5) let plugins add support for pages in the
+	 * root of the install. These root level pages are now handled by actual
+	 * WordPress pages and this function is now a convenience for compatibility
+	 * with the new method.
+	 *
+	 * @since 1.0.0
+	 * @deprecated 12.0.0
+	 *
+	 * @param string $slug The slug of the component being added to the root list.
+	 */
+	function bp_core_add_root_component( $slug ) {
+		_deprecated_function( __FUNCTION__, '12.0.0' );
+	}
+
+	/**
+	 * Return the domain for the root blog.
+	 *
+	 * Eg: http://example.com OR https://example.com
+	 *
+	 * @since 1.0.0
+	 * @deprecated 12.0.0
+	 *
+	 * @return string The domain URL for the blog.
+	 */
+	function bp_core_get_root_domain() {
+		_deprecated_function( __FUNCTION__, '12.0.0', 'bp_rewrites_get_root_url()' );
+		$domain = bp_rewrites_get_root_url();
+
+		/**
+		 * Filters the domain for the root blog.
+		 *
+		 * @since 1.0.1
+		 * @deprecated 12.0.0 Use {@see 'bp_rewrites_get_root_url'} instead.
+		 *
+		 * @param string $domain The domain URL for the blog.
+		 */
+		return apply_filters_deprecated( 'bp_core_get_root_domain', array( $domain ), '12.0.0', 'bp_rewrites_get_root_url' );
+	}
+
+	/**
+	 * Return the "root domain", the URL of the BP root blog.
+	 *
+	 * @since 1.1.0
+	 * @deprecated 12.0.0
+	 *
+	 * @return string URL of the BP root blog.
+	 */
+	function bp_get_root_domain() {
+		_deprecated_function( __FUNCTION__, '12.0.0', 'bp_get_root_url()' );
+		$domain = bp_get_root_url();
+
+		/**
+		 *  Filters the "root domain", the URL of the BP root blog.
+		 *
+		 * @since 1.2.4
+		 * @deprecated 12.0.0 Use {@see 'bp_get_root_url'} instead.
+		 *
+		 * @param string $domain URL of the BP root blog.
+		 */
+		return apply_filters_deprecated( 'bp_get_root_domain', array( $domain ), '12.0.0', 'bp_get_root_url' );
+	}
+
+	/**
+	 * Output the "root domain", the URL of the BP root blog.
+	 *
+	 * @since 1.1.0
+	 * @deprecated 12.0.0
+	 */
+	function bp_root_domain() {
+		_deprecated_function( __FUNCTION__, '12.0.0', 'bp_root_url()' );
+		bp_root_url();
+	}
+
+	/**
+	 * Renders the page mapping admin panel.
+	 *
+	 * @since 1.6.0
+	 * @deprecated 12.0.0
+	 */
+	function bp_core_admin_slugs_settings() {
+		_deprecated_function( __FUNCTION__, '12.0.0' );
+	}
+
+	/**
+	 * Generate a list of directory pages, for use when building Components panel markup.
+	 *
+	 * @since 2.4.1
+	 * @deprecated 12.0.0
+	 *
+	 * @return array
+	 */
+	function bp_core_admin_get_directory_pages() {
+		_deprecated_function( __FUNCTION__, '12.0.0' );
+
+		$directory_pages = (array) bp_core_get_directory_pages();
+		$return          =  wp_list_pluck( $directory_pages, 'name', 'id' );
+
+		return apply_filters_deprecated( 'bp_directory_pages', array( $return ), '12.0.0' );
+	}
+
+	/**
+	 * Generate a list of static pages, for use when building Components panel markup.
+	 *
+	 * By default, this list contains 'register' and 'activate'.
+	 *
+	 * @since 2.4.1
+	 * @deprecated 12.0.0
+	 *
+	 * @return array
+	 */
+	function bp_core_admin_get_static_pages() {
+		_deprecated_function( __FUNCTION__, '12.0.0' );
+
+		$static_pages = array(
+			'register' => __( 'Register', 'buddypress' ),
+			'activate' => __( 'Activate', 'buddypress' ),
+		);
+
+		return apply_filters_deprecated( 'bp_directory_pages', array( $static_pages ), '12.0.0' );
+	}
+
+	/**
+	 * Creates reusable markup for page setup on the Components and Pages dashboard panel.
+	 *
+	 * @package BuddyPress
+	 * @since 1.6.0
+	 * @deprecated 12.0.0
+	 */
+	function bp_core_admin_slugs_options() {
+		_deprecated_function( __FUNCTION__, '12.0.0' );
+
+		do_action_deprecated( 'bp_active_external_directories', array(), '12.0.0' );
+		do_action_deprecated( 'bp_active_external_pages', array(), '12.0.0' );
+	}
+
+	/**
+	 * Handle saving of the BuddyPress slugs.
+	 *
+	 * @since 1.6.0
+	 * @deprecated 12.0.0
+	 */
+	function bp_core_admin_slugs_setup_handler() {
+		_deprecated_function( __FUNCTION__, '12.0.0' );
+	}
 }
 
 /**
@@ -66,78 +200,6 @@ function bp_core_component_slug_from_root_slug( $root_slug ) {
 	_deprecated_function( __FUNCTION__, '12.0.0' );
 
 	return apply_filters_deprecated( 'bp_core_component_slug_from_root_slug', array( $root_slug, $root_slug ), '12.0.0' );
-}
-
-/**
- * Renders the page mapping admin panel.
- *
- * @since 1.6.0
- * @deprecated 12.0.0
- */
-function bp_core_admin_slugs_settings() {
-	_deprecated_function( __FUNCTION__, '12.0.0' );
-}
-
-/**
- * Generate a list of directory pages, for use when building Components panel markup.
- *
- * @since 2.4.1
- * @deprecated 12.0.0
- *
- * @return array
- */
-function bp_core_admin_get_directory_pages() {
-	_deprecated_function( __FUNCTION__, '12.0.0' );
-
-	$directory_pages = (array) bp_core_get_directory_pages();
-	$return          =  wp_list_pluck( $directory_pages, 'name', 'id' );
-
-	return apply_filters_deprecated( 'bp_directory_pages', array( $return ), '12.0.0' );
-}
-
-/**
- * Generate a list of static pages, for use when building Components panel markup.
- *
- * By default, this list contains 'register' and 'activate'.
- *
- * @since 2.4.1
- * @deprecated 12.0.0
- *
- * @return array
- */
-function bp_core_admin_get_static_pages() {
-	_deprecated_function( __FUNCTION__, '12.0.0' );
-
-	$static_pages = array(
-		'register' => __( 'Register', 'buddypress' ),
-		'activate' => __( 'Activate', 'buddypress' ),
-	);
-
-	return apply_filters_deprecated( 'bp_directory_pages', array( $static_pages ), '12.0.0' );
-}
-
-/**
- * Creates reusable markup for page setup on the Components and Pages dashboard panel.
- *
- * @package BuddyPress
- * @since 1.6.0
- * @deprecated 12.0.0
- */
-function bp_core_admin_slugs_options() {
-	_deprecated_function( __FUNCTION__, '12.0.0' );
-
-	do_action_deprecated( 'bp_active_external_directories', array(), '12.0.0' );
-	do_action_deprecated( 'bp_active_external_pages', array(), '12.0.0' );
-}
-
-/**
- * Handle saving of the BuddyPress slugs.
- *
- * @since 1.6.0
- * @deprecated 12.0.0
- */
-function bp_core_admin_slugs_setup_handler() {
-	_deprecated_function( __FUNCTION__, '12.0.0' );
 }
 
 /**

--- a/src/bp-core/deprecated/12.0.php
+++ b/src/bp-core/deprecated/12.0.php
@@ -299,6 +299,41 @@ function bp_user_link() {
 }
 
 /**
+ * Output group directory permalink.
+ *
+ * @since 1.5.0
+ * @deprecated 12.0.0
+ */
+function bp_groups_directory_permalink() {
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_groups_directory_url()' );
+	bp_groups_directory_url();
+}
+
+/**
+ * Return group directory permalink.
+ *
+ * @since 1.5.0
+ * @deprecated 12.0.0
+ *
+ * @return string
+ */
+function bp_get_groups_directory_permalink() {
+	_deprecated_function( __FUNCTION__, '12.0.0', 'bp_get_groups_directory_url()' );
+
+	$url = bp_get_groups_directory_url();
+
+	/**
+	 * Filters the group directory permalink.
+	 *
+	 * @since 1.5.0
+	 * @deprecated 12.0.0
+	 *
+	 * @param string $url Permalink for the group directory.
+	 */
+	return apply_filters_deprecated( 'bp_get_groups_directory_permalink', array( $url ), '12.0.0', 'bp_get_groups_directory_url' );
+}
+
+/**
  * Output the permalink for the group.
  *
  * @since 1.0.0

--- a/src/bp-groups/actions/create.php
+++ b/src/bp-groups/actions/create.php
@@ -30,7 +30,8 @@ function groups_action_create_group() {
 		bp_core_redirect( bp_get_groups_directory_url() );
 	}
 
-	$bp = buddypress();
+	$bp           = buddypress();
+	$redirect_url = bp_groups_get_create_url();
 
 	// Make sure creation steps are in the right order.
 	groups_action_sort_creation_steps();
@@ -44,15 +45,16 @@ function groups_action_create_group() {
 		setcookie( 'bp_new_group_id', false, time() - 1000, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
 		setcookie( 'bp_completed_create_steps', false, time() - 1000, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
 
-		$reset_steps = true;
-		$keys        = array_keys( $bp->groups->group_creation_steps );
-		bp_core_redirect( trailingslashit( bp_get_groups_directory_permalink() . 'create/step/' . array_shift( $keys ) ) );
+		$reset_steps     = true;
+		$keys            = array_keys( $bp->groups->group_creation_steps );
+		$action_variable = array_shift( $keys );
+		bp_core_redirect( bp_groups_get_create_url( array( $action_variable ) ) );
 	}
 
 	// If this is a creation step that is not recognized, just redirect them back to the first screen.
 	if ( bp_get_groups_current_create_step() && empty( $bp->groups->group_creation_steps[bp_get_groups_current_create_step()] ) ) {
 		bp_core_add_message( __('There was an error saving group details. Please try again.', 'buddypress'), 'error' );
-		bp_core_redirect( trailingslashit( bp_get_groups_directory_permalink() . 'create' ) );
+		bp_core_redirect( $redirect_url );
 	}
 
 	// Fetch the currently completed steps variable.
@@ -66,7 +68,7 @@ function groups_action_create_group() {
 		// Only allow the group creator to continue to edit the new group.
 		if ( ! bp_is_group_creator( $bp->groups->current_group, bp_loggedin_user_id() ) ) {
 			bp_core_add_message( __( 'Only the group creator may continue editing this group.', 'buddypress' ), 'error' );
-			bp_core_redirect( trailingslashit( bp_get_groups_directory_permalink() . 'create' ) );
+			bp_core_redirect( $redirect_url );
 		}
 	}
 
@@ -79,14 +81,14 @@ function groups_action_create_group() {
 		if ( 'group-details' == bp_get_groups_current_create_step() ) {
 			if ( empty( $_POST['group-name'] ) || empty( $_POST['group-desc'] ) || !strlen( trim( $_POST['group-name'] ) ) || !strlen( trim( $_POST['group-desc'] ) ) ) {
 				bp_core_add_message( __( 'Please fill in all of the required fields', 'buddypress' ), 'error' );
-				bp_core_redirect( trailingslashit( bp_get_groups_directory_permalink() . 'create/step/' . bp_get_groups_current_create_step() ) );
+				bp_core_redirect( bp_groups_get_create_url( array( bp_get_groups_current_create_step() ) ) );
 			}
 
 			$new_group_id = isset( $bp->groups->new_group_id ) ? $bp->groups->new_group_id : 0;
 
-			if ( !$bp->groups->new_group_id = groups_create_group( array( 'group_id' => $new_group_id, 'name' => $_POST['group-name'], 'description' => $_POST['group-desc'], 'slug' => groups_check_slug( sanitize_title( esc_attr( $_POST['group-name'] ) ) ), 'date_created' => bp_core_current_time(), 'status' => 'public' ) ) ) {
+			if ( ! $bp->groups->new_group_id = groups_create_group( array( 'group_id' => $new_group_id, 'name' => $_POST['group-name'], 'description' => $_POST['group-desc'], 'slug' => groups_check_slug( sanitize_title( esc_attr( $_POST['group-name'] ) ) ), 'date_created' => bp_core_current_time(), 'status' => 'public' ) ) ) {
 				bp_core_add_message( __( 'There was an error saving group details. Please try again.', 'buddypress' ), 'error' );
-				bp_core_redirect( trailingslashit( bp_get_groups_directory_permalink() . 'create/step/' . bp_get_groups_current_create_step() ) );
+				bp_core_redirect( bp_groups_get_create_url( array( bp_get_groups_current_create_step() ) ) );
 			}
 		}
 
@@ -103,9 +105,9 @@ function groups_action_create_group() {
 			elseif ( 'hidden' == $_POST['group-status'] )
 				$group_status = 'hidden';
 
-			if ( !$bp->groups->new_group_id = groups_create_group( array( 'group_id' => $bp->groups->new_group_id, 'status' => $group_status, 'enable_forum' => $group_enable_forum ) ) ) {
+			if ( ! $bp->groups->new_group_id = groups_create_group( array( 'group_id' => $bp->groups->new_group_id, 'status' => $group_status, 'enable_forum' => $group_enable_forum ) ) ) {
 				bp_core_add_message( __( 'There was an error saving group details. Please try again.', 'buddypress' ), 'error' );
-				bp_core_redirect( trailingslashit( bp_get_groups_directory_permalink() . 'create/step/' . bp_get_groups_current_create_step() ) );
+				bp_core_redirect( bp_groups_get_create_url( array( bp_get_groups_current_create_step() ) ) );
 			}
 
 			// Save group types.
@@ -218,7 +220,8 @@ function groups_action_create_group() {
 				}
 			}
 
-			bp_core_redirect( trailingslashit( bp_get_groups_directory_permalink() . 'create/step/' . $next_step ) );
+			$redirect_url = bp_get_groups_directory_url( bp_groups_get_path_chunks( array( $next_step ), 'create' ) );
+			bp_core_redirect( $redirect_url );
 		}
 	}
 
@@ -237,7 +240,7 @@ function groups_action_create_group() {
 		}
 
 		bp_core_add_message( $message, $error );
-		bp_core_redirect( trailingslashit( bp_get_groups_directory_permalink() . 'create/step/group-invites' ) );
+		bp_core_redirect( bp_groups_get_create_url( array( 'group-invites' ) ) );
 	}
 
 	// Group avatar is handled separately.

--- a/src/bp-groups/bp-groups-admin.php
+++ b/src/bp-groups/bp-groups-admin.php
@@ -636,13 +636,9 @@ function bp_groups_admin_edit() {
 	$group_name = isset( $group->name ) ? bp_get_group_name( $group ) : '';
 
 	// Construct URL for form.
-	$form_url = remove_query_arg( array( 'action', 'deleted', 'no_admins', 'error', 'error_new', 'success_new', 'error_modified', 'success_modified' ), $_SERVER['REQUEST_URI'] );
-	$form_url = add_query_arg( 'action', 'save', $form_url );
-	$create_url = bp_get_groups_directory_url(
-		array(
-			'create_single_item' => 1,
-		)
-	);
+	$form_url   = remove_query_arg( array( 'action', 'deleted', 'no_admins', 'error', 'error_new', 'success_new', 'error_modified', 'success_modified' ), $_SERVER['REQUEST_URI'] );
+	$form_url   = add_query_arg( 'action', 'save', $form_url );
+	$create_url = bp_groups_get_create_url();
 
 	/**
 	 * Fires before the display of the edit form.
@@ -818,11 +814,7 @@ function bp_groups_admin_index() {
 
 	// Prepare the group items for display.
 	$bp_groups_list_table->prepare_items();
-	$create_url = bp_get_groups_directory_url(
-		array(
-			'create_single_item' => 1,
-		)
-	);
+	$create_url = bp_groups_get_create_url();
 
 	/**
 	 * Fires before the display of messages for the edit form.

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -4014,16 +4014,25 @@ function bp_groups_get_path_chunks( $chunks = array(), $context = 'read' ) {
 		}
 	}
 
+	$key_action_variables = 'single_item_action_variables';
+	if ( 'create' === $context ) {
+		$path_chunks['create_single_item'] = 1;
+		$key_action_variables              = 'create_single_item_variables';
+
+		// Init create action variables with the `step` slug.
+		$path_chunks[ $key_action_variables ][] = bp_rewrites_get_slug( 'groups', 'bp_group_create_step', 'step' );
+	}
+
 	if ( $chunks ) {
 		foreach ( $chunks as $chunk ) {
 			if ( is_numeric( $chunk ) ) {
-				$path_chunks['single_item_action_variables'][] = $chunk;
+				$path_chunks[ $key_action_variables ][] = $chunk;
 			} else {
 				if ( isset( $group_screens[ $chunk ]['rewrite_id'] ) ) {
-					$item_action_variable_rewrite_id               = $group_screens[ $chunk ]['rewrite_id'];
-					$path_chunks['single_item_action_variables'][] = bp_rewrites_get_slug( 'groups', $item_action_variable_rewrite_id, $chunk );
+					$item_action_variable_rewrite_id        = $group_screens[ $chunk ]['rewrite_id'];
+					$path_chunks[ $key_action_variables ][] = bp_rewrites_get_slug( 'groups', $item_action_variable_rewrite_id, $chunk );
 				} else {
-					$path_chunks['single_item_action_variables'][] = $chunk;
+					$path_chunks[ $key_action_variables ][] = $chunk;
 				}
 			}
 		}

--- a/src/bp-templates/bp-legacy/buddypress-functions.php
+++ b/src/bp-templates/bp-legacy/buddypress-functions.php
@@ -1423,7 +1423,11 @@ function bp_legacy_theme_ajax_invite_user() {
 		$user = new BP_Core_User( $friend_id );
 
 		if ( bp_is_current_action( 'create' ) ) {
-			$uninvite_url = bp_get_groups_directory_permalink() . 'create/step/group-invites/?user_id=' . $friend_id;
+			$uninvite_url = add_query_arg(
+				'user_id',
+				$user_id,
+				bp_get_groups_directory_url( bp_groups_get_path_chunks( array( 'group-invites' ), 'create' ) )
+			);
 		} else {
 			$path_chunks  = bp_groups_get_path_chunks( array( 'send-invites', 'remove', $friend_id ) );
 			$uninvite_url = bp_get_group_url( $group, $path_chunks );

--- a/src/bp-templates/bp-nouveau/includes/groups/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/functions.php
@@ -593,11 +593,7 @@ function bp_nouveau_get_groups_directory_nav_items() {
 				'component' => 'groups',
 				'slug'      => 'create', // slug is used because BP_Core_Nav requires it, but it's the scope
 				'li_class'  => array( 'no-ajax', 'group-create', 'create-button' ),
-				'link'      => bp_get_groups_directory_url(
-					array(
-						'create_single_item' => 1,
-					)
-				),
+				'link'      => bp_groups_get_create_url(),
 				'text'      => __( 'Create a Group', 'buddypress' ),
 				'count'     => false,
 				'position'  => 999,

--- a/tests/phpunit/testcases/core/nav/bpCoreNewSubnavItem.php
+++ b/tests/phpunit/testcases/core/nav/bpCoreNewSubnavItem.php
@@ -223,11 +223,11 @@ class BP_Tests_Core_Nav_BpCoreNewSubnavItem extends BP_UnitTestCase {
 			'name' => 'bar',
 			'slug' => 'bar',
 			'parent_slug' => 'foo',
-			'parent_url' => bp_get_root_domain() . 'foo/',
+			'parent_url' => bp_get_root_url() . 'foo/',
 			'screen_function' => 'foo',
 		) );
 
-		$expected = bp_get_root_domain() . 'foo/bar/';
+		$expected = bp_get_root_url() . 'foo/bar/';
 		$this->assertSame( $expected, buddypress()->bp_options_nav['foo']['bar']['link'] );
 	}
 
@@ -239,7 +239,7 @@ class BP_Tests_Core_Nav_BpCoreNewSubnavItem extends BP_UnitTestCase {
 		bp_core_new_nav_item( array(
 			'name' => 'foo',
 			'slug' => 'foo-parent',
-			'link' => bp_get_root_domain() . 'foo-parent/',
+			'link' => bp_get_root_url() . 'foo-parent/',
 			'default_subnav_slug' => 'bar',
 			'screen_function' => 'foo',
 		) );
@@ -248,11 +248,11 @@ class BP_Tests_Core_Nav_BpCoreNewSubnavItem extends BP_UnitTestCase {
 			'name' => 'bar',
 			'slug' => 'bar',
 			'parent_slug' => 'foo-parent',
-			'parent_url' => bp_get_root_domain() . '/foo-parent/',
+			'parent_url' => bp_get_root_url() . '/foo-parent/',
 			'screen_function' => 'bar',
 		) );
 
-		$expected = bp_get_root_domain() . '/foo-parent/bar/';
+		$expected = bp_get_root_url() . '/foo-parent/bar/';
 		$this->assertSame( $expected, buddypress()->bp_options_nav['foo-parent']['bar']['link'] );
 	}
 
@@ -295,7 +295,7 @@ class BP_Tests_Core_Nav_BpCoreNewSubnavItem extends BP_UnitTestCase {
 			'name' => 'Foo',
 			'slug' => 'foo',
 			'parent_slug' => 'parent',
-			'parent_url' => bp_get_root_domain() . '/parent/',
+			'parent_url' => bp_get_root_url() . '/parent/',
 			'screen_function' => 'foo',
 			'site_admin_only' => true,
 		);
@@ -317,7 +317,7 @@ class BP_Tests_Core_Nav_BpCoreNewSubnavItem extends BP_UnitTestCase {
 			'name' => 'Foo',
 			'slug' => 'foo',
 			'parent_slug' => 'parent',
-			'parent_url' => bp_get_root_domain() . '/parent/',
+			'parent_url' => bp_get_root_url() . '/parent/',
 			'screen_function' => 'foo',
 		);
 		bp_core_new_subnav_item( $args );
@@ -339,7 +339,7 @@ class BP_Tests_Core_Nav_BpCoreNewSubnavItem extends BP_UnitTestCase {
 			'name' => 'Foo',
 			'slug' => 'foo',
 			'parent_slug' => 'parent',
-			'parent_url' => bp_get_root_domain() . '/parent/',
+			'parent_url' => bp_get_root_url() . '/parent/',
 			'screen_function' => 'foo',
 			'item_css_id' => 'bar',
 		);

--- a/tests/phpunit/testcases/routing/groups.php
+++ b/tests/phpunit/testcases/routing/groups.php
@@ -55,7 +55,13 @@ class BP_Tests_Routing_Groups extends BP_UnitTestCase {
 	public function test_group_directory_with_type() {
 		$this->set_permalink_structure( '/%postname%/' );
 		bp_groups_register_group_type( 'foo' );
-		$this->go_to( bp_get_groups_directory_permalink() . 'type/foo/' );
+		$this->go_to(
+			bp_get_groups_directory_url(
+				array(
+					'directory_type' => 'foo',
+				)
+			)
+		);
 		$this->assertTrue( bp_is_groups_component() && ! bp_is_group() && bp_is_current_action( bp_get_groups_group_type_base() ) && bp_is_action_variable( 'foo', 0 ) );
 	}
 
@@ -65,7 +71,13 @@ class BP_Tests_Routing_Groups extends BP_UnitTestCase {
 	public function test_group_directory_with_type_that_has_custom_directory_slug() {
 		$this->set_permalink_structure( '/%postname%/' );
 		bp_groups_register_group_type( 'foo', array( 'has_directory' => 'foos' ) );
-		$this->go_to( bp_get_groups_directory_permalink() . 'type/foos/' );
+		$this->go_to(
+			bp_get_groups_directory_url(
+				array(
+					'directory_type' => 'foos',
+				)
+			)
+		);
 		$this->assertTrue( bp_is_groups_component() && ! bp_is_group() && bp_is_current_action( bp_get_groups_group_type_base() ) && bp_is_action_variable( 'foos', 0 ) );
 	}
 
@@ -101,7 +113,13 @@ class BP_Tests_Routing_Groups extends BP_UnitTestCase {
 			'slug'     => 'ralph',
 		) );
 
-		$this->go_to( bp_get_groups_directory_permalink() . 'ralph' );
+		$this->go_to(
+			bp_get_groups_directory_url(
+				array(
+					'directory_type' => 'ralph',
+				)
+			)
+		);
 
 		$this->assertEquals( $g1, bp_get_current_group_id() );
 	}
@@ -120,7 +138,14 @@ class BP_Tests_Routing_Groups extends BP_UnitTestCase {
 			'slug'           => 'sam!',
 			'notify_members' => false,
 		) );
-		$this->go_to( bp_get_groups_directory_permalink() . 'george' );
+
+		$this->go_to(
+			bp_get_groups_directory_url(
+				array(
+					'directory_type' => 'george',
+				)
+			)
+		);
 
 		$this->assertEquals( $g1, bp_get_current_group_id() );
 	}
@@ -147,7 +172,14 @@ class BP_Tests_Routing_Groups extends BP_UnitTestCase {
 			'notify_members' => false,
 		) );
 
-		$this->go_to( bp_get_groups_directory_permalink() . 'george' );
+		$this->go_to(
+			bp_get_groups_directory_url(
+				array(
+					'directory_type' => 'george',
+				)
+			)
+		);
+
 		$this->assertEquals( $g2, bp_get_current_group_id() );
 	}
 


### PR DESCRIPTION
- Start moving deprecated functions inside a `function_exists( 'bp_classic' )` check, corresponding functions were added inside the [BP Classic](https://github.com/buddypress/bp-classic) backcompat plugin.
- Replace all remaining deprecated functions usage.
- Improve `bp_groups_get_path_chunks()` to deal with front-end group admin URLs and the groups create URLs.
- Adjust some routing unit tests

Trac ticket: https://buddypress.trac.wordpress.org/ticket/4954

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
