### PR TITLE
BP Rewrites merge, step 16

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -497,6 +497,49 @@ class BP_Activity_Component extends BP_Component {
 	}
 
 	/**
+	 * Parse the WP_Query and eventually display the component's directory or single item.
+	 *
+	 * @since 12.0.0
+	 *
+	 * @param WP_Query $query Required. See BP_Component::parse_query() for
+	 *                        description.
+	 */
+	public function parse_query( $query ) {
+		if ( bp_is_directory_homepage( $this->id ) ) {
+			$query->set( $this->rewrite_ids['directory'], 1 );
+		}
+
+		if ( 1 === (int) $query->get( $this->rewrite_ids['directory'] ) ) {
+			$bp = buddypress();
+
+			// Set the Activity component as current.
+			$bp->current_component = 'activity';
+
+			$current_action = $query->get( $this->rewrite_ids['single_item_action'] );
+			if ( $current_action ) {
+				$bp->current_action = $current_action;
+			}
+
+			$action_variables = $query->get( $this->rewrite_ids['single_item_action_variables'] );
+			if ( $action_variables ) {
+				if ( ! is_array( $action_variables ) ) {
+					$bp->action_variables = explode( '/', ltrim( $action_variables, '/' ) );
+				} else {
+					$bp->action_variables = $action_variables;
+				}
+			}
+
+			// Set the BuddyPress queried object.
+			if ( isset( $bp->pages->activity->id ) ) {
+				$query->queried_object    = get_post( $bp->pages->activity->id );
+				$query->queried_object_id = $query->queried_object->ID;
+			}
+		}
+
+		parent::parse_query( $query );
+	}
+
+	/**
 	 * Init the BP REST API.
 	 *
 	 * @since 5.0.0

--- a/src/bp-blogs/classes/class-bp-blogs-component.php
+++ b/src/bp-blogs/classes/class-bp-blogs-component.php
@@ -437,6 +437,53 @@ class BP_Blogs_Component extends BP_Component {
 	}
 
 	/**
+	 * Parse the WP_Query and eventually display the component's directory or single item.
+	 *
+	 * @since 12.0.0
+	 *
+	 * @param WP_Query $query Required. See BP_Component::parse_query() for
+	 *                        description.
+	 */
+	public function parse_query( $query ) {
+		if ( ! is_multisite() ) {
+			return parent::parse_query( $query );
+		}
+
+		// Get the BuddyPress main instance.
+		$bp = buddypress();
+
+		if ( bp_is_directory_homepage( $this->id ) ) {
+			$query->set( $this->rewrite_ids['directory'], 1 );
+		}
+
+		if ( 1 === (int) $query->get( $this->rewrite_ids['directory'] ) ) {
+			$bp->current_component = 'blogs';
+
+			$current_action = $query->get( $this->rewrite_ids['single_item_action'] );
+			if ( $current_action ) {
+				$bp->current_action = $current_action;
+			}
+
+			$action_variables = $query->get( $this->rewrite_ids['single_item_action_variables'] );
+			if ( $action_variables ) {
+				if ( ! is_array( $action_variables ) ) {
+					$bp->action_variables = explode( '/', ltrim( $action_variables, '/' ) );
+				} else {
+					$bp->action_variables = $action_variables;
+				}
+			}
+
+			// Set the BuddyPress queried object.
+			if ( isset( $bp->pages->blogs->id ) ) {
+				$query->queried_object    = get_post( $bp->pages->blogs->id );
+				$query->queried_object_id = $query->queried_object->ID;
+			}
+		}
+
+		parent::parse_query( $query );
+	}
+
+	/**
 	 * Init the BP REST API.
 	 *
 	 * @since 6.0.0

--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -204,7 +204,6 @@ function bp_core_add_admin_notice( $notice = '', $type = 'updated' ) {
  * Verify that some BP prerequisites are set up properly, and notify the admin if not.
  *
  * On every Dashboard page, this function checks the following:
- *   - that pretty permalinks are enabled.
  *   - that every BP component that needs a WP page for a directory has one.
  *   - that no WP page has multiple BP components associated with it.
  * The administrator will be shown a notice for each check that fails.
@@ -249,18 +248,6 @@ function bp_core_activation_notice() {
 		if ( empty( $count ) ) {
 			bp_blogs_record_existing_blogs();
 		}
-	}
-
-	// Add notice if no rewrite rules are enabled.
-	if ( empty( $wp_rewrite->permalink_structure ) ) {
-		bp_core_add_admin_notice(
-			sprintf(
-				// Translators: %s is the url to the permalink settings.
-				__( '<strong>BuddyPress is almost ready</strong>. You must <a href="%s">update your permalink structure</a> to something other than the default for it to work.', 'buddypress' ),
-				admin_url( 'options-permalink.php' )
-			),
-			'error'
-		);
 	}
 
 	// Get BuddyPress instance.

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -957,6 +957,28 @@ function bp_core_set_unique_directory_page_slug( $slug = '', $post_ID = 0, $post
 add_filter( 'wp_unique_post_slug', 'bp_core_set_unique_directory_page_slug', 10, 6 );
 
 /**
+ * Checks if a component's directory is set as the site's homepage.
+ *
+ * @since 12.0.0
+ *
+ * @param string   $component The component ID.
+ * @return boolean            True if a component's directory is set as the site's homepage.
+ *                            False otherwise.
+ */
+function bp_is_directory_homepage( $component = '' ) {
+	$is_directory_homepage = false;
+	$is_page_on_front      = 'page' === get_option( 'show_on_front', 'posts' );
+	$page_id_on_front      = get_option( 'page_on_front', 0 );
+	$directory_pages       = bp_core_get_directory_pages();
+
+	if ( $is_page_on_front && isset( $directory_pages->{$component} ) && (int) $page_id_on_front === (int) $directory_pages->{$component}->id ) {
+		$is_directory_homepage = true;
+	}
+
+	return $is_directory_homepage;
+}
+
+/**
  * Remove the entry from bp_pages when the corresponding WP page is deleted.
  *
  * Bails early on multisite installations when not viewing the root site.

--- a/src/bp-core/classes/class-bp-component.php
+++ b/src/bp-core/classes/class-bp-component.php
@@ -577,7 +577,14 @@ class BP_Component {
 		add_action( 'bp_add_permastructs',       array( $this, 'add_permastructs'       ), 10 );
 
 		// Allow components to parse the main query.
-		add_action( 'bp_parse_query',            array( $this, 'parse_query'            ), 10 );
+		if ( ! bp_has_pretty_urls() ) {
+			/**
+			 * Only fire this hook when pretty links are disabled.
+			 *
+			 * @todo Remove once BP Rewrites merge process is ended.
+			 */
+			add_action( 'bp_parse_query',  array( $this, 'parse_query' ), 10 );
+		}
 
 		// Generate rewrite rules.
 		add_action( 'bp_generate_rewrite_rules', array( $this, 'generate_rewrite_rules' ), 10 );


### PR DESCRIPTION
- Start implementing the `parse_query()` methods for the Activity/Blogs and Members components.
- Remove the notice used to force pretty permalinks
- Use plain links to test `parse_query()` methods are rightly setting BuddyPress URI globals
- Introduce some helper functions used during the BP Rewrites API parsing process : 
  -  `bp_is_directory_homepage()` is checking if a BP Directory is used as the site's homepage.
  - `bp_rewrites_get_custom_slug_rewrite_id()` finds a Rewrite ID out of a custom slug.
  - `bp_rewrites_get_member_data()` returns the field to use to get the user by.
  - `bp_reset_query()` makes it possible to parse again a request in specific cases (eg: root profiles)

Trac ticket: https://buddypress.trac.wordpress.org/ticket/4954

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
