### PR TITLE
Add Single group slugs to the BP URLs Settings tab screen

### DIFF
--- a/src/bp-core/admin/bp-core-admin-rewrites.php
+++ b/src/bp-core/admin/bp-core-admin-rewrites.php
@@ -199,6 +199,74 @@ function bp_core_admin_rewrites_settings() {
 								<?php endforeach; ?>
 							<?php endif; ?>
 						<?php endif; ?>
+
+						<?php if ( 'groups' === $component_id ) : ?>
+
+							<?php
+							foreach (
+								array(
+									'create' => __( 'Single Group creation steps slugs', 'bp-rewrites' ),
+									'read'   => __( 'Single Group regular screens slugs', 'bp-rewrites' ),
+									'manage' => __( 'Single Group management screens slugs', 'bp-rewrites' ),
+								) as $screen_type => $screen_type_title ) :
+								?>
+
+								<div class="health-check-accordion">
+									<h4 class="health-check-accordion-heading">
+										<button aria-expanded="false" class="health-check-accordion-trigger" aria-controls="health-check-accordion-block-group-<?php echo esc_attr( $screen_type ); ?>" type="button">
+											<span class="title"><?php echo esc_html( $screen_type_title ); ?></span>
+											<span class="icon"></span>
+										</button>
+									</h4>
+									<div id="health-check-accordion-block-group-<?php echo esc_attr( $screen_type ); ?>" class="health-check-accordion-panel" hidden="hidden">
+										<table class="form-table" role="presentation">
+
+										<?php
+										if ( 'create' === $screen_type ) :
+											foreach ( bp_get_group_restricted_screens() as $group_create_restricted_screen ) :
+												?>
+												<tr>
+													<th scope="row">
+														<label style="margin-left: 2em; display: inline-block; vertical-align: middle" for="<?php echo esc_attr( sprintf( '%s-slug', sanitize_key( $group_create_restricted_screen['rewrite_id'] ) ) ); ?>">
+															<?php echo esc_html( $group_create_restricted_screen['name'] ); ?>
+														</label>
+													</th>
+													<td>
+														<input type="text" class="code" name="<?php printf( 'components[%1$d][_bp_component_slugs][%2$s]', absint( $directory_data->id ), esc_attr( $group_create_restricted_screen['rewrite_id'] ) ); ?>" id="<?php echo esc_attr( sprintf( '%s-slug', sanitize_key( $group_create_restricted_screen['rewrite_id'] ) ) ); ?>" value="<?php echo esc_attr( bp_rewrites_get_slug( $component_id, $group_create_restricted_screen['rewrite_id'], $group_create_restricted_screen['slug'] ) ); ?>">
+													</td>
+												</tr>
+												<?php
+											endforeach;
+
+										endif;
+
+										foreach ( bp_get_group_screens( $screen_type ) as $group_screen ) :
+											if ( ! isset( $group_screen['rewrite_id'] ) || ! $group_screen['rewrite_id'] ) {
+												continue;
+											}
+											?>
+												<tr>
+													<th scope="row">
+														<label style="margin-left: 2em; display: inline-block; vertical-align: middle" for="<?php echo esc_attr( sprintf( '%s-slug', sanitize_key( $group_screen['rewrite_id'] ) ) ); ?>">
+															<?php
+															printf(
+																/* translators: %s is group view name */
+																esc_html_x( '"%s" slug', 'group view name URL admin label', 'bp-rewrites' ),
+																esc_html( _bp_strip_spans_from_title( $group_screen['name'] ) )
+															);
+															?>
+														</label>
+													</th>
+													<td>
+														<input type="text" class="code" name="<?php printf( 'components[%1$d][_bp_component_slugs][%2$s]', absint( $directory_data->id ), esc_attr( $group_screen['rewrite_id'] ) ); ?>" id="<?php echo esc_attr( sprintf( '%s-slug', sanitize_key( $group_screen['rewrite_id'] ) ) ); ?>" value="<?php echo esc_attr( bp_rewrites_get_slug( $component_id, $group_screen['rewrite_id'], $group_screen['slug'] ) ); ?>">
+													</td>
+												</tr>
+											<?php endforeach; ?>
+										</table>
+									</div>
+								</div>
+							<?php endforeach; ?>
+						<?php endif; ?>
 					</div>
 				<?php endforeach; ?>
 			</form>

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -3809,10 +3809,11 @@ function bp_get_group_extension_screens( $context = 'read' ) {
  *
  * @since 12.0.0
  *
- * @param string $context The display context. Required. Defaults to `read`.
- * @return array          The list of potential Group screens.
+ * @param string  $context  The display context. Required. Defaults to `read`.
+ * @param boolean $built_in True to only get builtin screens. False otherwise.
+ * @return array            The list of potential Group screens.
  */
-function bp_get_group_screens( $context = 'read' ) {
+function bp_get_group_screens( $context = 'read', $built_in = false ) {
 	$screens = array(
 		'create' => array(
 			'group-details'     => array(
@@ -3979,6 +3980,11 @@ function bp_get_group_screens( $context = 'read' ) {
 		return array();
 	}
 
+	// We only need built-in screens, do not get custom ones.
+	if ( $built_in ) {
+		return $screens[ $context ];
+	}
+
 	$context_screens         = array();
 	$custom_screens          = apply_filters( 'bp_get_group_custom_' . $context . '_screens', $context_screens );
 	$group_extension_screens = bp_get_group_extension_screens( $context );
@@ -3989,7 +3995,7 @@ function bp_get_group_screens( $context = 'read' ) {
 
 	if ( $custom_screens && ! wp_is_numeric_array( $custom_screens ) ) {
 		// The screen key (used as default slug) and `rewrite_id` prop need to be unique.
-		$valid_custom_screens   = array_diff_key( $custom_screens, $screens[ $context ] );
+		$valid_custom_screens = array_diff_key( $custom_screens, $screens[ $context ] );
 		$existing_rewrite_ids = array_column( $screens[ $context ], 'rewrite_id' );
 		$existing_rewrite_ids = array_merge(
 			$existing_rewrite_ids,

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -1277,6 +1277,25 @@ function groups_get_current_group() {
 	return apply_filters( 'groups_get_current_group', $current_group );
 }
 
+/**
+ * Can the current user access to the current group?
+ *
+ * @since 12.0.0
+ *
+ * @return boolean True if the current user can access to the current group.
+ *                 False otherwise.
+ */
+function bp_groups_user_can_access_current_group() {
+	$can_access = false;
+
+	$current_group = groups_get_current_group();
+	if ( isset( $current_group->user_has_access ) ) {
+		$can_access = $current_group->user_has_access;
+	}
+
+	return $can_access;
+}
+
 /** Group Avatars *************************************************************/
 
 /**
@@ -3836,16 +3855,6 @@ function bp_get_group_screens( $context = 'read' ) {
 				'position'        => 10,
 				'item_css_id'     => 'home',
 			),
-			'activity'            => array(
-				'rewrite_id'      => 'bp_group_read_activity',
-				'slug'            => 'activity',
-				'name'            => _x( 'Activity', 'Group read screen', 'buddypress' ),
-				'screen_function' => 'groups_screen_group_activity',
-				'position'        => 11,
-				'user_has_access' => false,
-				'no_access_url'   => '',
-				'item_css_id'     => 'activity',
-			),
 			'request-membership' => array(
 				'rewrite_id'      => 'bp_group_read_request_membership',
 				'slug'            => 'request-membership',
@@ -3853,36 +3862,50 @@ function bp_get_group_screens( $context = 'read' ) {
 				'screen_function' => 'groups_screen_group_request_membership',
 				'position'        => 30,
 			),
+			'activity'           => array(
+				'rewrite_id'               => 'bp_group_read_activity',
+				'slug'                     => 'activity',
+				'name'                     => _x( 'Activity', 'Group read screen', 'buddypress' ),
+				'screen_function'          => 'groups_screen_group_activity',
+				'position'                 => 11,
+				'user_has_access'          => false,
+				'user_has_access_callback' => 'bp_groups_user_can_access_current_group',
+				'no_access_url'            => '',
+				'item_css_id'              => 'activity',
+			),
 			'members'            => array(
-				'rewrite_id'      => 'bp_group_read_members',
-				'slug'            => 'members',
+				'rewrite_id'               => 'bp_group_read_members',
+				'slug'                     => 'members',
 				/* translators: %s: total member count */
-				'name'            => _x( 'Members %s', 'Group read screen', 'buddypress' ),
-				'screen_function' => 'groups_screen_group_members',
-				'position'        => 60,
-				'user_has_access' => false,
-				'no_access_url'   => '',
-				'item_css_id'     => 'members',
+				'name'                     => _x( 'Members %s', 'Group read screen', 'buddypress' ),
+				'screen_function'          => 'groups_screen_group_members',
+				'position'                 => 60,
+				'user_has_access'          => false,
+				'user_has_access_callback' => 'bp_groups_user_can_access_current_group',
+				'no_access_url'            => '',
+				'item_css_id'              => 'members',
 			),
 			'send-invites'       => array(
-				'rewrite_id'      => 'bp_group_read_send_invites',
-				'slug'            => 'send-invites',
-				'name'            => _x( 'Send Invites', 'Group read screen', 'buddypress' ),
-				'screen_function' => 'groups_screen_group_invite',
-				'position'        => 70,
-				'user_has_access' => false,
-				'no_access_url'   => '',
-				'item_css_id'     => 'invite',
+				'rewrite_id'               => 'bp_group_read_send_invites',
+				'slug'                     => 'send-invites',
+				'name'                     => _x( 'Send Invites', 'Group read screen', 'buddypress' ),
+				'screen_function'          => 'groups_screen_group_invite',
+				'position'                 => 70,
+				'user_has_access'          => false,
+				'user_has_access_callback' => 'bp_groups_user_can_send_invites',
+				'no_access_url'            => '',
+				'item_css_id'              => 'invite',
 			),
 			'admin'              => array(
-				'rewrite_id'      => 'bp_group_read_admin',
-				'slug'            => 'admin',
-				'name'            => _x( 'Manage', 'Group read screen', 'buddypress' ),
-				'screen_function' => 'groups_screen_group_admin',
-				'position'        => 1000,
-				'user_has_access' => false,
-				'no_access_url'   => '',
-				'item_css_id'     => 'admin',
+				'rewrite_id'               => 'bp_group_read_admin',
+				'slug'                     => 'admin',
+				'name'                     => _x( 'Manage', 'Group read screen', 'buddypress' ),
+				'screen_function'          => 'groups_screen_group_admin',
+				'position'                 => 1000,
+				'user_has_access'          => false,
+				'user_has_access_callback' => 'bp_is_item_admin',
+				'no_access_url'            => '',
+				'item_css_id'              => 'admin',
 			),
 		),
 		'manage' => array(

--- a/src/bp-groups/bp-groups-template.php
+++ b/src/bp-groups/bp-groups-template.php
@@ -3242,9 +3242,9 @@ function bp_group_form_action( $page, $group = false ) {
 			return '';
 		}
 
-		$views = bp_get_group_screens( 'read' );
-		if ( isset( $views[ $page ]['rewrite_id'] ) ) {
-			$page = bp_rewrites_get_slug( 'groups', $views[ $page ]['rewrite_id'], $page );
+		$screens = bp_get_group_screens( 'read' );
+		if ( isset( $screens[ $page ]['rewrite_id'] ) ) {
+			$page = bp_rewrites_get_slug( 'groups', $screens[ $page ]['rewrite_id'], $page );
 		}
 
 		$url = bp_get_group_url(
@@ -3302,9 +3302,9 @@ function bp_group_admin_form_action( $page = false, $group = false ) {
 			$page = bp_action_variable( 0 );
 		}
 
-		$views = bp_get_group_screens( 'manage' );
-		if ( isset( $views[ $page ]['rewrite_id'] ) ) {
-			$page = bp_rewrites_get_slug( 'groups', $views[ $page ]['rewrite_id'], $page );
+		$screens = bp_get_group_screens( 'manage' );
+		if ( isset( $screens[ $page ]['rewrite_id'] ) ) {
+			$page = bp_rewrites_get_slug( 'groups', $screens[ $page ]['rewrite_id'], $page );
 		}
 
 		$url = bp_get_group_url(

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -374,7 +374,7 @@ class BP_Groups_Component extends BP_Component {
 		}
 
 		// Set default Group creation steps.
-		$group_creation_steps = bp_get_group_screens( 'create' );
+		$group_creation_steps = bp_get_group_screens( 'create', true );
 
 		// If avatar uploads are disabled, remove avatar view.
 		$disabled_avatar_uploads = (int) bp_disable_group_avatar_uploads();
@@ -653,7 +653,7 @@ class BP_Groups_Component extends BP_Component {
 			);
 
 			// Get the "read" screens.
-			$screens    = bp_get_group_screens( 'read' );
+			$screens    = bp_get_group_screens( 'read', true );
 			$group_link = bp_get_group_url( $this->current_group );
 			$sub_nav    = array();
 
@@ -714,7 +714,7 @@ class BP_Groups_Component extends BP_Component {
 			// If the user is a group admin, then show the group admin nav item.
 			if ( bp_is_item_admin() ) {
 				// Get the "manage" screens.
-				$manage_screens    = bp_get_group_screens( 'manage' );
+				$manage_screens    = bp_get_group_screens( 'manage', true );
 				$admin_link        = bp_get_group_url(
 					$this->current_group,
 					array(


### PR DESCRIPTION
- Edit BP_Groups_Component::setup_nav() so that it uses `bp_get_group_screens()` to generate the single group's navigation items.
- `bp_get_group_screens()` is making it possible to get all single group's nav item slugs from the BP Urls settings tab, use it to add these slugs into the Accordion UI.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/4954

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
