### PR TITLE
Remove global variable declaration when not used in the code

### DIFF
--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -209,12 +209,11 @@ function bp_core_add_admin_notice( $notice = '', $type = 'updated' ) {
  * The administrator will be shown a notice for each check that fails.
  *
  * @global wpdb $wpdb WordPress database object.
- * @global WP_Rewrite $wp_rewrite WordPress object implementing a rewrite component API.
  *
  * @since 1.2.0
  */
 function bp_core_activation_notice() {
-	global $wp_rewrite, $wpdb;
+	global $wpdb;
 
 	// Only the super admin gets warnings.
 	if ( ! bp_current_user_can( 'bp_moderate' ) ) {

--- a/src/bp-core/classes/class-bp-optouts-list-table.php
+++ b/src/bp-core/classes/class-bp-optouts-list-table.php
@@ -52,8 +52,6 @@ class BP_Optouts_List_Table extends WP_Users_List_Table {
 	 * @since 8.0.0
 	 */
 	public function prepare_items() {
-		global $usersearch;
-
 		$search   = isset( $_REQUEST['s'] ) ? $_REQUEST['s'] : '';
 		$per_page = $this->get_items_per_page( str_replace( '-', '_', "{$this->screen->id}_per_page" ) );
 		$paged    = $this->get_pagenum();

--- a/src/bp-groups/classes/class-bp-groups-group.php
+++ b/src/bp-groups/classes/class-bp-groups-group.php
@@ -755,13 +755,10 @@ class BP_Groups_Group {
 	 *
 	 * @since 2.9.0
 	 *
-	 * @param string      $slug       Slug to check.
-	 *
-	 * @return int|null|false Group ID if found; null if not; false if missing parameters.
+	 * @param  string         $slug Slug to check.
+	 * @return int|null|false       Group ID if found; null if not; false if missing parameters.
 	 */
 	public static function get_id_by_previous_slug( $slug ) {
-		global $wpdb;
-
 		if ( empty( $slug ) ) {
 			return false;
 		}

--- a/src/bp-groups/classes/class-bp-groups-member.php
+++ b/src/bp-groups/classes/class-bp-groups-member.php
@@ -1097,12 +1097,10 @@ class BP_Groups_Member {
 	 *
 	 * @since 1.6.0
 	 *
-	 * @param int $group_id ID of the group.
-	 * @return array Info about group admins (user_id + date_modified).
+	 * @param  int   $group_id ID of the group.
+	 * @return array           Info about group admins (user_id + date_modified).
 	 */
 	public static function get_group_administrator_ids( $group_id ) {
-		global $wpdb;
-
 		if ( empty( $group_id ) ) {
 			return array();
 		}

--- a/src/bp-members/classes/class-bp-members-invitations-list-table.php
+++ b/src/bp-members/classes/class-bp-members-invitations-list-table.php
@@ -59,8 +59,6 @@ class BP_Members_Invitations_List_Table extends WP_Users_List_Table {
 	 * @since 8.0.0
 	 */
 	public function prepare_items() {
-		global $usersearch;
-
 		$search   = isset( $_REQUEST['s'] ) ? $_REQUEST['s'] : '';
 		$per_page = $this->get_items_per_page( str_replace( '-', '_', "{$this->screen->id}_per_page" ) );
 		$paged    = $this->get_pagenum();

--- a/src/bp-members/classes/class-bp-signup.php
+++ b/src/bp-members/classes/class-bp-signup.php
@@ -615,12 +615,10 @@ class BP_Signup {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param int $user_id ID of the user being checked.
-	 * @return int|bool The status if found, otherwise false.
+	 * @param  int      $user_id ID of the user being checked.
+	 * @return int|bool          The status if found, otherwise false.
 	 */
 	public static function check_user_status( $user_id = 0 ) {
-		global $wpdb;
-
 		if ( empty( $user_id ) ) {
 			return false;
 		}

--- a/src/bp-templates/bp-nouveau/includes/groups/classes.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/classes.php
@@ -125,7 +125,11 @@ class BP_Nouveau_Group_Invite_Query extends BP_User_Query {
 	}
 
 	/**
+	 * Build the Meta Query to get all members list.
+	 *
 	 * @since 3.0.0
+	 *
+	 * @param BP_User_Query $bp_user_query The User Query object.
 	 */
 	public function build_meta_query( BP_User_Query $bp_user_query ) {
 		if ( isset( $this->query_vars['scope'] ) && 'members' === $this->query_vars['scope'] && isset( $this->query_vars['meta_query'] ) ) {
@@ -143,21 +147,27 @@ class BP_Nouveau_Group_Invite_Query extends BP_User_Query {
 	}
 
 	/**
+	 * Get the list of group invites.
+	 *
 	 * @since 3.0.0
+	 *
+	 * @param integer $user_id  The User ID.
+	 * @param integer $group_id The Group ID.
+	 * @return array            Matching BP_Invitation objects.
 	 */
 	public static function get_inviter_ids( $user_id = 0, $group_id = 0 ) {
-		global $wpdb;
-
 		if ( empty( $group_id ) || empty( $user_id ) ) {
 			return array();
 		}
 
-		return groups_get_invites( array(
-			'user_id'     => $user_id,
-			'item_id'     => $group_id,
-			'invite_sent' => 'sent',
-			'fields'      => 'inviter_ids'
-		) );
+		return groups_get_invites(
+			array(
+				'user_id'     => $user_id,
+				'item_id'     => $group_id,
+				'invite_sent' => 'sent',
+				'fields'      => 'inviter_ids',
+			)
+		);
 	}
 }
 

--- a/src/bp-xprofile/classes/class-bp-xprofile-field.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-field.php
@@ -266,8 +266,6 @@ class BP_XProfile_Field {
 	 * @return BP_XProfile_Field|false Field object if found, otherwise false.
 	 */
 	public static function get_instance( $field_id, $user_id = null, $get_data = true ) {
-		global $wpdb;
-
 		$field_id = (int) $field_id;
 		if ( ! $field_id ) {
 			return false;


### PR DESCRIPTION
+ Remove global variable declarations when corresponding variables are not used in the code.
+ Do some extra code clean-up.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8882

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
