### PR TITLE
Make sure to reset the sending status on sent reply/message errors

### DIFF
--- a/src/bp-templates/bp-nouveau/js/buddypress-messages.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-messages.js
@@ -654,6 +654,9 @@ window.bp = window.bp || {};
 				} );
 
 				bp.Nouveau.Messages.displayFeedback( feedback, 'error' );
+				self.model.set( 'sending', false, { silent: true } );
+				$( button ).removeClass( 'disabled' ).prop( 'disabled', false );
+
 				return;
 			}
 
@@ -1411,11 +1414,18 @@ window.bp = window.bp || {};
 			this.reply.set( 'sending', false );
 
 			this.collection.add( _.first( reply ) );
+
+			// Remove any existing feedback.
+			bp.Nouveau.Messages.removeFeedback();
 		},
 
 		replyError: function( response ) {
 			if ( response.feedback && response.type ) {
 				bp.Nouveau.Messages.displayFeedback( response.feedback, response.type );
+			}
+
+			if ( this.reply.get( 'sending' ) ) {
+				this.reply.set( 'sending', false );
 			}
 		}
 	} );


### PR DESCRIPTION
Make sure to reset the sending status on sent reply/message errors so that it's possible to use the reply/message form again.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8871

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
