### PR TITLE
Add URLs WP Admin settings screen

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -238,22 +238,16 @@ class BP_Activity_Component extends BP_Component {
 	}
 
 	/**
-	 * Set up component navigation.
+	 * Register component navigation.
 	 *
-	 * @since 1.5.0
+	 * @since 12.0.0
 	 *
-	 * @see BP_Component::setup_nav() for a description of arguments.
+	 * @see `BP_Component::register_nav()` for a description of arguments.
 	 *
-	 * @param array $main_nav Optional. See BP_Component::setup_nav() for description.
-	 * @param array $sub_nav  Optional. See BP_Component::setup_nav() for description.
+	 * @param array $main_nav Optional. See `BP_Component::register_nav()` for description.
+	 * @param array $sub_nav  Optional. See `BP_Component::register_nav()` for description.
 	 */
-	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
-
-		// Stop if there is no user displayed or logged in.
-		if ( ! is_user_logged_in() && ! bp_displayed_user_id() ) {
-			return;
-		}
-
+	public function register_nav( $main_nav = array(), $sub_nav = array() ) {
 		$slug = bp_get_activity_slug();
 
 		// Add 'Activity' to the main navigation.
@@ -276,28 +270,26 @@ class BP_Activity_Component extends BP_Component {
 		);
 
 		// Check @mentions.
-		if ( bp_activity_do_mentions() ) {
-			$sub_nav[] = array(
-				'name'            => _x( 'Mentions', 'Profile activity screen sub nav', 'buddypress' ),
-				'slug'            => 'mentions',
-				'parent_slug'     => $slug,
-				'screen_function' => 'bp_activity_screen_mentions',
-				'position'        => 20,
-				'item_css_id'     => 'activity-mentions'
-			);
-		}
+		$sub_nav[] = array(
+			'name'            => _x( 'Mentions', 'Profile activity screen sub nav', 'buddypress' ),
+			'slug'            => 'mentions',
+			'parent_slug'     => $slug,
+			'screen_function' => 'bp_activity_screen_mentions',
+			'position'        => 20,
+			'item_css_id'     => 'activity-mentions',
+			'generate'        => bp_activity_do_mentions(),
+		);
 
 		// Favorite activity items.
-		if ( bp_activity_can_favorite() ) {
-			$sub_nav[] = array(
-				'name'            => _x( 'Favorites', 'Profile activity screen sub nav', 'buddypress' ),
-				'slug'            => 'favorites',
-				'parent_slug'     => $slug,
-				'screen_function' => 'bp_activity_screen_favorites',
-				'position'        => 30,
-				'item_css_id'     => 'activity-favs'
-			);
-		}
+		$sub_nav[] = array(
+			'name'            => _x( 'Favorites', 'Profile activity screen sub nav', 'buddypress' ),
+			'slug'            => 'favorites',
+			'parent_slug'     => $slug,
+			'screen_function' => 'bp_activity_screen_favorites',
+			'position'        => 30,
+			'item_css_id'     => 'activity-favs',
+			'generate'        => bp_activity_can_favorite(),
+		);
 
 		// Additional menu if friends is active.
 		if ( bp_is_active( 'friends' ) ) {
@@ -307,8 +299,8 @@ class BP_Activity_Component extends BP_Component {
 				'parent_slug'     => $slug,
 				'screen_function' => 'bp_activity_screen_friends',
 				'position'        => 40,
-				'item_css_id'     => 'activity-friends'
-			) ;
+				'item_css_id'     => 'activity-friends',
+			);
 		}
 
 		// Additional menu if groups is active.
@@ -323,7 +315,7 @@ class BP_Activity_Component extends BP_Component {
 			);
 		}
 
-		parent::setup_nav( $main_nav, $sub_nav );
+		parent::register_nav( $main_nav, $sub_nav );
 	}
 
 	/**

--- a/src/bp-blogs/classes/class-bp-blogs-component.php
+++ b/src/bp-blogs/classes/class-bp-blogs-component.php
@@ -198,17 +198,18 @@ class BP_Blogs_Component extends BP_Component {
 	}
 
 	/**
-	 * Set up component navigation for bp-blogs.
+	 * Register component navigation.
 	 *
-	 * @see BP_Component::setup_nav() for a description of arguments.
+	 * @since 12.0.0
 	 *
-	 * @param array $main_nav Optional. See BP_Component::setup_nav() for
+	 * @see `BP_Component::register_nav()` for a description of arguments.
+	 *
+	 * @param array $main_nav Optional. See `BP_Component::register_nav()` for
 	 *                        description.
-	 * @param array $sub_nav  Optional. See BP_Component::setup_nav() for
+	 * @param array $sub_nav  Optional. See `BP_Component::register_nav()` for
 	 *                        description.
 	 */
-	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
-
+	public function register_nav( $main_nav = array(), $sub_nav = array() ) {
 		/**
 		 * Blog/post/comment menus should not appear on single WordPress setups.
 		 * Although comments and posts made by users will still show on their
@@ -218,27 +219,10 @@ class BP_Blogs_Component extends BP_Component {
 			return false;
 		}
 
-		// Stop if there is no user displayed or logged in.
-		if ( ! is_user_logged_in() && ! bp_displayed_user_id() ) {
-			return;
-		}
-
 		$slug = bp_get_blogs_slug();
 
-		// Add 'Sites' to the main navigation.
-		$count    = (int) bp_get_total_blog_count_for_user();
-		$class    = ( 0 === $count ) ? 'no-count' : 'count';
-		$nav_text = sprintf(
-			/* translators: %s: Site count for the current user */
-			__( 'Sites %s', 'buddypress' ),
-			sprintf(
-				'<span class="%s">%s</span>',
-				esc_attr( $class ),
-				esc_html( $count )
-			)
-		);
 		$main_nav = array(
-			'name'                => $nav_text,
+			'name'                => __( 'Sites', 'buddypress' ),
 			'slug'                => $slug,
 			'position'            => 30,
 			'screen_function'     => 'bp_blogs_screen_my_blogs',
@@ -255,6 +239,39 @@ class BP_Blogs_Component extends BP_Component {
 		);
 
 		// Setup navigation.
+		parent::register_nav( $main_nav, $sub_nav );
+	}
+
+	/**
+	 * Set up component navigation.
+	 *
+	 * @since 1.5.0
+	 * @since 12.0.0 Used to customize the main navigation name.
+	 *
+	 * @see `BP_Component::setup_nav()` for a description of arguments.
+	 *
+	 * @param array $main_nav Optional. See `BP_Component::setup_nav()` for
+	 *                        description.
+	 * @param array $sub_nav  Optional. See `BP_Component::setup_nav()` for
+	 *                        description.
+	 */
+	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
+		// Only grab count if we're on a user page.
+		if ( is_multisite() && bp_is_user() && isset( $this->main_nav['name'] ) ) {
+			// Add the number of sites to the main nav.
+			$count                  = (int) bp_get_total_blog_count_for_user();
+			$class                  = ( 0 === $count ) ? 'no-count' : 'count';
+			$this->main_nav['name'] = sprintf(
+				/* translators: %s: Site count for the displayed user */
+				__( 'Sites %s', 'buddypress' ),
+				sprintf(
+					'<span class="%s">%s</span>',
+					esc_attr( $class ),
+					bp_core_number_format( $count )
+				)
+			);
+		}
+
 		parent::setup_nav( $main_nav, $sub_nav );
 	}
 

--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -489,6 +489,11 @@ function bp_core_get_admin_settings_tabs( $apply_filters = true ) {
 			'href' => bp_get_admin_url( add_query_arg( array( 'page' => 'bp-components' ), 'admin.php' ) ),
 			'name' => __( 'Components', 'buddypress' ),
 		),
+		'1' => array(
+			'id'   => 'bp-rewrites',
+			'href' => bp_get_admin_url( add_query_arg( array( 'page' => 'bp-rewrites' ), 'admin.php' ) ),
+			'name' => __( 'URLs', 'buddypress' ),
+		),
 		'2' => array(
 			'id'   => 'bp-settings',
 			'href' => bp_get_admin_url( add_query_arg( array( 'page' => 'bp-settings' ), 'admin.php' ) ),

--- a/src/bp-core/admin/bp-core-admin-rewrites.php
+++ b/src/bp-core/admin/bp-core-admin-rewrites.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * BuddyPress Admin URLs/Rewrites Functions.
+ *
+ * @package BuddyPress
+ * @subpackage Admin
+ * @since 12.0.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles BP Rewrites settings updates & load styles and scripts.
+ *
+ * @since 12.0.0
+ */
+function bp_core_admin_rewrites_load() {
+	wp_enqueue_style( 'site-health' );
+	wp_add_inline_style(
+		'site-health',
+		'#bp-admin-rewrites-form .form-table { border: none; padding: 0; }
+		#bp-admin-rewrites-form .bp-nav-slug { margin-left: 2em; display: inline-block; vertical-align: middle; }
+		.site-health-issues-wrapper:first-of-type { margin-top: 0; }
+		.site-health-issues-wrapper .health-check-accordion { border-bottom: none; }
+		.site-health-issues-wrapper .health-check-accordion:last-of-type { border-bottom: 1px solid #c3c4c7; }'
+	);
+
+	wp_enqueue_script( 'bp-rewrites-ui' );
+}
+
+/**
+ * Outputs BP Rewrites URLs settings.
+ *
+ * @since 12.0.0
+ */
+function bp_core_admin_rewrites_settings() {
+	$bp              = buddypress();
+	$bp_pages        = $bp->pages;
+	$reordered_pages = array();
+
+	if ( isset( $bp_pages->register ) ) {
+		$reordered_pages['register'] = $bp_pages->register;
+		unset( $bp_pages->register );
+	}
+
+	if ( isset( $bp_pages->activate ) ) {
+		$reordered_pages['activate'] = $bp_pages->activate;
+		unset( $bp_pages->activate );
+	}
+
+	if ( $reordered_pages ) {
+		foreach ( $reordered_pages as $page_key => $reordered_page ) {
+			$bp_pages->{$page_key} = $reordered_page;
+		}
+	}
+
+	// Members component navigations.
+	$members_navigation     = bp_get_component_navigations();
+	$members_sub_navigation = array();
+
+	// Remove the members component navigation when needed.
+	if ( bp_is_active( 'xprofile' ) ) {
+		unset( $members_navigation['members'] );
+	}
+
+	bp_core_admin_tabbed_screen_header( __( 'BuddyPress Settings', 'buddypress' ), __( 'URLs', 'buddypress' ) );
+	?>
+	<div class="buddypress-body">
+		<div class="health-check-body">
+			<form action="" method="post" id="bp-admin-rewrites-form">
+				<?php foreach ( $bp->pages as $component_id => $directory_data ) : ?>
+					<div class="site-health-issues-wrapper">
+						<h2>
+							<?php
+							if ( isset( $bp->{$component_id}->name ) && $bp->{$component_id}->name ) {
+								echo esc_html( $bp->{$component_id}->name );
+							} else {
+								echo esc_html( $directory_data->title );
+							}
+							?>
+						</h2>
+						<div class="health-check-accordion">
+							<h4 class="health-check-accordion-heading">
+								<button aria-expanded="false" class="health-check-accordion-trigger" aria-controls="health-check-accordion-block-<?php echo esc_attr( $component_id ); ?>-directory" type="button">
+									<span class="title"><?php esc_html_e( 'Directory', 'buddypress' ); ?></span>
+									<span class="icon"></span>
+								</button>
+							</h4>
+							<div id="health-check-accordion-block-<?php echo esc_attr( $component_id ); ?>-directory" class="health-check-accordion-panel" hidden="hidden">
+								<table class="form-table" role="presentation">
+									<tr>
+										<th scope="row">
+											<label for="<?php echo esc_attr( sprintf( '%s-directory-title', sanitize_key( $component_id ) ) ); ?>">
+												<?php esc_html_e( 'Directory title', 'buddypress' ); ?>
+											</label>
+										</th>
+										<td>
+											<input type="text" class="code" name="<?php printf( 'components[%d][post_title]', absint( $directory_data->id ) ); ?>" id="<?php echo esc_attr( sprintf( '%s-directory-title', sanitize_key( $component_id ) ) ); ?>" value="<?php echo esc_attr( $directory_data->title ); ?>">
+										</td>
+									</tr>
+									<tr>
+										<th scope="row">
+											<label for="<?php echo esc_attr( sprintf( '%s-directory-slug', sanitize_key( $component_id ) ) ); ?>">
+												<?php esc_html_e( 'Directory slug', 'buddypress' ); ?>
+											</label>
+										</th>
+										<td>
+											<input type="text" class="code" name="<?php printf( 'components[%d][post_name]', absint( $directory_data->id ) ); ?>" id="<?php echo esc_attr( sprintf( '%s-directory-slug', sanitize_key( $component_id ) ) ); ?>" value="<?php echo esc_attr( $directory_data->slug ); ?>">
+										</td>
+									</tr>
+								</table>
+							</div>
+						</div>
+
+						<?php if ( 'members' === $component_id ) : ?>
+							<div class="health-check-accordion">
+								<h4 class="health-check-accordion-heading">
+									<button aria-expanded="false" class="health-check-accordion-trigger" aria-controls="health-check-accordion-block-member-primary-nav" type="button">
+										<span class="title"><?php esc_html_e( 'Single Member primary screens slugs', 'buddypress' ); ?></span>
+										<span class="icon"></span>
+									</button>
+								</h4>
+								<div id="health-check-accordion-block-member-primary-nav" class="health-check-accordion-panel" hidden="hidden">
+									<table class="form-table" role="presentation">
+										<?php
+										foreach ( $members_navigation as $members_component => $navs ) :
+											if ( ! isset( $navs['main_nav']['rewrite_id'] ) || ! $navs['main_nav']['rewrite_id'] ) {
+												continue;
+											}
+
+											if ( isset( $navs['sub_nav'] ) ) {
+												$members_sub_navigation[ $navs['main_nav']['slug'] ] = array(
+													'name'    => $navs['main_nav']['name'],
+													'sub_nav' => $navs['sub_nav'],
+												);
+											}
+										?>
+										<tr>
+											<th scope="row">
+												<label class="bp-nav-slug" for="<?php echo esc_attr( sprintf( '%s-slug', sanitize_key( $navs['main_nav']['rewrite_id'] ) ) ); ?>">
+													<?php
+													printf(
+														/* translators: %s is the member primary screen name */
+														esc_html_x( '"%s" slug', 'member primary screen name URL admin label', 'buddypress' ),
+														esc_html( _bp_strip_spans_from_title( $navs['main_nav']['name'] ) )
+													);
+													?>
+												</label>
+											</th>
+											<td>
+												<input type="text" class="code" name="<?php printf( 'components[%1$d][_bp_component_slugs][%2$s]', absint( $directory_data->id ), esc_attr( $navs['main_nav']['rewrite_id'] ) ); ?>" id="<?php echo esc_attr( sprintf( '%s-slug', sanitize_key( $navs['main_nav']['rewrite_id'] ) ) ); ?>" value="<?php echo esc_attr( bp_rewrites_get_slug( $component_id, $navs['main_nav']['rewrite_id'],  $navs['main_nav']['slug'] ) ); ?>">
+											</td>
+										</tr>
+										<?php endforeach; ?>
+									</table>
+								</div>
+							</div>
+							<?php if ( $members_sub_navigation ) : ?>
+								<?php foreach ( $members_sub_navigation as $members_navigation_slug => $members_component_navigations ) : ?>
+									<div class="health-check-accordion">
+										<h4 class="health-check-accordion-heading">
+											<button aria-expanded="false" class="health-check-accordion-trigger" aria-controls="<?php echo esc_attr( sprintf( 'health-check-accordion-block-member-%s-secondary-nav', $members_navigation_slug ) ); ?>" type="button">
+												<?php /* translators: %s is the BP Component name the secondery views belong to. */ ?>
+												<span class="title"><?php echo esc_html( sprintf( __( 'Single Member %s secondary screens slugs', 'buddypress' ), _bp_strip_spans_from_title( $members_component_navigations['name'] ) ) ); ?></span>
+												<span class="icon"></span>
+											</button>
+										</h4>
+										<div id="<?php echo esc_attr( sprintf( 'health-check-accordion-block-member-%s-secondary-nav', $members_navigation_slug ) ); ?>" class="health-check-accordion-panel" hidden="hidden">
+											<table class="form-table" role="presentation">
+												<?php
+												foreach ( $members_component_navigations['sub_nav'] as $secondary_nav_item ) :
+													if ( ! isset( $secondary_nav_item['rewrite_id'] ) || ! $secondary_nav_item['rewrite_id'] ) {
+														continue;
+													}
+													?>
+													<tr>
+														<th scope="row">
+															<label class="bp-nav-slug" for="<?php echo esc_attr( sprintf( '%s-slug', sanitize_key( $secondary_nav_item['rewrite_id'] ) ) ); ?>">
+																<?php
+																printf(
+																	/* translators: %s is the member secondary view name */
+																	esc_html_x( '"%s" slug', 'member secondary screen name URL admin label', 'buddypress' ),
+																	esc_html( _bp_strip_spans_from_title( $secondary_nav_item['name'] ) )
+																);
+																?>
+															</label>
+														</th>
+														<td>
+															<input type="text" class="code" name="<?php printf( 'components[%1$d][_bp_component_slugs][%2$s]', absint( $directory_data->id ), esc_attr( $secondary_nav_item['rewrite_id'] ) ); ?>" id="<?php echo esc_attr( sprintf( '%s-slug', sanitize_key( $secondary_nav_item['rewrite_id'] ) ) ); ?>" value="<?php echo esc_attr( bp_rewrites_get_slug( $component_id, $secondary_nav_item['rewrite_id'], $secondary_nav_item['slug'] ) ); ?>">
+														</td>
+													</tr>
+												<?php endforeach; ?>
+											</table>
+										</div>
+									</div>
+								<?php endforeach; ?>
+							<?php endif; ?>
+						<?php endif; ?>
+					</div>
+				<?php endforeach; ?>
+			</form>
+		</div>
+	</div>
+	<?php
+}

--- a/src/bp-core/admin/js/rewrites-ui.js
+++ b/src/bp-core/admin/js/rewrites-ui.js
@@ -1,0 +1,30 @@
+( function() {
+	var bpRewritesUI = function() {
+		var accordions = document.querySelectorAll( '.health-check-accordion' );
+
+		accordions.forEach( function( accordion ) {
+			accordion.addEventListener( 'click', function( e ) {
+				e.preventDefault();
+
+				if ( e.target && e.target.matches( 'button.health-check-accordion-trigger' ) ) {
+					var isExpanded = ( 'true' === e.target.getAttribute( 'aria-expanded' ) ),
+					    panel = document.querySelector( '#' + e.target.getAttribute( 'aria-controls' ) );
+
+					if ( isExpanded ) {
+						e.target.setAttribute( 'aria-expanded', 'false' );
+						panel.setAttribute( 'hidden', true );
+					} else {
+						e.target.setAttribute( 'aria-expanded', 'true' );
+						panel.removeAttribute( 'hidden' );
+					}
+				}
+			} );
+		} );
+	};
+
+	if ( 'loading' === document.readyState ) {
+		document.addEventListener( 'DOMContentLoaded', bpRewritesUI );
+	} else {
+		bpRewritesUI();
+	}
+} )();

--- a/src/bp-core/bp-core-caps.php
+++ b/src/bp-core/bp-core-caps.php
@@ -304,6 +304,17 @@ function bp_current_user_can( $capability, $args = array() ) {
 }
 
 /**
+ * Callback function to inform whether current user can moderate the community.
+ *
+ * @since 12.0.0
+ *
+ * @return boolean True if current user can moderate the community. False otherwise.
+ */
+function bp_current_user_can_moderate() {
+	return bp_current_user_can( 'bp_moderate' );
+}
+
+/**
  * Check whether the specified user has a given capability on a given site.
  *
  * @since 2.7.0

--- a/src/bp-core/classes/class-bp-admin.php
+++ b/src/bp-core/classes/class-bp-admin.php
@@ -142,12 +142,13 @@ class BP_Admin {
 	 * @since 1.6.0
 	 */
 	private function includes() {
-		require( $this->admin_dir . 'bp-core-admin-actions.php'    );
-		require( $this->admin_dir . 'bp-core-admin-settings.php'   );
-		require( $this->admin_dir . 'bp-core-admin-functions.php'  );
-		require( $this->admin_dir . 'bp-core-admin-components.php' );
-		require( $this->admin_dir . 'bp-core-admin-tools.php'      );
-		require( $this->admin_dir . 'bp-core-admin-optouts.php'    );
+		require $this->admin_dir . 'bp-core-admin-actions.php';
+		require $this->admin_dir . 'bp-core-admin-settings.php';
+		require $this->admin_dir . 'bp-core-admin-functions.php';
+		require $this->admin_dir . 'bp-core-admin-components.php';
+		require $this->admin_dir . 'bp-core-admin-rewrites.php';
+		require $this->admin_dir . 'bp-core-admin-tools.php';
+		require $this->admin_dir . 'bp-core-admin-optouts.php';
 	}
 
 	/**
@@ -274,6 +275,18 @@ class BP_Admin {
 		$this->submenu_pages['settings']['bp-components'] = $bp_components_page;
 		$hooks[]                                          = $bp_components_page;
 
+		$bp_rewrite_settings_page = add_submenu_page(
+			$this->settings_page,
+			__( 'BuddyPress URLs', 'buddypress' ),
+			__( 'BuddyPress URLs', 'buddypress' ),
+			$this->capability,
+			'bp-rewrites',
+			'bp_core_admin_rewrites_settings'
+		);
+
+		$this->submenu_pages['settings']['bp-rewrites'] = $bp_rewrite_settings_page;
+		$hooks[]                                        = $bp_rewrite_settings_page;
+
 		$bp_settings_page = add_submenu_page(
 			$this->settings_page,
 			__( 'BuddyPress Options', 'buddypress' ),
@@ -374,6 +387,10 @@ class BP_Admin {
 
 		foreach( $hooks as $hook ) {
 			add_action( "admin_head-$hook", 'bp_core_modify_admin_menu_highlight' );
+
+			if ( 'settings_page_bp-rewrites' === $hook ) {
+				add_action( "load-{$hook}", 'bp_core_admin_rewrites_load' );
+			}
 		}
 
 		/**
@@ -613,8 +630,9 @@ class BP_Admin {
 	public function admin_head() {
 
 		// Settings pages.
-		remove_submenu_page( $this->settings_page, 'bp-settings'      );
-		remove_submenu_page( $this->settings_page, 'bp-credits'       );
+		remove_submenu_page( $this->settings_page, 'bp-rewrites' );
+		remove_submenu_page( $this->settings_page, 'bp-settings' );
+		remove_submenu_page( $this->settings_page, 'bp-credits'  );
 
 		// Network Admin Tools.
 		remove_submenu_page( 'network-tools', 'network-tools' );
@@ -1395,6 +1413,13 @@ class BP_Admin {
 						'nonce'  => wp_create_nonce( 'bp_dismiss_admin_notice' ),
 					),
 				),
+			),
+
+			// 12.0
+			'bp-rewrites-ui' => array(
+				'file' => "{$url}rewrites-ui.js",
+				'dependencies' => array(),
+				'footer'       => true,
 			),
 		) );
 

--- a/src/bp-core/classes/class-bp-component.php
+++ b/src/bp-core/classes/class-bp-component.php
@@ -543,11 +543,11 @@ class BP_Component {
 		// Load files conditionally, based on certain pages.
 		add_action( 'bp_late_include',           array( $this, 'late_includes'          ) );
 
+		// Generate navigation.
+		add_action( 'bp_setup_nav',              array( $this, 'register_nav'           ),  7 );
+
 		// Setup navigation.
 		add_action( 'bp_setup_nav',              array( $this, 'setup_nav'              ),  9 );
-
-		// Generate navigation.
-		add_action( 'bp_setup_nav',              array( $this, 'generate_nav'           ), 10, 0 );
 
 		// Setup WP Toolbar menus.
 		add_action( 'bp_setup_admin_bar',        array( $this, 'setup_admin_bar'        ), $this->adminbar_myaccount_order );
@@ -613,10 +613,9 @@ class BP_Component {
 	public function setup_canonical_stack() {}
 
 	/**
-	 * Set up component navigation.
+	 * Registers nav items globalizing them into `BP_Component::$main_nav` & `BP_Component::$sub_nav` properties.
 	 *
-	 * @since 1.5.0
-	 * @since 12.0.0 Uses `BP_Component::$main_nav` && `BP_Component::$sub_nav` to globalize nav items.
+	 * @since 12.0.0
 	 *
 	 * @param array $main_nav Optional. Passed directly to bp_core_new_nav_item().
 	 *                        See that function for a description.
@@ -624,7 +623,7 @@ class BP_Component {
 	 *                        which is passed to bp_core_new_subnav_item(). See that
 	 *                        function for a description.
 	 */
-	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
+	public function register_nav( $main_nav = array(), $sub_nav = array() ) {
 		if ( isset( $main_nav['slug'] ) ) {
 			// Always set the component ID.
 			$this->main_nav['component_id'] = $this->id;
@@ -657,79 +656,110 @@ class BP_Component {
 	}
 
 	/**
-	 * Generate component navigation using the nav/subnav set up in `BP_Component::setup_nav()`.
+	 * Set up component navigation.
 	 *
-	 * @since 12.0.0
+	 * @since 1.5.0
+	 * @since 12.0.0 Uses the registered navigations to generate it.
+	 *
+	 * @param array $main_nav Optional. Passed directly to bp_core_new_nav_item().
+	 *                        See that function for a description.
+	 * @param array $sub_nav  Optional. Multidimensional array, each item in
+	 *                        which is passed to bp_core_new_subnav_item(). See that
+	 *                        function for a description.
 	 */
-	public function generate_nav() {
-		// Don't generate navigation if there's no member.
-		if ( ! is_user_logged_in() && ! bp_is_user() ) {
-			return;
-		}
-
-		$generate = true;
-		if ( isset( $this->main_nav['generate'] ) ) {
-			$generate = is_callable( $this->main_nav['generate'] ) ? call_user_func( $this->main_nav['generate'] ) : (bool) $this->main_nav['generate'];
-			unset( $this->main_nav['generate'] );
-		}
-
-		if ( bp_displayed_user_has_front_template() ) {
-			bp_core_new_nav_item(
-				array(
-					'name'                => _x( 'Home', 'Member Home page', 'buddypress' ),
-					'slug'                => 'front',
-					'position'            => 5,
-					'screen_function'     => 'bp_members_screen_display_profile',
-					'default_subnav_slug' => 'public',
-				),
-				'members'
-			);
-		}
-
-		if ( 'xprofile' === $this->id ) {
-			$extra_subnavs = wp_list_filter(
-				buddypress()->members->sub_nav,
-				array(
-					'slug'            => 'change-avatar',
-					'screen_function' => 'bp_members_screen_change_cover_image',
-				),
-				'OR'
-			);
-
-			$this->sub_nav = array_merge( $this->sub_nav, $extra_subnavs );
-		}
-
-		// No sub nav items without a main nav item.
-		if ( $this->main_nav && $generate) {
-			if ( isset( $this->main_nav['user_has_access_callback'] ) && is_callable( $this->main_nav['user_has_access_callback'] ) ) {
-				$this->main_nav['show_for_displayed_user'] = call_user_func( $this->main_nav['user_has_access_callback'] );
-				unset( $this->main_nav['user_has_access_callback'] );
+	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
+		// Use the registered navigations if available.
+		if ( empty( $main_nav ) && $this->main_nav ) {
+			// Don't generate navigation if there's no member.
+			if ( ! is_user_logged_in() && ! bp_is_user() ) {
+				return;
 			}
 
-			bp_core_new_nav_item( $this->main_nav, 'members' );
+			$generate = true;
+			if ( isset( $this->main_nav['generate'] ) ) {
+				$generate = is_callable( $this->main_nav['generate'] ) ? call_user_func( $this->main_nav['generate'] ) : (bool) $this->main_nav['generate'];
+				unset( $this->main_nav['generate'] );
+			}
+
+			if ( bp_displayed_user_has_front_template() ) {
+				bp_core_new_nav_item(
+					array(
+						'name'                => _x( 'Home', 'Member Home page', 'buddypress' ),
+						'slug'                => 'front',
+						'position'            => 5,
+						'screen_function'     => 'bp_members_screen_display_profile',
+						'default_subnav_slug' => 'public',
+					),
+					'members'
+				);
+			}
+
+			if ( 'xprofile' === $this->id ) {
+				$extra_subnavs = wp_list_filter(
+					buddypress()->members->sub_nav,
+					array(
+						'slug'            => 'change-avatar',
+						'screen_function' => 'bp_members_screen_change_cover_image',
+					),
+					'OR'
+				);
+
+				$this->sub_nav = array_merge( $this->sub_nav, $extra_subnavs );
+			}
+
+			// No sub nav items without a main nav item.
+			if ( $this->main_nav && $generate) {
+				if ( isset( $this->main_nav['user_has_access_callback'] ) && is_callable( $this->main_nav['user_has_access_callback'] ) ) {
+					$this->main_nav['show_for_displayed_user'] = call_user_func( $this->main_nav['user_has_access_callback'] );
+					unset( $this->main_nav['user_has_access_callback'] );
+				}
+
+				bp_core_new_nav_item( $this->main_nav, 'members' );
+
+				// Sub nav items are not required.
+				if ( $this->sub_nav ) {
+					foreach( (array) $this->sub_nav as $nav ) {
+						if ( isset( $nav['user_has_access_callback'] ) && is_callable( $nav['user_has_access_callback'] ) ) {
+							$nav['user_has_access'] = call_user_func( $nav['user_has_access_callback'] );
+							unset( $nav['user_has_access_callback'] );
+						}
+
+						if ( isset( $nav['generate'] ) ) {
+							if ( is_callable( $nav['generate'] ) ) {
+								$generate_sub = call_user_func( $nav['generate'] );
+							} else {
+								$generate_sub = (bool) $nav['generate'];
+							}
+
+							unset( $nav['generate'] );
+
+							if ( ! $generate_sub ) {
+								continue;
+							}
+						}
+
+						bp_core_new_subnav_item( $nav, 'members' );
+					}
+				}
+			}
+
+			/*
+			 * If the `$main_nav` is populated, it means a plugin is not registering its navigation using
+			 * `BP_Component::register_nav()` to enjoy the BP Rewrites API slug customization. Let's simply
+			 * preverve backward compatibility in this case.
+			 */
+		} elseif ( ! empty( $main_nav ) && ! $this->main_nav ) {
+			// Always set the component ID.
+			$main_nav['component_id'] = $this->id;
+			$this->main_nav           = $main_nav;
+
+			bp_core_new_nav_item( $main_nav, 'members' );
 
 			// Sub nav items are not required.
-			if ( $this->sub_nav ) {
-				foreach( (array) $this->sub_nav as $nav ) {
-					if ( isset( $nav['user_has_access_callback'] ) && is_callable( $nav['user_has_access_callback'] ) ) {
-						$nav['user_has_access'] = call_user_func( $nav['user_has_access_callback'] );
-						unset( $nav['user_has_access_callback'] );
-					}
+			if ( ! empty( $sub_nav ) ) {
+				$this->sub_nav = $sub_nav;
 
-					if ( isset( $nav['generate'] ) ) {
-						if ( is_callable( $nav['generate'] ) ) {
-							$generate_sub = call_user_func( $nav['generate'] );
-						} else {
-							$generate_sub = (bool) $nav['generate'];
-						}
-
-						unset( $nav['generate'] );
-
-						if ( ! $generate_sub ) {
-							continue;
-						}
-					}
-
+				foreach( (array) $sub_nav as $nav ) {
 					bp_core_new_subnav_item( $nav, 'members' );
 				}
 			}

--- a/src/bp-friends/classes/class-bp-friends-component.php
+++ b/src/bp-friends/classes/class-bp-friends-component.php
@@ -148,43 +148,22 @@ class BP_Friends_Component extends BP_Component {
 	}
 
 	/**
-	 * Set up component navigation.
+	 * Register component navigation.
 	 *
-	 * @since 1.5.0
+	 * @since 12.0.0
 	 *
-	 * @see BP_Component::setup_nav() for a description of arguments.
+	 * @see `BP_Component::register_nav()` for a description of arguments.
 	 *
-	 * @param array $main_nav Optional. See BP_Component::setup_nav() for
+	 * @param array $main_nav Optional. See `BP_Component::register_nav()` for
 	 *                        description.
-	 * @param array $sub_nav  Optional. See BP_Component::setup_nav() for
+	 * @param array $sub_nav  Optional. See `BP_Component::register_nav()` for
 	 *                        description.
 	 */
-	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
-
-		// Stop if there is no user displayed or logged in.
-		if ( ! is_user_logged_in() && ! bp_displayed_user_id() ) {
-			return;
-		}
-
-		$access = bp_core_can_edit_settings();
+	public function register_nav( $main_nav = array(), $sub_nav = array() ) {
 		$slug   = bp_get_friends_slug();
 
-		// Add 'Friends' to the main navigation.
-		$count = friends_get_total_friend_count();
-		$class = ( 0 === $count ) ? 'no-count' : 'count';
-
-		$main_nav_name = sprintf(
-			/* translators: %s: Friend count for the current user */
-			__( 'Friends %s', 'buddypress' ),
-			sprintf(
-				'<span class="%s">%s</span>',
-				esc_attr( $class ),
-				esc_html( $count )
-			)
-		);
-
 		$main_nav = array(
-			'name'                => $main_nav_name,
+			'name'                => __( 'Friends', 'buddypress' ),
 			'slug'                => $slug,
 			'position'            => 60,
 			'screen_function'     => 'friends_screen_my_friends',
@@ -203,13 +182,46 @@ class BP_Friends_Component extends BP_Component {
 		);
 
 		$sub_nav[] = array(
-			'name'            => _x( 'Requests', 'Friends screen sub nav', 'buddypress' ),
-			'slug'            => 'requests',
-			'parent_slug'     => $slug,
-			'screen_function' => 'friends_screen_requests',
-			'position'        => 20,
-			'user_has_access' => $access,
+			'name'                     => _x( 'Requests', 'Friends screen sub nav', 'buddypress' ),
+			'slug'                     => 'requests',
+			'parent_slug'              => $slug,
+			'screen_function'          => 'friends_screen_requests',
+			'position'                 => 20,
+			'user_has_access'          => false,
+			'user_has_access_callback' => 'bp_core_can_edit_settings',
 		);
+
+		parent::register_nav( $main_nav, $sub_nav );
+	}
+
+	/**
+	 * Set up component navigation.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @see `BP_Component::setup_nav()` for a description of arguments.
+	 *
+	 * @param array $main_nav Optional. See `BP_Component::setup_nav()` for
+	 *                        description.
+	 * @param array $sub_nav  Optional. See `BP_Component::setup_nav()` for
+	 *                        description.
+	 */
+	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
+		// Only grab count if we're on a user page.
+		if ( bp_is_user() && isset( $this->main_nav['name'] ) ) {
+			// Add 'Friends' to the main navigation.
+			$count                  = friends_get_total_friend_count();
+			$class                  = ( 0 === $count ) ? 'no-count' : 'count';
+			$this->main_nav['name'] = sprintf(
+				/* translators: %s: Friend count for the current user */
+				__( 'Friends %s', 'buddypress' ),
+				sprintf(
+					'<span class="%s">%s</span>',
+					esc_attr( $class ),
+					esc_html( $count )
+				)
+			);
+		}
 
 		parent::setup_nav( $main_nav, $sub_nav );
 	}

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -41,7 +41,7 @@ class BP_Groups_Component extends BP_Component {
 	 * @todo Is this used anywhere? Is this a duplicate of $default_extension?
 	 * @var string
 	 */
-	var $default_component;
+	public $default_component;
 
 	/**
 	 * Default group extension.

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -38,15 +38,6 @@ class BP_Groups_Component extends BP_Component {
 	 * Default group extension.
 	 *
 	 * @since 1.6.0
-	 * @todo Is this used anywhere? Is this a duplicate of $default_extension?
-	 * @var string
-	 */
-	public $default_component;
-
-	/**
-	 * Default group extension.
-	 *
-	 * @since 1.6.0
 	 * @var string
 	 */
 	public $default_extension;

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -563,72 +563,52 @@ class BP_Groups_Component extends BP_Component {
 	}
 
 	/**
-	 * Set up component navigation.
+	 * Register component navigation.
 	 *
-	 * @since 1.5.0
+	 * @since 12.0.0
 	 *
-	 * @see BP_Component::setup_nav() for a description of arguments.
+	 * @see `BP_Component::register_nav()` for a description of arguments.
 	 *
-	 * @param array $main_nav Optional. See BP_Component::setup_nav() for description.
-	 * @param array $sub_nav  Optional. See BP_Component::setup_nav() for description.
+	 * @param array $main_nav Optional. See `BP_Component::register_nav()` for description.
+	 * @param array $sub_nav  Optional. See `BP_Component::register_nav()` for description.
 	 */
-	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
+	public function register_nav( $main_nav = array(), $sub_nav = array() ) {
+		$slug = bp_get_groups_slug();
 
-		if ( is_user_logged_in() || bp_displayed_user_id() ) {
-			// Only grab count if we're on a user page.
-			if ( bp_is_user() ) {
-				$class = ( 0 === groups_total_groups_for_user( bp_displayed_user_id() ) ) ? 'no-count' : 'count';
+		// Add 'Groups' to the main navigation.
+		$main_nav = array(
+			'name'                => _x( 'Groups', 'Group screen nav without counter', 'buddypress' ),
+			'slug'                => $slug,
+			'position'            => 70,
+			'screen_function'     => 'groups_screen_my_groups',
+			'default_subnav_slug' => 'my-groups',
+			'item_css_id'         => $this->id
+		);
 
-				$nav_name = sprintf(
-					/* translators: %s: Group count for the current user */
-					_x( 'Groups %s', 'Group screen nav with counter', 'buddypress' ),
-					sprintf(
-						'<span class="%s">%s</span>',
-						esc_attr( $class ),
-						bp_get_total_group_count_for_user()
-					)
-				);
-			} else {
-				$nav_name = _x( 'Groups', 'Group screen nav without counter', 'buddypress' );
-			}
+		// Add the My Groups nav item.
+		$sub_nav[] = array(
+			'name'            => __( 'Memberships', 'buddypress' ),
+			'slug'            => 'my-groups',
+			'parent_slug'     => $slug,
+			'screen_function' => 'groups_screen_my_groups',
+			'position'        => 10,
+			'item_css_id'     => 'groups-my-groups'
+		);
 
-			$slug   = bp_get_groups_slug();
-			$access = bp_core_can_edit_settings();
-
-			// Add 'Groups' to the main navigation.
-			$main_nav = array(
-				'name'                => $nav_name,
-				'slug'                => $slug,
-				'position'            => 70,
-				'screen_function'     => 'groups_screen_my_groups',
-				'default_subnav_slug' => 'my-groups',
-				'item_css_id'         => $this->id
-			);
-
-			// Add the My Groups nav item.
+		if ( bp_is_active( 'groups', 'invitations' ) ) {
+			// Add the Group Invites nav item.
 			$sub_nav[] = array(
-				'name'            => __( 'Memberships', 'buddypress' ),
-				'slug'            => 'my-groups',
-				'parent_slug'     => $slug,
-				'screen_function' => 'groups_screen_my_groups',
-				'position'        => 10,
-				'item_css_id'     => 'groups-my-groups'
+				'name'                     => __( 'Invitations', 'buddypress' ),
+				'slug'                     => 'invites',
+				'parent_slug'              => $slug,
+				'screen_function'          => 'groups_screen_group_invites',
+				'position'                 => 30,
+				'user_has_access'          => false,
+				'user_has_access_callback' => 'bp_core_can_edit_settings',
 			);
-
-			if ( bp_is_active( 'groups', 'invitations' ) ) {
-				// Add the Group Invites nav item.
-				$sub_nav[] = array(
-					'name'            => __( 'Invitations', 'buddypress' ),
-					'slug'            => 'invites',
-					'parent_slug'     => $slug,
-					'screen_function' => 'groups_screen_group_invites',
-					'user_has_access' => $access,
-					'position'        => 30
-				);
-			}
-
-			parent::setup_nav( $main_nav, $sub_nav );
 		}
+
+		parent::register_nav( $main_nav, $sub_nav );
 
 		if ( bp_is_groups_component() && bp_is_single_item() ) {
 
@@ -820,6 +800,38 @@ class BP_Groups_Component extends BP_Component {
 			/** This action is documented in bp-groups/bp-groups-loader.php */
 			do_action( 'groups_setup_nav');
 		}
+	}
+
+	/**
+	 * Set up component navigation.
+	 *
+	 * @since 1.5.0
+	 * @since 12.0.0 Used to customize the main navigation name.
+	 *
+	 * @see `BP_Component::setup_nav()` for a description of arguments.
+	 *
+	 * @param array $main_nav Optional. See `BP_Component::setup_nav()` for
+	 *                        description.
+	 * @param array $sub_nav  Optional. See `BP_Component::setup_nav()` for
+	 *                        description.
+	 */
+	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
+		// Only grab count if we're on a user page.
+		if ( isset( $this->main_nav['name'] ) && bp_is_user() ) {
+			$class                  = ( 0 === groups_total_groups_for_user( bp_displayed_user_id() ) ) ? 'no-count' : 'count';
+			$this->main_nav['name'] = sprintf(
+				/* translators: %s: Group count for the current user */
+				_x( 'Groups %s', 'Group screen nav with counter', 'buddypress' ),
+				sprintf(
+					'<span class="%s">%s</span>',
+					esc_attr( $class ),
+					bp_get_total_group_count_for_user()
+				)
+			);
+
+		}
+
+		parent::setup_nav( $main_nav, $sub_nav );
 	}
 
 	/**

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -609,12 +609,38 @@ class BP_Groups_Component extends BP_Component {
 		}
 
 		parent::register_nav( $main_nav, $sub_nav );
+	}
+
+	/**
+	 * Set up component navigation.
+	 *
+	 * @since 1.5.0
+	 * @since 12.0.0 Used to customize the main navigation name and set
+	 *               a Groups single item navigation.
+	 *
+	 * @see `BP_Component::setup_nav()` for a description of arguments.
+	 *
+	 * @param array $main_nav Optional. See `BP_Component::setup_nav()` for
+	 *                        description.
+	 * @param array $sub_nav  Optional. See `BP_Component::setup_nav()` for
+	 *                        description.
+	 */
+	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
+		// Only grab count if we're on a user page.
+		if ( isset( $this->main_nav['name'] ) && bp_is_user() ) {
+			$class                  = ( 0 === groups_total_groups_for_user( bp_displayed_user_id() ) ) ? 'no-count' : 'count';
+			$this->main_nav['name'] = sprintf(
+				/* translators: %s: Group count for the current user */
+				_x( 'Groups %s', 'Group screen nav with counter', 'buddypress' ),
+				sprintf(
+					'<span class="%s">%s</span>',
+					esc_attr( $class ),
+					bp_get_total_group_count_for_user()
+				)
+			);
+		}
 
 		if ( bp_is_groups_component() && bp_is_single_item() ) {
-
-			// Reset sub nav.
-			$sub_nav = array();
-
 			/*
 			 * The top-level Groups item is called 'Memberships' for legacy reasons.
 			 * It does not appear in the interface.
@@ -640,11 +666,11 @@ class BP_Groups_Component extends BP_Component {
 				'item_css_id'     => 'home'
 			);
 
-			// If this is a private group, and the user is not a
-			// member and does not have an outstanding invitation,
-			// show a "Request Membership" nav item.
+			/*
+			 * If this is a private group, and the user is not a member and does not
+			 * have an outstanding invitation, how a "Request Membership" nav item.
+			 */
 			if ( bp_current_user_can( 'groups_request_membership', array( 'group_id' => $this->current_group->id ) ) ) {
-
 				$sub_nav[] = array(
 					'name'            => _x( 'Request Membership','Group screen nav', 'buddypress' ),
 					'slug'            => 'request-membership',
@@ -655,9 +681,7 @@ class BP_Groups_Component extends BP_Component {
 			}
 
 			if ( $this->current_group->front_template || bp_is_active( 'activity' ) ) {
-				/**
-				 * If the theme is using a custom front, create activity subnav.
-				 */
+				// If the theme is using a custom front, create activity subnav.
 				if ( $this->current_group->front_template && bp_is_active( 'activity' ) ) {
 					$sub_nav[] = array(
 						'name'            => _x( 'Activity', 'My Group screen nav', 'buddypress' ),
@@ -671,9 +695,7 @@ class BP_Groups_Component extends BP_Component {
 					);
 				}
 
-				/**
-				 * Only add the members subnav if it's not the home's nav.
-				 */
+				// Only add the members subnav if it's not the home's nav.
 				$sub_nav[] = array(
 					'name'            => sprintf(
 						/* translators: %s: total member count */
@@ -783,52 +805,22 @@ class BP_Groups_Component extends BP_Component {
 			foreach ( $sub_nav as $nav ) {
 				bp_core_new_subnav_item( $nav, 'groups' );
 			}
-		}
 
-		if ( isset( $this->current_group->user_has_access ) ) {
+			if ( isset( $this->current_group->user_has_access ) ) {
 
-			/**
-			 * Fires at the end of the groups navigation setup if user has access.
-			 *
-			 * @since 1.0.2
-			 *
-			 * @param bool $user_has_access Whether or not user has access.
-			 */
-			do_action( 'groups_setup_nav', $this->current_group->user_has_access );
-		} else {
+				/**
+				 * Fires at the end of the groups navigation setup if user has access.
+				 *
+				 * @since 1.0.2
+				 *
+				 * @param bool $user_has_access Whether or not user has access.
+				 */
+				do_action( 'groups_setup_nav', $this->current_group->user_has_access );
+			} else {
 
-			/** This action is documented in bp-groups/bp-groups-loader.php */
-			do_action( 'groups_setup_nav');
-		}
-	}
-
-	/**
-	 * Set up component navigation.
-	 *
-	 * @since 1.5.0
-	 * @since 12.0.0 Used to customize the main navigation name.
-	 *
-	 * @see `BP_Component::setup_nav()` for a description of arguments.
-	 *
-	 * @param array $main_nav Optional. See `BP_Component::setup_nav()` for
-	 *                        description.
-	 * @param array $sub_nav  Optional. See `BP_Component::setup_nav()` for
-	 *                        description.
-	 */
-	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
-		// Only grab count if we're on a user page.
-		if ( isset( $this->main_nav['name'] ) && bp_is_user() ) {
-			$class                  = ( 0 === groups_total_groups_for_user( bp_displayed_user_id() ) ) ? 'no-count' : 'count';
-			$this->main_nav['name'] = sprintf(
-				/* translators: %s: Group count for the current user */
-				_x( 'Groups %s', 'Group screen nav with counter', 'buddypress' ),
-				sprintf(
-					'<span class="%s">%s</span>',
-					esc_attr( $class ),
-					bp_get_total_group_count_for_user()
-				)
-			);
-
+				/** This action is documented in bp-groups/bp-groups-loader.php */
+				do_action( 'groups_setup_nav');
+			}
 		}
 
 		parent::setup_nav( $main_nav, $sub_nav );

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -422,55 +422,27 @@ class BP_Members_Component extends BP_Component {
 	 * Get the Avatar and Cover image subnavs.
 	 *
 	 * @since 6.0.0
+	 * @deprecated 12.0.0
 	 *
 	 * @return array The Avatar and Cover image subnavs.
 	 */
 	public function get_avatar_cover_image_subnavs() {
-		$subnavs = array();
-
-		$access = bp_core_can_edit_settings();
-		$slug   = bp_get_profile_slug();
-
-		// Change Avatar.
-		if ( buddypress()->avatar->show_avatars ) {
-			$subnavs[] = array(
-				'name'            => _x( 'Change Profile Photo', 'Profile header sub menu', 'buddypress' ),
-				'slug'            => 'change-avatar',
-				'parent_slug'     => $slug,
-				'screen_function' => 'bp_members_screen_change_avatar',
-				'position'        => 30,
-				'user_has_access' => $access
-			);
-		}
-
-		// Change Cover image.
-		if ( bp_displayed_user_use_cover_image_header() ) {
-			$subnavs[] = array(
-				'name'            => _x( 'Change Cover Image', 'Profile header sub menu', 'buddypress' ),
-				'slug'            => 'change-cover-image',
-				'parent_slug'     => $slug,
-				'screen_function' => 'bp_members_screen_change_cover_image',
-				'position'        => 40,
-				'user_has_access' => $access
-			);
-		}
-
-		return $subnavs;
+		_deprecated_function( __METHOD__, '12.0.0' );
 	}
 
 	/**
-	 * Set up fall-back component navigation if XProfile is inactive.
+	 * Register component navigation.
 	 *
-	 * @since 1.5.0
+	 * @since 12.0.0
 	 *
-	 * @see BP_Component::setup_nav() for a description of arguments.
+	 * @see `BP_Component::register_nav()` for a description of arguments.
 	 *
-	 * @param array $main_nav Optional. See BP_Component::setup_nav() for
+	 * @param array $main_nav Optional. See `BP_Component::register_nav()` for
 	 *                        description.
-	 * @param array $sub_nav  Optional. See BP_Component::setup_nav() for
+	 * @param array $sub_nav  Optional. See `BP_Component::register_nav()` for
 	 *                        description.
 	 */
-	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
+	public function register_nav( $main_nav = array(), $sub_nav = array() ) {
 		// Set slug to profile in case the xProfile component is not active
 		$slug = bp_get_profile_slug();
 
@@ -515,7 +487,7 @@ class BP_Members_Component extends BP_Component {
 			'generate'                 => bp_displayed_user_use_cover_image_header(),
 		);
 
-		parent::setup_nav( $main_nav, $sub_nav );
+		parent::register_nav( $main_nav, $sub_nav );
 	}
 
 	/**

--- a/src/bp-notifications/classes/class-bp-notifications-component.php
+++ b/src/bp-notifications/classes/class-bp-notifications-component.php
@@ -133,32 +133,76 @@ class BP_Notifications_Component extends BP_Component {
 	}
 
 	/**
+	 * Register component navigation.
+	 *
+	 * @since 12.0.0
+	 *
+	 * @see `BP_Component::register_nav()` for a description of arguments.
+	 *
+	 * @param array $main_nav Optional. See `BP_Component::register_nav()` for
+	 *                        description.
+	 * @param array $sub_nav  Optional. See `BP_Component::register_nav()` for
+	 *                        description.
+	 */
+	public function register_nav( $main_nav = array(), $sub_nav = array() ) {
+		$slug   = bp_get_notifications_slug();
+
+		// Add 'Notifications' to the main navigation.
+		$main_nav = array(
+			'name'                     => _x( 'Notifications', 'Profile screen nav', 'buddypress' ),
+			'slug'                     => $slug,
+			'position'                 => 30,
+			'show_for_displayed_user'  => false,
+			'screen_function'          => 'bp_notifications_screen_unread',
+			'default_subnav_slug'      => 'unread',
+			'item_css_id'              => $this->id,
+			'user_has_access_callback' => 'bp_core_can_edit_settings',
+		);
+
+		// Add the subnav items to the notifications nav item.
+		$sub_nav[] = array(
+			'name'                     => _x( 'Unread', 'Notification screen nav', 'buddypress' ),
+			'slug'                     => 'unread',
+			'parent_slug'              => $slug,
+			'screen_function'          => 'bp_notifications_screen_unread',
+			'position'                 => 10,
+			'item_css_id'              => 'notifications-my-notifications',
+			'user_has_access'          => false,
+			'user_has_access_callback' => 'bp_core_can_edit_settings',
+		);
+
+		$sub_nav[] = array(
+			'name'                     => _x( 'Read', 'Notification screen nav', 'buddypress' ),
+			'slug'                     => 'read',
+			'parent_slug'              => $slug,
+			'screen_function'          => 'bp_notifications_screen_read',
+			'position'                 => 20,
+			'user_has_access'          => false,
+			'user_has_access_callback' => 'bp_core_can_edit_settings',
+		);
+
+		parent::register_nav( $main_nav, $sub_nav );
+	}
+
+	/**
 	 * Set up component navigation.
 	 *
 	 * @since 1.9.0
+	 * @since 12.0.0 Used to customize the main navigation name.
 	 *
-	 * @see BP_Component::setup_nav() for a description of arguments.
+	 * @see `BP_Component::setup_nav()` for a description of arguments.
 	 *
-	 * @param array $main_nav Optional. See BP_Component::setup_nav() for
+	 * @param array $main_nav Optional. See `BP_Component::setup_nav()` for
 	 *                        description.
-	 * @param array $sub_nav  Optional. See BP_Component::setup_nav() for
+	 * @param array $sub_nav  Optional. See `BP_Component::setup_nav()` for
 	 *                        description.
 	 */
 	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
-
-		// Stop if there is no user displayed or logged in.
-		if ( ! is_user_logged_in() && ! bp_displayed_user_id() ) {
-			return;
-		}
-
-		$access = bp_core_can_edit_settings();
-		$slug   = bp_get_notifications_slug();
-
 		// Only grab count if we're on a user page and current user has access.
-		if ( bp_is_user() && bp_user_has_access() ) {
-			$count    = bp_notifications_get_unread_notification_count( bp_displayed_user_id() );
-			$class    = ( 0 === $count ) ? 'no-count' : 'count';
-			$nav_name = sprintf(
+		if ( isset( $this->main_nav['name'] ) && bp_is_user() && bp_user_has_access() ) {
+			$count                  = bp_notifications_get_unread_notification_count( bp_displayed_user_id() );
+			$class                  = ( 0 === $count ) ? 'no-count' : 'count';
+			$this->main_nav['name'] = sprintf(
 				/* translators: %s: Unread notification count for the current user */
 				_x( 'Notifications %s', 'Profile screen nav', 'buddypress' ),
 				sprintf(
@@ -167,40 +211,7 @@ class BP_Notifications_Component extends BP_Component {
 					esc_html( $count )
 				)
 			);
-		} else {
-			$nav_name = _x( 'Notifications', 'Profile screen nav', 'buddypress' );
 		}
-
-		// Add 'Notifications' to the main navigation.
-		$main_nav = array(
-			'name'                    => $nav_name,
-			'slug'                    => $slug,
-			'position'                => 30,
-			'show_for_displayed_user' => $access,
-			'screen_function'         => 'bp_notifications_screen_unread',
-			'default_subnav_slug'     => 'unread',
-			'item_css_id'             => $this->id,
-		);
-
-		// Add the subnav items to the notifications nav item.
-		$sub_nav[] = array(
-			'name'            => _x( 'Unread', 'Notification screen nav', 'buddypress' ),
-			'slug'            => 'unread',
-			'parent_slug'     => $slug,
-			'screen_function' => 'bp_notifications_screen_unread',
-			'position'        => 10,
-			'item_css_id'     => 'notifications-my-notifications',
-			'user_has_access' => $access,
-		);
-
-		$sub_nav[] = array(
-			'name'            => _x( 'Read', 'Notification screen nav', 'buddypress' ),
-			'slug'            => 'read',
-			'parent_slug'     => $slug,
-			'screen_function' => 'bp_notifications_screen_read',
-			'position'        => 20,
-			'user_has_access' => $access,
-		);
 
 		parent::setup_nav( $main_nav, $sub_nav );
 	}

--- a/src/bp-settings/bp-settings-functions.php
+++ b/src/bp-settings/bp-settings-functions.php
@@ -363,6 +363,17 @@ function bp_settings_data_exporter_items() {
 }
 
 /**
+ * Whether a user can delete self account from front-end.
+ *
+ * @since 12.0.0
+ *
+ * @return boolean True if user can delete self account from front-end. False otherwise.
+ */
+function bp_settings_can_delete_self_account() {
+	return ! user_can( bp_displayed_user_id(), 'delete_users' );
+}
+
+/**
  * Whether to show the Delete account front-end nav.
  *
  * @since 12.0.0

--- a/src/bp-settings/bp-settings-functions.php
+++ b/src/bp-settings/bp-settings-functions.php
@@ -361,3 +361,25 @@ function bp_settings_data_exporter_items() {
 
 <?php
 }
+
+/**
+ * Whether to show the Delete account front-end nav.
+ *
+ * @since 12.0.0
+ *
+ * @return boolean True if user can be shown the Delete account nav. False otherwise.
+ */
+function bp_settings_show_delete_account_nav() {
+	return ( ! bp_disable_account_deletion() && bp_is_my_profile() ) || bp_current_user_can( 'delete_users' );
+}
+
+/**
+ * Whether to show the Capability front-end nav.
+ *
+ * @since 12.0.0
+ *
+ * @return boolean True if user can be shown the Capability nav. False otherwise.
+ */
+function bp_settings_show_capability_nav() {
+	return ! bp_is_my_profile();
+}

--- a/src/bp-settings/classes/class-bp-settings-component.php
+++ b/src/bp-settings/classes/class-bp-settings-component.php
@@ -131,57 +131,61 @@ class BP_Settings_Component extends BP_Component {
 	 *                        description.
 	 */
 	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
-
-		// Stop if there is no user displayed or logged in.
-		if ( ! is_user_logged_in() && ! bp_displayed_user_id() ) {
-			return;
-		}
-
-		$access = bp_core_can_edit_settings();
 		$slug   = bp_get_settings_slug();
 
 		// Add the settings navigation item.
 		$main_nav = array(
-			'name'                    => __( 'Settings', 'buddypress' ),
-			'slug'                    => $slug,
-			'position'                => 100,
-			'show_for_displayed_user' => $access,
-			'screen_function'         => 'bp_settings_screen_general',
-			'default_subnav_slug'     => 'general',
+			'name'                     => __( 'Settings', 'buddypress' ),
+			'slug'                     => $slug,
+			'position'                 => 100,
+			'screen_function'          => 'bp_settings_screen_general',
+			'default_subnav_slug'      => 'general',
+			'user_has_access_callback' => 'bp_core_can_edit_settings',
 		);
 
 		// Add General Settings nav item.
 		$sub_nav[] = array(
-			'name'            => __( 'General', 'buddypress' ),
-			'slug'            => 'general',
-			'parent_slug'     => $slug,
-			'screen_function' => 'bp_settings_screen_general',
-			'position'        => 10,
-			'user_has_access' => $access,
+			'name'                     => __( 'General', 'buddypress' ),
+			'slug'                     => 'general',
+			'parent_slug'              => $slug,
+			'screen_function'          => 'bp_settings_screen_general',
+			'position'                 => 10,
+			'user_has_access'          => false,
+			'user_has_access_callback' => 'bp_core_can_edit_settings',
 		);
 
 		// Add Email nav item. Formerly called 'Notifications', we
 		// retain the old slug and function names for backward compat.
 		$sub_nav[] = array(
-			'name'            => __( 'Email', 'buddypress' ),
-			'slug'            => 'notifications',
-			'parent_slug'     => $slug,
-			'screen_function' => 'bp_settings_screen_notification',
-			'position'        => 20,
-			'user_has_access' => $access,
+			'name'                     => __( 'Email', 'buddypress' ),
+			'slug'                     => 'notifications',
+			'parent_slug'              => $slug,
+			'screen_function'          => 'bp_settings_screen_notification',
+			'position'                 => 20,
+			'user_has_access'          => false,
+			'user_has_access_callback' => 'bp_core_can_edit_settings',
 		);
 
-		// Add Spam Account nav item.
-		if ( bp_current_user_can( 'bp_moderate' ) ) {
-			$sub_nav[] = array(
-				'name'            => __( 'Capabilities', 'buddypress' ),
-				'slug'            => 'capabilities',
-				'parent_slug'     => $slug,
-				'screen_function' => 'bp_settings_screen_capabilities',
-				'position'        => 80,
-				'user_has_access' => ! bp_is_my_profile(),
-			);
-		}
+		$sub_nav[] = array(
+			'name'                     => _x( 'Profile Visibility', 'Profile settings sub nav', 'buddypress' ),
+			'slug'                     => 'profile',
+			'parent_slug'              => $slug,
+			'screen_function'          => 'bp_xprofile_screen_settings',
+			'position'                 => 30,
+			'user_has_access'          => false,
+			'user_has_access_callback' => 'bp_core_can_edit_settings',
+		);
+
+		$sub_nav[] = array(
+			'name'                     => __( 'Capabilities', 'buddypress' ),
+			'slug'                     => 'capabilities',
+			'parent_slug'              => $slug,
+			'screen_function'          => 'bp_settings_screen_capabilities',
+			'position'                 => 80,
+			'user_has_access'          => false,
+			'user_has_access_callback' => 'bp_settings_show_capability_nav',
+			'generate'                 => bp_current_user_can( 'bp_moderate' ),
+		);
 
 		/**
 		 * Filter whether the site should show the "Settings > Data" page.
@@ -195,26 +199,26 @@ class BP_Settings_Component extends BP_Component {
 		// Export Data.
 		if ( true === $show_data_page ) {
 			$sub_nav[] = array(
-				'name'            => __( 'Export Data', 'buddypress' ),
-				'slug'            => 'data',
-				'parent_slug'     => $slug,
-				'screen_function' => 'bp_settings_screen_data',
-				'position'        => 89,
-				'user_has_access' => $access,
+				'name'                     => __( 'Export Data', 'buddypress' ),
+				'slug'                     => 'data',
+				'parent_slug'              => $slug,
+				'screen_function'          => 'bp_settings_screen_data',
+				'position'                 => 89,
+				'user_has_access'          => false,
+				'user_has_access_callback' => 'bp_core_can_edit_settings',
 			);
 		}
 
 		// Add Delete Account nav item.
-		if ( ( ! bp_disable_account_deletion() && bp_is_my_profile() ) || bp_current_user_can( 'delete_users' ) ) {
-			$sub_nav[] = array(
-				'name'            => __( 'Delete Account', 'buddypress' ),
-				'slug'            => 'delete-account',
-				'parent_slug'     => $slug,
-				'screen_function' => 'bp_settings_screen_delete_account',
-				'position'        => 90,
-				'user_has_access' => ! user_can( bp_displayed_user_id(), 'delete_users' ),
-			);
-		}
+		$sub_nav[] = array(
+			'name'            => __( 'Delete Account', 'buddypress' ),
+			'slug'            => 'delete-account',
+			'parent_slug'     => $slug,
+			'screen_function' => 'bp_settings_screen_delete_account',
+			'position'        => 90,
+			'user_has_access' => ! user_can( bp_displayed_user_id(), 'delete_users' ),
+			'generate'        => 'bp_settings_show_delete_account_nav',
+		);
 
 		parent::setup_nav( $main_nav, $sub_nav );
 	}

--- a/src/bp-settings/classes/class-bp-settings-component.php
+++ b/src/bp-settings/classes/class-bp-settings-component.php
@@ -119,18 +119,18 @@ class BP_Settings_Component extends BP_Component {
 	}
 
 	/**
-	 * Set up navigation.
+	 * Register component navigation.
 	 *
-	 * @since 1.5.0
+	 * @since 12.0.0
 	 *
-	 * @see BP_Component::setup_nav() for a description of arguments.
+	 * @see `BP_Component::register_nav()` for a description of arguments.
 	 *
-	 * @param array $main_nav Optional. See BP_Component::setup_nav() for
+	 * @param array $main_nav Optional. See `BP_Component::register_nav()` for
 	 *                        description.
-	 * @param array $sub_nav  Optional. See BP_Component::setup_nav() for
+	 * @param array $sub_nav  Optional. See `BP_Component::register_nav()` for
 	 *                        description.
 	 */
-	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
+	public function register_nav( $main_nav = array(), $sub_nav = array() ) {
 		$slug   = bp_get_settings_slug();
 
 		// Add the settings navigation item.
@@ -220,7 +220,7 @@ class BP_Settings_Component extends BP_Component {
 			'generate'        => 'bp_settings_show_delete_account_nav',
 		);
 
-		parent::setup_nav( $main_nav, $sub_nav );
+		parent::register_nav( $main_nav, $sub_nav );
 	}
 
 	/**
@@ -228,10 +228,10 @@ class BP_Settings_Component extends BP_Component {
 	 *
 	 * @since 1.5.0
 	 *
-	 * @see BP_Component::setup_nav() for a description of the $wp_admin_nav
+	 * @see `BP_Component::setup_admin_bar()` for a description of the $wp_admin_nav
 	 *      parameter array.
 	 *
-	 * @param array $wp_admin_nav See BP_Component::setup_admin_bar() for a
+	 * @param array $wp_admin_nav See `BP_Component::setup_admin_bar()` for a
 	 *                            description.
 	 */
 	public function setup_admin_bar( $wp_admin_nav = array() ) {

--- a/src/bp-settings/classes/class-bp-settings-component.php
+++ b/src/bp-settings/classes/class-bp-settings-component.php
@@ -211,13 +211,14 @@ class BP_Settings_Component extends BP_Component {
 
 		// Add Delete Account nav item.
 		$sub_nav[] = array(
-			'name'            => __( 'Delete Account', 'buddypress' ),
-			'slug'            => 'delete-account',
-			'parent_slug'     => $slug,
-			'screen_function' => 'bp_settings_screen_delete_account',
-			'position'        => 90,
-			'user_has_access' => ! user_can( bp_displayed_user_id(), 'delete_users' ),
-			'generate'        => 'bp_settings_show_delete_account_nav',
+			'name'                     => __( 'Delete Account', 'buddypress' ),
+			'slug'                     => 'delete-account',
+			'parent_slug'              => $slug,
+			'screen_function'          => 'bp_settings_screen_delete_account',
+			'position'                 => 90,
+			'user_has_access'          => false,
+			'user_has_access_callback' => 'bp_settings_can_delete_self_account',
+			'generate'                 => 'bp_settings_show_delete_account_nav',
 		);
 
 		parent::register_nav( $main_nav, $sub_nav );

--- a/src/bp-xprofile/classes/class-bp-xprofile-component.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-component.php
@@ -220,14 +220,14 @@ class BP_XProfile_Component extends BP_Component {
 	}
 
 	/**
-	 * Set up navigation.
+	 * Register component navigation.
 	 *
-	 * @since 1.5.0
+	 * @since 12.0.0
 	 *
-	 * @param array $main_nav Array of main nav items to set up.
-	 * @param array $sub_nav  Array of sub nav items to set up.
+	 * @param array $main_nav See `BP_Component::register_nav()` for details.
+	 * @param array $sub_nav  See `BP_Component::register_nav()` for details.
 	 */
-	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
+	public function register_nav( $main_nav = array(), $sub_nav = array() ) {
 		$slug = bp_get_profile_slug();
 
 		// Add 'Profile' to the main navigation.
@@ -260,7 +260,7 @@ class BP_XProfile_Component extends BP_Component {
 			'user_has_access_callback' => 'bp_core_can_edit_settings',
 		);
 
-		parent::setup_nav( $main_nav, $sub_nav );
+		parent::register_nav( $main_nav, $sub_nav );
 	}
 
 	/**

--- a/src/bp-xprofile/classes/class-bp-xprofile-component.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-component.php
@@ -228,14 +228,7 @@ class BP_XProfile_Component extends BP_Component {
 	 * @param array $sub_nav  Array of sub nav items to set up.
 	 */
 	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
-
-		// Stop if there is no user displayed or logged in.
-		if ( ! is_user_logged_in() && ! bp_displayed_user_id() ) {
-			return;
-		}
-
-		$access = bp_core_can_edit_settings();
-		$slug   = bp_get_profile_slug();
+		$slug = bp_get_profile_slug();
 
 		// Add 'Profile' to the main navigation.
 		$main_nav = array(
@@ -258,17 +251,14 @@ class BP_XProfile_Component extends BP_Component {
 
 		// Edit Profile.
 		$sub_nav[] = array(
-			'name'            => _x( 'Edit','Profile header sub menu', 'buddypress' ),
-			'slug'            => 'edit',
-			'parent_slug'     => $slug,
-			'screen_function' => 'xprofile_screen_edit_profile',
-			'position'        => 20,
-			'user_has_access' => $access,
+			'name'                     => _x( 'Edit','Profile header sub menu', 'buddypress' ),
+			'slug'                     => 'edit',
+			'parent_slug'              => $slug,
+			'screen_function'          => 'xprofile_screen_edit_profile',
+			'position'                 => 20,
+			'user_has_access'          => false,
+			'user_has_access_callback' => 'bp_core_can_edit_settings',
 		);
-
-		// The Settings > Profile nav item can only be set up after
-		// the Settings component has run its own nav routine.
-		add_action( 'bp_settings_setup_nav', array( $this, 'setup_settings_nav' ) );
 
 		parent::setup_nav( $main_nav, $sub_nav );
 	}
@@ -280,28 +270,10 @@ class BP_XProfile_Component extends BP_Component {
 	 * be loaded in time for BP_XProfile_Component::setup_nav().
 	 *
 	 * @since 2.1.0
+	 * @deprecated 12.0.0
 	 */
 	public function setup_settings_nav() {
-		if ( ! bp_is_active( 'settings' ) ) {
-			return;
-		}
-
-		// Stop if there is no user displayed or logged in.
-		if ( ! is_user_logged_in() && ! bp_displayed_user_id() ) {
-			return;
-		}
-
-		// Get the settings slug.
-		$settings_slug = bp_get_settings_slug();
-
-		bp_core_new_subnav_item( array(
-			'name'            => _x( 'Profile Visibility', 'Profile settings sub nav', 'buddypress' ),
-			'slug'            => 'profile',
-			'parent_slug'     => $settings_slug,
-			'screen_function' => 'bp_xprofile_screen_settings',
-			'position'        => 30,
-			'user_has_access' => bp_core_can_edit_settings(),
-		), 'members' );
+		_deprecated_function( __METHOD__, '12.0.0' );
 	}
 
 	/**


### PR DESCRIPTION
Compared to commit [13442](https://buddypress.trac.wordpress.org/changeset/13442), change the logic of Components user navigation generation by introducing a `BP_Component::register_nav()` function to globalize the nav items and make them available for the added URLs WP Admin settings screen. After a second thought, using `BP_Component::setup_nav()` to play the registration role can be problematic considering backward compatibility. We are maintaining `BP_Component::setup_nav()` to play the role of generating the user navigation, Third party plugins wishing their slugs to be customizable will need to "opt-in" BP Rewrites using `BP_Component::register_nav()`.

This first version of the URLs WP Admin settings screen does not handle slug customization yet, it's used to make sure all BP Component user navigation slugs can be customized.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/4954

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
