### PR TITLE
Make sure Thread Header & the send action can get needed data

### DIFF
--- a/src/bp-templates/bp-nouveau/js/buddypress-messages.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-messages.js
@@ -1,7 +1,7 @@
 /* global wp, BP_Nouveau, _, Backbone, tinymce, tinyMCE */
 /* jshint devel: true */
 /* @since 3.0.0 */
-/* @version 10.3.0 */
+/* @version 11.2.0 */
 window.wp = window.wp || {};
 window.bp = window.bp || {};
 
@@ -1354,7 +1354,7 @@ window.bp = window.bp || {};
 		},
 
 		messagesFetched: function( collection, response ) {
-			if ( response.thread && !! response.thread.length ) {
+			if ( response.thread && !! response.thread.id ) {
 				this.options.thread = new Backbone.Model( response.thread );
 			}
 
@@ -1387,12 +1387,12 @@ window.bp = window.bp || {};
 			}
 
 			threadItem = this.options.thread;
-			if ( ! threadItem.has( 'id' ) ) {
+			if ( ! threadItem.id ) {
 				threadItem = this.options.collection.at( 0 );
 			}
 
 			this.reply.set ( {
-				thread_id : threadItem.get( 'id' ),
+				thread_id : threadItem.id,
 				content   : tinyMCE.activeEditor.getContent(),
 				sending   : true
 			} );


### PR DESCRIPTION
- Make sure the send action can get the Thread ID if the thread view was generated by opening the inbox view or thanks to the BackBone Router (direct URL access).
- Make sure the Thread data used by the Thread's header is initialized as a BackBone Model.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8870

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
