### PR TITLE
BP Rewrites merge process, step 18

### DIFF
--- a/src/bp-core/admin/bp-core-admin-actions.php
+++ b/src/bp-core/admin/bp-core-admin-actions.php
@@ -54,7 +54,8 @@ add_action( 'bp_admin_init', 'bp_core_activation_notice', 1010 );
 add_action( 'bp_admin_init', 'bp_register_importers'           );
 add_action( 'bp_admin_init', 'bp_register_admin_style'         );
 add_action( 'bp_admin_init', 'bp_register_admin_settings'      );
-add_action( 'bp_admin_init', 'bp_do_activation_redirect', 1    );
+add_action( 'bp_admin_init', 'bp_do_activation_redirect',    1 );
+add_action( 'bp_admin_init', 'bp_core_set_ajax_uri_globals', 2 );
 
 // Add a new separator.
 add_action( 'bp_admin_menu', 'bp_admin_separator' );

--- a/src/bp-core/bp-core-actions.php
+++ b/src/bp-core/bp-core-actions.php
@@ -71,16 +71,59 @@ add_action( 'bp_loaded', 'bp_register_theme_directory', 14 );
 add_action( 'bp_init', 'bp_register_post_types',     2  );
 add_action( 'bp_init', 'bp_register_post_statuses',  2  );
 add_action( 'bp_init', 'bp_register_taxonomies',     2  );
-add_action( 'bp_init', 'bp_core_set_uri_globals',    2  );
 add_action( 'bp_init', 'bp_setup_globals',           4  );
-add_action( 'bp_init', 'bp_setup_canonical_stack',   5  );
-add_action( 'bp_init', 'bp_setup_nav',               6  );
-add_action( 'bp_init', 'bp_setup_title',             8  );
 add_action( 'bp_init', 'bp_blocks_init',             10 );
 add_action( 'bp_init', 'bp_core_load_admin_bar_css', 12 );
 add_action( 'bp_init', 'bp_add_rewrite_tags',        20 );
 add_action( 'bp_init', 'bp_add_rewrite_rules',       30 );
 add_action( 'bp_init', 'bp_add_permastructs',        40 );
+
+/**
+ * Adats BuddyPress key actions starting point according to the request parser in use.
+ *
+ * The legacy request parser needs key actions to hook at `bp_init`, while the BP Rewrites API
+ * needs key actions to hook at `bp_parse_query`.
+ *
+ * @since 12.0.0
+ */
+function bp_core_setup_query_parser() {
+	$hook        = bp_core_get_key_actions_hook();
+	$key_actions = array(
+		'bp_setup_canonical_stack'            => 11,
+		'bp_setup_nav'                        => 12,
+		'bp_core_action_search_site'          => 13,
+		'bp_setup_title'                      => 14,
+		'_bp_maybe_remove_redirect_canonical' => 20,
+		'bp_remove_adjacent_posts_rel_link'   => 20,
+	);
+
+	if ( 'bp_init' === $hook ) {
+		$key_actions['bp_setup_canonical_stack']            = 5;
+		$key_actions['bp_setup_nav']                        = 6;
+		$key_actions['bp_core_action_search_site']          = 7;
+		$key_actions['bp_setup_title']                      = 8;
+		$key_actions['_bp_maybe_remove_redirect_canonical'] = 10;
+		$key_actions['bp_remove_adjacent_posts_rel_link']   = 10;
+
+		/**
+		 *
+		 * @todo This code should be moved to BP Classic.
+		 *
+		 */
+		add_action( $hook, 'bp_core_set_uri_globals', 2 );
+	}
+
+	foreach ( $key_actions as $action => $priority ) {
+		$arguments = 1;
+
+		if ( 'bp_core_action_search_site' === $action ) {
+			$arguments = 0;
+		}
+
+		add_action( $hook, $action, $priority, $arguments );
+	}
+}
+add_action( 'bp_init', 'bp_core_setup_query_parser', 1 );
 
 /**
  * The bp_register_taxonomies hooks - Attached to 'bp_init' @ priority 2 above.

--- a/src/bp-core/bp-core-actions.php
+++ b/src/bp-core/bp-core-actions.php
@@ -87,7 +87,12 @@ add_action( 'bp_init', 'bp_add_permastructs',        40 );
  * @since 12.0.0
  */
 function bp_core_setup_query_parser() {
-	$hook        = bp_core_get_key_actions_hook();
+	$parser = bp_core_get_query_parser();
+	$hook   = 'bp_parse_query';
+	if ( 'legacy' === $parser ) {
+		$hook = 'bp_init';
+	}
+
 	$key_actions = array(
 		'bp_setup_canonical_stack'            => 11,
 		'bp_setup_nav'                        => 12,

--- a/src/bp-core/bp-core-actions.php
+++ b/src/bp-core/bp-core-actions.php
@@ -79,7 +79,7 @@ add_action( 'bp_init', 'bp_add_rewrite_rules',       30 );
 add_action( 'bp_init', 'bp_add_permastructs',        40 );
 
 /**
- * Adats BuddyPress key actions starting point according to the request parser in use.
+ * Adapt BuddyPress key actions starting point according to the request parser in use.
  *
  * The legacy request parser needs key actions to hook at `bp_init`, while the BP Rewrites API
  * needs key actions to hook at `bp_parse_query`.

--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -14,62 +14,6 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Get a specific BuddyPress URI segment based on the current URI.
- *
- * You shouldn't really have to use this function unless you need to find a BP
- * URI segment earlier than the `'bp_parse_query'` action.
- *
- * @since 1.0.0
- *
- * @param array $bp_global An array containing the BuddyPress global name. Required.
- * @return string The global value if found. False otherwise.
- */
-function bp_core_get_unfiltered_uri() {
-	// Don't do this on non-root blogs unless multiblog mode is on.
-	if ( ! bp_is_root_blog() && ! bp_is_multiblog_mode() ) {
-		return '';
-	}
-
-	$bp = buddypress();
-
-	// Get existing BuddyPress URI if already calculated.
-	if ( isset( $bp->unfiltered_uri ) && $bp->unfiltered_uri ) {
-		$bp_uri = $bp->unfiltered_uri;
-
-		// calculate the BuddyPress URI.
-	} elseif ( isset( $_SERVER['REQUEST_URI'] ) ) {
-		$requested_uri = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
-
-		/**
-		 * Filters the BuddyPress global URI path.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param string $path Path to set.
-		 */
-		$path = apply_filters( 'bp_uri', $requested_uri );
-
-		// Get the regular site path.
-		$site_path = trim( bp_core_get_site_path(), '/' );
-
-		// Get the multisite subdirectory install site path.
-		if ( is_multisite() && ! is_subdomain_install() ) {
-			$current_blog = get_site();
-			$site_path    = trim( $current_blog->path, '/' );
-		}
-
-		// strip site path from URI.
-		$path   = str_replace( $site_path, '', $path );
-		$bp_uri = explode( '/', trim( wp_parse_url( $path, PHP_URL_PATH ), '/' ) );
-
-		// save for later.
-		$bp->unfiltered_uri = $bp_uri;
-	}
-
-	return $bp_uri;
-}
-
-/**
  * Analyze the URI and break it down into BuddyPress-usable chunks.
  *
  * BuddyPress can use complete custom friendly URIs without the user having to

--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -388,6 +388,29 @@ function bp_core_set_uri_globals() {
 }
 
 /**
+ * Sets BuddyPress globals for Ajax requests using the BP Rewrites API.
+ *
+ * @since 12.0.0
+ */
+function bp_core_set_ajax_uri_globals() {
+	if ( ! wp_doing_ajax() || 'rewrites' !== bp_core_get_query_parser() ) {
+		return;
+	}
+
+	$action = '';
+	if ( isset( $_REQUEST['action'] ) ) {
+		$action = wp_unslash( sanitize_text_field( $_REQUEST['action'] ) );
+	}
+
+	// Only set BuddyPress URI globals for registered Ajax actions.
+	if ( ! bp_ajax_action_is_registered( $action ) ) {
+		return;
+	}
+
+	bp_reset_query( bp_get_referer_path(), $GLOBALS['wp_query'] );
+}
+
+/**
  * Are root profiles enabled and allowed?
  *
  * @since 1.6.0

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -3000,6 +3000,38 @@ function bp_core_get_suggestions( $args ) {
 }
 
 /**
+ * Register Ajax actions needing the BP URI globals to be set.
+ *
+ * @since 12.0.0
+ *
+ * @param string $ajax_action The ajax action needing the BP URI globals to be set.
+ * @return boolean            True if the ajax action was registered. False otherwise.
+ */
+function bp_ajax_register_action( $ajax_action = '' ) {
+	// Checks the ajax action is registered.
+	if ( bp_ajax_action_is_registered( $ajax_action ) ) {
+		return false;
+	}
+
+	buddypress()->ajax_actions[] = $ajax_action;
+	return true;
+}
+
+/**
+ * Is the requested ajax action registered?
+ *
+ * @since 12.0.0
+ *
+ * @param string $ajax_action The ajax action to check.
+ * @return boolean            True if the ajax action is registered. False otherwise
+ */
+function bp_ajax_action_is_registered( $ajax_action = '' ) {
+	$registered_ajax_actions = buddypress()->ajax_actions;
+
+	return in_array( $ajax_action, $registered_ajax_actions, true );
+}
+
+/**
  * AJAX endpoint for Suggestions API lookups.
  *
  * @since 2.1.0

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -142,27 +142,24 @@ function bp_is_running_wp( $version, $compare = '>=' ) {
 /** Functions *****************************************************************/
 
 /**
- * Get the hook to attach key BP actions to according to the parser in use.
+ * Get the BuddyPress parser in use.
  *
  * @since 12.0.0
+ *
+ * @return string The name of the parser in use.
  */
-function bp_core_get_key_actions_hook() {
+function bp_core_get_query_parser() {
 	/**
 	 * Which parser is in use? `rewrites` or `legacy`?
+	 *
+	 * @todo Remove the Pretty URLs check used during BP Rewrites merge process.
 	 *
 	 * @since 12.0.0
 	 *
 	 * @param string $parser The parser to use to decide the hook to attach key actions to.
 	 *                       Possible values are `rewrites` or `legacy`.
 	 */
-	$parser = apply_filters( 'bp_core_setup_query_parser', 'legacy' );
-	$hook   = 'bp_parse_query';
-
-	if ( 'legacy' === $parser ) {
-		$hook = 'bp_init';
-	}
-
-	return $hook;
+	return apply_filters( 'bp_core_get_query_parser', bp_has_pretty_urls() ? 'legacy' : 'rewrites' );
 }
 
 /**

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -142,6 +142,30 @@ function bp_is_running_wp( $version, $compare = '>=' ) {
 /** Functions *****************************************************************/
 
 /**
+ * Get the hook to attach key BP actions to according to the parser in use.
+ *
+ * @since 12.0.0
+ */
+function bp_core_get_key_actions_hook() {
+	/**
+	 * Which parser is in use? `rewrites` or `legacy`?
+	 *
+	 * @since 12.0.0
+	 *
+	 * @param string $parser The parser to use to decide the hook to attach key actions to.
+	 *                       Possible values are `rewrites` or `legacy`.
+	 */
+	$parser = apply_filters( 'bp_core_setup_query_parser', 'legacy' );
+	$hook   = 'bp_parse_query';
+
+	if ( 'legacy' === $parser ) {
+		$hook = 'bp_init';
+	}
+
+	return $hook;
+}
+
+/**
  * Get the $wpdb base prefix, run through the 'bp_core_get_table_prefix' filter.
  *
  * The filter is intended primarily for use in multinetwork installations.
@@ -2587,7 +2611,6 @@ function bp_core_action_search_site( $slug = '' ) {
 	 */
 	bp_core_redirect( apply_filters( 'bp_core_search_site', home_url( $slug . $query_string . urlencode( $search_terms ) ), $search_terms ) );
 }
-add_action( 'bp_parse_query', 'bp_core_action_search_site', 13, 0 );
 
 /**
  * Remove "prev" and "next" relational links from <head> on BuddyPress pages.
@@ -2606,7 +2629,6 @@ function bp_remove_adjacent_posts_rel_link() {
 
 	remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head', 10 );
 }
-add_action( 'bp_init', 'bp_remove_adjacent_posts_rel_link' );
 
 /**
  * Strip the span count of a menu item or of a title part.

--- a/src/bp-core/bp-core-rewrites.php
+++ b/src/bp-core/bp-core-rewrites.php
@@ -210,7 +210,7 @@ function bp_rewrites_get_url( $args = array() ) {
 				$qv[ $rewrite_id ] = $r[ $key ];
 			}
 
-			$url = add_query_arg( $qv, $url );
+			$url = add_query_arg( $qv, trailingslashit( $url ) );
 
 			// Using pretty URLs.
 		} else {

--- a/src/bp-core/bp-core-rewrites.php
+++ b/src/bp-core/bp-core-rewrites.php
@@ -78,25 +78,23 @@ function bp_has_pretty_urls() {
  * @return string The slug to use for the screen belonging to the requested component.
  */
 function bp_rewrites_get_slug( $component_id = '', $rewrite_id = '', $default_slug = '' ) {
+	$using_legacy = 'legacy' === bp_core_get_query_parser();
+
 	/**
-	 * This filter is used by the BP Classic plugin to force `$default_slug` usage.
-	 *
-	 * Using the "Classic" BuddyPress means deprecated functions building URL concatening
-	 * URL chunks are available, we cannot use the BP Rewrites API in this case & as a result
-	 * slug customization is bypassed.
-	 *
-	 * The BP Classic plugin is simply returning the `$default_slug` to bypass slug customization.
+	 * This filter is used to simply return the `$default_slug` to bypass slug customization
+	 * when the query parser is the legacy one.
 	 *
 	 * @since 12.0.0
 	 *
-	 * @param string $value        An empty string to use as to know whether slug customization should be used.
-	 * @param string $default_slug The screen default slug, used as a fallback.
-	 * @param string $rewrite_id   The screen rewrite ID, used to find the custom slugs.
-	 * @param string $component_id The BuddyPress component's ID.
+	 * @param boolean $using_legacy Whether the legacy URL parser is in use.
+	 *                              In this case, slug customization is not supported.
+	 * @param string  $default_slug The screen default slug, used as a fallback.
+	 * @param string  $rewrite_id   The screen rewrite ID, used to find the custom slugs.
+	 * @param string  $component_id The BuddyPress component's ID.
 	 */
-	$classic_slug = apply_filters( 'bp_rewrites_pre_get_slug', '', $default_slug, $rewrite_id, $component_id );
-	if ( $classic_slug ) {
-		return $classic_slug;
+	$use_default_slug = apply_filters( 'bp_rewrites_pre_get_slug', $using_legacy, $default_slug, $rewrite_id, $component_id );
+	if ( $use_default_slug ) {
+		return $default_slug;
 	}
 
 	$directory_pages = bp_core_get_directory_pages();

--- a/src/bp-core/classes/class-bp-component.php
+++ b/src/bp-core/classes/class-bp-component.php
@@ -577,7 +577,7 @@ class BP_Component {
 		add_action( 'bp_add_permastructs',       array( $this, 'add_permastructs'       ), 10 );
 
 		// Allow components to parse the main query.
-		if ( ! bp_has_pretty_urls() ) {
+		if ( 'rewrites' === bp_core_get_query_parser() ) {
 			/**
 			 * Only fire this hook when pretty links are disabled.
 			 *
@@ -1272,6 +1272,14 @@ class BP_Component {
 		if ( $queried_object instanceof WP_Post && 'buddypress' === get_post_type( $queried_object ) ) {
 			// Only include the queried directory post into returned posts.
 			$retval = array( $queried_object );
+
+			// Reset some query flags.
+			$query->is_home       = false;
+			$query->is_front_page = false;
+			$query->is_page       = false;
+			$query->is_single     = true;
+			$query->is_archive    = false;
+			$query->is_tax        = false;
 		}
 
 		return $retval;

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -234,21 +234,25 @@ class BP_Members_Component extends BP_Component {
 		// The domain for the user currently logged in. eg: http://example.com/members/andy.
 		$bp->loggedin_user->domain = bp_members_get_user_url( bp_loggedin_user_id() );
 
-		/** Displayed user ***************************************************
+		/**
+		 * Set the Displayed user for the classic BuddyPress. This should only be the case when the
+		 * legacy parser is on. When BP Rewrites are on, the displayed user is set in
+		 * `BP_Members_Component::parse_query()`.
 		 */
+		if ( bp_displayed_user_id() ) {
+			// The core userdata of the user who is currently being displayed.
+			$bp->displayed_user->userdata = bp_core_get_core_userdata( bp_displayed_user_id() );
 
-		// The core userdata of the user who is currently being displayed.
-		$bp->displayed_user->userdata = bp_core_get_core_userdata( bp_displayed_user_id() );
+			// Fetch the full name displayed user.
+			$bp->displayed_user->fullname = isset( $bp->displayed_user->userdata->display_name ) ? $bp->displayed_user->userdata->display_name : '';
 
-		// Fetch the full name displayed user.
-		$bp->displayed_user->fullname = isset( $bp->displayed_user->userdata->display_name ) ? $bp->displayed_user->userdata->display_name : '';
+			// The domain for the user currently being displayed.
+			$bp->displayed_user->domain = bp_members_get_user_url( bp_displayed_user_id() );
 
-		// The domain for the user currently being displayed.
-		$bp->displayed_user->domain = bp_members_get_user_url( bp_displayed_user_id() );
-
-		// If A user is displayed, check if there is a front template
-		if ( bp_get_displayed_user() ) {
-			$bp->displayed_user->front_template = bp_displayed_user_get_front_template();
+			// If A user is displayed, check if there is a front template
+			if ( bp_get_displayed_user() ) {
+				$bp->displayed_user->front_template = bp_displayed_user_get_front_template();
+			}
 		}
 
 		/** Initialize the nav for the members component *********************
@@ -393,7 +397,7 @@ class BP_Members_Component extends BP_Component {
 				$bp->canonical_stack['action'] = bp_current_action();
 			}
 
-			if ( !empty( $bp->action_variables ) ) {
+			if ( ! empty( $bp->action_variables ) ) {
 				$bp->canonical_stack['action_variables'] = bp_action_variables();
 			}
 

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -858,9 +858,12 @@ class BP_Members_Component extends BP_Component {
 					$bp->displayed_user->domain = bp_members_get_user_url( bp_displayed_user_id() );
 				}
 
-				// If A user is displayed, check if there is a front template.
+				// If a user is displayed, check if there is a front template and reset navigation.
 				if ( bp_get_displayed_user() ) {
 					$bp->displayed_user->front_template = bp_displayed_user_get_front_template();
+
+					// Reset the nav for the members component.
+					$this->nav = new BP_Core_Nav();
 				}
 
 				$member_component = $query->get( $this->rewrite_ids['single_item_component'] );

--- a/src/bp-templates/bp-legacy/buddypress-functions.php
+++ b/src/bp-templates/bp-legacy/buddypress-functions.php
@@ -184,6 +184,7 @@ class BP_Legacy extends BP_Theme_Compat {
 		 * executes for users that aren't logged in. This is for backpat with BP <1.6.
 		 */
 		foreach( $actions as $name => $function ) {
+			bp_ajax_register_action( $name );
 			add_action( 'wp_ajax_'        . $name, $function );
 			add_action( 'wp_ajax_nopriv_' . $name, $function );
 		}

--- a/src/bp-templates/bp-nouveau/buddypress-functions.php
+++ b/src/bp-templates/bp-nouveau/buddypress-functions.php
@@ -4,7 +4,7 @@
  *
  * @since 3.0.0
  * @package BuddyPress
- * @version 10.0.0
+ * @version 12.0.0
  *
  * @buddypress-template-pack {
  *   Template Pack ID:       nouveau
@@ -176,23 +176,8 @@ class BP_Nouveau extends BP_Theme_Compat {
 		// We need to neutralize the BuddyPress core "bp_core_render_message()" once it has been added.
 		add_action( 'bp_actions', array( $this, 'neutralize_core_template_notices' ), 6 );
 
-		// Scripts & Styles.
-		$registration_params = array(
-			'hook'     => 'bp_enqueue_community_scripts',
-			'priority' => 2,
-		);
-
-		/*
-		 * The WordPress Full Site Editing feature needs Scripts
-		 * and Styles to be registered earlier.
-		 */
-		if ( current_theme_supports( 'block-templates' ) ) {
-			$registration_params['hook']     = 'bp_init';
-			$registration_params['priority'] = 20;
-		}
-
-		// Register theme JS.
-		add_action( $registration_params['hook'], array( $this, 'register_scripts' ), $registration_params['priority'] );
+		// Register scripts & styles.
+		add_action( 'bp_enqueue_community_scripts', array( $this, 'register_scripts' ), 2 );
 
 		// Enqueue theme CSS.
 		add_action( 'bp_enqueue_community_scripts', array( $this, 'enqueue_styles' ) );

--- a/src/bp-templates/bp-nouveau/includes/activity/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/functions.php
@@ -568,3 +568,16 @@ function bp_nouveau_activity_excerpt_append_text( $read_more = '' ) {
 	return str_replace( array( '[', ']' ), '', $read_more );
 }
 add_filter( 'bp_activity_excerpt_append_text', 'bp_nouveau_activity_excerpt_append_text', 10, 1 );
+
+/**
+ * Register Activity Ajax actions.
+ *
+ * @since 12.0.0
+ */
+function bp_nouveau_register_activity_ajax_actions() {
+	$ajax_actions = array( 'activity_filter', 'get_single_activity_content', 'activity_mark_fav', 'activity_mark_unfav', 'activity_clear_new_mentions', 'delete_activity', 'new_activity_comment', 'bp_nouveau_get_activity_objects', 'post_update', 'bp_spam_activity' );
+
+	foreach ( $ajax_actions as $ajax_action ) {
+		bp_ajax_register_action( $ajax_action );
+	}
+}

--- a/src/bp-templates/bp-nouveau/includes/activity/loader.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/loader.php
@@ -3,7 +3,7 @@
  * BP Nouveau Activity
  *
  * @since 3.0.0
- * @version 8.0.0
+ * @version 12.0.0
  */
 
 // Exit if accessed directly.
@@ -90,6 +90,7 @@ class BP_Nouveau_Activity {
 	 * @since 3.0.0
 	 */
 	protected function setup_actions() {
+		add_action( 'bp_init', 'bp_nouveau_register_activity_ajax_actions' );
 		add_action( 'bp_nouveau_enqueue_scripts', 'bp_nouveau_activity_enqueue_scripts' );
 		add_action( 'bp_nouveau_notifications_init_filters', 'bp_nouveau_activity_notification_filters' );
 

--- a/src/bp-templates/bp-nouveau/includes/blogs/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/blogs/functions.php
@@ -3,7 +3,7 @@
  * Blogs functions
  *
  * @since 3.0.0
- * @version 3.1.0
+ * @version 12.0.0
  */
 
 // Exit if accessed directly.
@@ -225,3 +225,12 @@ function bp_nouveau_blog_loop_item_has_lastest_post( $classes ) {
 	return $classes;
 }
 add_filter( 'bp_get_blog_class', 'bp_nouveau_blog_loop_item_has_lastest_post' );
+
+/**
+ * Register Blogs Ajax actions.
+ *
+ * @since 12.0.0
+ */
+function bp_nouveau_register_blogs_ajax_actions() {
+	bp_ajax_register_action( 'blogs_filter' );
+}

--- a/src/bp-templates/bp-nouveau/includes/blogs/loader.php
+++ b/src/bp-templates/bp-nouveau/includes/blogs/loader.php
@@ -3,7 +3,7 @@
  * BP Nouveau Blogs
  *
  * @since 3.0.0
- * @version 6.1.0
+ * @version 12.0.0
  */
 
 // Exit if accessed directly.
@@ -66,6 +66,8 @@ class BP_Nouveau_Blogs {
 	 * @since 3.0.0
 	 */
 	protected function setup_actions() {
+		add_action( 'bp_init', 'bp_nouveau_register_blogs_ajax_actions' );
+
 		if ( ! is_admin() || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
 			// Avoid Notices for BuddyPress Legacy Backcompat
 			remove_action( 'bp_blogs_directory_blog_types', 'bp_blog_backcompat_create_nav_item', 1000 );

--- a/src/bp-templates/bp-nouveau/includes/friends/loader.php
+++ b/src/bp-templates/bp-nouveau/includes/friends/loader.php
@@ -3,7 +3,7 @@
  * BP Nouveau Friends
  *
  * @since 3.0.0
- * @version 6.1.0
+ * @version 12.0.0
  */
 
 // Exit if accessed directly.
@@ -68,6 +68,8 @@ class BP_Nouveau_Friends {
 
 		// Register the friends Notifications filters
 		add_action( 'bp_nouveau_notifications_init_filters', array( $this, 'notification_filters' ) );
+
+		add_action( 'bp_init', array( $this, 'register_ajax_actions' ) );
 	}
 
 	/**
@@ -115,6 +117,19 @@ class BP_Nouveau_Friends {
 
 		foreach ( $notifications as $notification ) {
 			bp_nouveau_notifications_register_filter( $notification );
+		}
+	}
+
+	/**
+	 * Register Friends Ajax actions.
+ 	 *
+	 * @since 12.0.0
+	 */
+	public function register_ajax_actions() {
+		$ajax_actions = array( 'friends_remove_friend', 'friends_add_friend', 'friends_withdraw_friendship', 'friends_accept_friendship', 'friends_reject_friendship' );
+
+		foreach ( $ajax_actions as $ajax_action ) {
+			bp_ajax_register_action( $ajax_action );
 		}
 	}
 }

--- a/src/bp-templates/bp-nouveau/includes/groups/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/functions.php
@@ -1284,3 +1284,16 @@ function bp_nouveau_rest_group_invites_get_items_permissions_check( $retval, $re
 	return $retval;
 }
 add_filter( 'bp_rest_group_invites_get_items_permissions_check', 'bp_nouveau_rest_group_invites_get_items_permissions_check', 10, 2 );
+
+/**
+ * Register Groups Ajax actions.
+ *
+ * @since 12.0.0
+ */
+function bp_nouveau_register_groups_ajax_actions() {
+	$ajax_actions = array( 'groups_filter', 'groups_join_group', 'groups_leave_group', 'groups_accept_invite', 'groups_reject_invite', 'groups_request_membership', 'groups_get_group_potential_invites', 'groups_send_group_invites', 'groups_delete_group_invite' );
+
+	foreach ( $ajax_actions as $ajax_action ) {
+		bp_ajax_register_action( $ajax_action );
+	}
+}

--- a/src/bp-templates/bp-nouveau/includes/groups/loader.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/loader.php
@@ -3,7 +3,7 @@
  * BP Nouveau Groups
  *
  * @since 3.0.0
- * @version 6.1.0
+ * @version 12.0.0
  */
 
 // Exit if accessed directly.
@@ -68,6 +68,8 @@ class BP_Nouveau_Groups {
 	 * @since 3.0.0
 	 */
 	protected function setup_actions() {
+		add_action( 'bp_init', 'bp_nouveau_register_groups_ajax_actions' );
+
 		if ( ! is_admin() || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
 			add_action( 'groups_setup_nav', 'bp_nouveau_group_setup_nav' );
 		}

--- a/src/bp-templates/bp-nouveau/includes/members/loader.php
+++ b/src/bp-templates/bp-nouveau/includes/members/loader.php
@@ -66,6 +66,8 @@ class BP_Nouveau_Members {
 		foreach ( $ajax_actions as $ajax_action ) {
 			$action = key( $ajax_action );
 
+			bp_ajax_register_action( $action );
+
 			add_action( 'wp_ajax_' . $action, $ajax_action[ $action ]['function'] );
 
 			if ( ! empty( $ajax_action[ $action ]['nopriv'] ) ) {

--- a/src/bp-templates/bp-nouveau/includes/messages/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/messages/functions.php
@@ -3,7 +3,7 @@
  * Messages functions
  *
  * @since 3.0.0
- * @version 10.3.0
+ * @version 12.0.0
  */
 
 // Exit if accessed directly.
@@ -511,4 +511,17 @@ function bp_nouveau_messages_catch_hook_content( $hooks = array() ) {
 	ob_end_clean();
 
 	return $content;
+}
+
+/**
+ * Register Messages Ajax actions.
+ *
+ * @since 12.0.0
+ */
+function bp_nouveau_register_messages_ajax_actions() {
+	$ajax_actions = array( 'messages_send_message', 'messages_send_reply', 'messages_get_user_message_threads', 'messages_thread_read', 'messages_get_thread_messages', 'messages_delete', 'messages_exit', 'messages_unstar', 'messages_star', 'messages_unread', 'messages_read', 'messages_dismiss_sitewide_notice' );
+
+	foreach ( $ajax_actions as $ajax_action ) {
+		bp_ajax_register_action( $ajax_action );
+	}
 }

--- a/src/bp-templates/bp-nouveau/includes/messages/loader.php
+++ b/src/bp-templates/bp-nouveau/includes/messages/loader.php
@@ -3,7 +3,7 @@
  * BP Nouveau Messages
  *
  * @since 3.0.0
- * @version 10.0.0
+ * @version 12.0.0
  */
 
 // Exit if accessed directly.
@@ -66,9 +66,17 @@ class BP_Nouveau_Messages {
 	 * @since 3.0.0
 	 */
 	protected function setup_actions() {
+		add_action( 'bp_init', 'bp_nouveau_register_messages_ajax_actions' );
+
 		// Notices
 		add_action( 'widgets_init', 'bp_nouveau_unregister_notices_widget' );
-		add_action( 'bp_init', 'bp_nouveau_push_sitewide_notices', 99 );
+
+		$hook = 'bp_parse_query';
+		if ( 'rewrites' !== bp_core_get_query_parser() ) {
+			$hook = 'bp_init';
+		}
+
+		add_action( $hook, 'bp_nouveau_push_sitewide_notices', 99 );
 
 		// Messages
 		add_action( 'bp_messages_setup_nav', 'bp_nouveau_messages_adjust_nav' );

--- a/src/bp-templates/bp-nouveau/includes/notifications/loader.php
+++ b/src/bp-templates/bp-nouveau/includes/notifications/loader.php
@@ -55,7 +55,12 @@ class BP_Nouveau_Notifications {
 	 * @since 3.0.0
 	 */
 	protected function setup_actions() {
-		add_action( 'bp_init', 'bp_nouveau_notifications_init_filters', 20 );
+		$hook = 'bp_parse_query';
+		if ( 'rewrites' !== bp_core_get_query_parser() ) {
+			$hook = 'bp_init';
+		}
+
+		add_action( $hook, 'bp_nouveau_notifications_init_filters', 20 );
 		add_action( 'bp_nouveau_enqueue_scripts', 'bp_nouveau_notifications_enqueue_scripts' );
 
 		$ajax_actions = array(

--- a/src/class-buddypress.php
+++ b/src/class-buddypress.php
@@ -200,6 +200,15 @@ class BuddyPress {
 	 */
 	public $profile;
 
+	/**
+	 * BuddyPress Ajax actions.
+	 *
+	 * @since 12.0.0
+	 *
+	 * @var array The list of registered Ajax actions.
+	 */
+	public $ajax_actions = array();
+
 	/** Option Overload *******************************************************/
 
 	/**

--- a/tests/phpunit/testcases/routing/core.php
+++ b/tests/phpunit/testcases/routing/core.php
@@ -5,19 +5,23 @@
  */
 class BP_Tests_Routing_Core extends BP_UnitTestCase {
 	protected $old_current_user = 0;
+	protected $permalink_structure = '';
 
 	public function set_up() {
 		parent::set_up();
 
 		$this->old_current_user = get_current_user_id();
 		$this->set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
 	}
 
 	public function tear_down() {
 		parent::tear_down();
 		$this->set_current_user( $this->old_current_user );
+		$this->set_permalink_structure( $this->permalink_structure );
 	}
 	function test_wordpress_page() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$this->go_to( '/' );
 		$this->assertEmpty( bp_current_component() );
 	}
@@ -26,6 +30,7 @@ class BP_Tests_Routing_Core extends BP_UnitTestCase {
 	 * @expectedIncorrectUsage bp_nav
 	 */
 	function test_nav_menu() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$this->go_to( '/' );
 		$this->assertTrue( isset( buddypress()->bp_nav['activity'] ) );
 		$this->assertTrue( isset( buddypress()->bp_nav['profile'] ) );

--- a/tests/phpunit/testcases/routing/root-profiles.php
+++ b/tests/phpunit/testcases/routing/root-profiles.php
@@ -7,6 +7,7 @@
 class BP_Tests_Routing_Members_Root_Profiles extends BP_UnitTestCase {
 	protected $old_current_user = 0;
 	protected $u;
+	protected $permalink_structure = '';
 
 	public function set_up() {
 		parent::set_up();
@@ -20,15 +21,18 @@ class BP_Tests_Routing_Members_Root_Profiles extends BP_UnitTestCase {
 		) );
 		$this->u = new WP_User( $uid );
 		$this->set_current_user( $uid );
+		$this->permalink_structure = get_option( 'permalink_structure', '' );
 	}
 
 	public function tear_down() {
 		parent::tear_down();
 		$this->set_current_user( $this->old_current_user );
+		$this->set_permalink_structure( $this->permalink_structure );
 		remove_filter( 'bp_core_enable_root_profiles', '__return_true' );
 	}
 
 	public function test_members_directory() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$this->go_to( home_url( bp_get_members_root_slug() ) );
 
 		$pages        = bp_core_get_directory_pages();
@@ -38,6 +42,7 @@ class BP_Tests_Routing_Members_Root_Profiles extends BP_UnitTestCase {
 	}
 
 	public function test_member_permalink() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$domain = home_url( $this->u->user_nicename );
 		$this->go_to( $domain );
 
@@ -50,6 +55,7 @@ class BP_Tests_Routing_Members_Root_Profiles extends BP_UnitTestCase {
 	 * @ticket BP6475
 	 */
 	public function test_member_permalink_when_members_page_is_nested_under_wp_page() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$p = self::factory()->post->create( array(
 			'post_type' => 'page',
 			'post_name' => 'foo',
@@ -70,6 +76,7 @@ class BP_Tests_Routing_Members_Root_Profiles extends BP_UnitTestCase {
 	}
 
 	public function test_member_activity_page() {
+		$this->set_permalink_structure( '/%postname%/' );
 		$url = home_url( $this->u->user_nicename ) . '/' . bp_get_activity_slug();
 		$this->go_to( $url );
 


### PR DESCRIPTION
- Introduces `bp_core_setup_query_parser()` to decide when to postpone some key hooks firing to `bp_parse_query`.
- Introduces `bp_core_get_query_parser()` to get the query parser in use. It contains a filter BP Classic will be able to use to force the Legacy URL parser. So far it uses `legacy` for pretty links and `rewrites` for plain links.
- Edit `bp_redirect_canonical()` & `bp_get_canonical_url()` so that they use the BP Rewrites API.
- Introduces `bp_core_set_ajax_uri_globals()` to set the BuddyPress URI globales using the BP Rewrites API inside the Ajax context thanks to the updated `bp_reset_query()` function.
- To avoid using `WP()` at each Ajax call, introduces a simple Ajax actions registration process thanks to the new `bp_ajax_register_action()`.
- Update Legacy & Nouveau template packs so that they use this logic. As BP Default will require the legacy URL parser and will be moved inside BP Classic, the theme can stay the way it is.
- Improve the `bp_rewrites_pre_get_slug` filter logic making it depends on the `bp_core_get_query_parser()` function.
- Make sure to reset the Members navigation to a new BP_Core_Nav based on the displayed user once the user is available in the components `parse_query()` method.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/4954

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
