### PR TITLE
Improve consistency about Viewing a group action

### DIFF
--- a/src/bp-groups/bp-groups-admin.php
+++ b/src/bp-groups/bp-groups-admin.php
@@ -234,7 +234,7 @@ function bp_groups_admin_load() {
 			'id'      => 'bp-groups-overview-actions',
 			'title'   => __( 'Group Actions', 'buddypress' ),
 			'content' =>
-				'<p>' . __( 'Clicking "Visit" will take you to the group&#8217;s public page. Use this link to see what the group looks like on the front end of your site.', 'buddypress' ) . '</p>' .
+				'<p>' . __( 'Clicking "View" will take you to the group&#8217;s public page. Use this link to see what the group looks like on the front end of your site.', 'buddypress' ) . '</p>' .
 				'<p>' . __( 'Clicking "Edit" will take you to a Dashboard panel where you can manage various details about the group, such as its name and description, its members, and other settings.', 'buddypress' ) . '</p>' .
 				'<p>' . __( 'If you click "Delete" under a specific group, or select a number of groups and then choose Delete from the Bulk Actions menu, you will be led to a page where you&#8217;ll be asked to confirm the permanent deletion of the group(s).', 'buddypress' ) . '</p>',
 		) );
@@ -686,7 +686,7 @@ function bp_groups_admin_edit() {
 											<span id="bp-groups-permalink">
 												<?php bp_groups_directory_url(); ?> <input type="text" id="bp-groups-slug" name="bp-groups-slug" value="<?php bp_group_slug( $group ); ?>" autocomplete="off"> /
 											</span>
-											<a href="<?php bp_group_url( $group ) ?>" class="button button-small" id="bp-groups-visit-group"><?php esc_html_e( 'Visit Group', 'buddypress' ) ?></a>
+											<a href="<?php bp_group_url( $group ) ?>" class="button button-small" id="bp-groups-visit-group"><?php esc_html_e( 'View Group', 'buddypress' ) ?></a>
 										</div>
 
 										<label for="bp-groups-description" class="screen-reader-text"><?php

--- a/src/bp-groups/bp-groups-blocks.php
+++ b/src/bp-groups/bp-groups-blocks.php
@@ -139,7 +139,7 @@ function bp_groups_render_group_block( $attributes = array() ) {
 				<a href="%1$s" class="button large primary button-primary" role="button">%2$s</a>
 			</div>',
 			esc_url( $group_link ),
-			esc_html__( 'Visit Group', 'buddypress' )
+			esc_html__( 'View Group', 'buddypress' )
 		);
 	}
 

--- a/src/bp-groups/classes/class-bp-groups-list-table.php
+++ b/src/bp-groups/classes/class-bp-groups-list-table.php
@@ -607,7 +607,7 @@ class BP_Groups_List_Table extends WP_List_Table {
 		// Delete.
 		$actions['delete'] = sprintf( '<a href="%s">%s</a>', esc_url( $delete_url ), __( 'Delete', 'buddypress' ) );
 
-		// Visit.
+		// View.
 		$actions['view']   = sprintf( '<a href="%s">%s</a>', esc_url( $view_url   ), __( 'View',   'buddypress' ) );
 
 		/**

--- a/src/bp-groups/screens/user/invites.php
+++ b/src/bp-groups/screens/user/invites.php
@@ -28,7 +28,7 @@ function groups_screen_group_invites() {
 			$group = groups_get_group( $group_id );
 
 			/* translators: %s: group link */
-			bp_core_add_message( sprintf( __( 'Group invite accepted. Visit %s.', 'buddypress' ), bp_get_group_link( $group ) ) );
+			bp_core_add_message( sprintf( __( 'Group invite accepted. View %s.', 'buddypress' ), bp_get_group_link( $group ) ) );
 
 			if ( bp_is_active( 'activity' ) ) {
 				groups_record_activity( array(

--- a/src/bp-templates/bp-legacy/buddypress/activity/type-parts/content-created-group.php
+++ b/src/bp-templates/bp-legacy/buddypress/activity/type-parts/content-created-group.php
@@ -5,7 +5,7 @@
  * This template is only used to display the `created_group` activity type content.
  *
  * @since 10.0.0
- * @version 10.0.0
+ * @version 12.0.0
  */
 ?>
 <div class="bp-group-activity-preview">
@@ -32,7 +32,7 @@
 		</p>
 
 		<div class="bp-profile-button">
-			<a href="<?php bp_activity_generated_content_part( 'group_url' ); ?>" class="button large primary button-primary" role="button"><?php esc_html_e( 'Visit group', 'buddypress'); ?></a>
+			<a href="<?php bp_activity_generated_content_part( 'group_url' ); ?>" class="button large primary button-primary" role="button"><?php esc_html_e( 'View group', 'buddypress'); ?></a>
 		</div>
 	</div>
 </div>

--- a/src/bp-templates/bp-nouveau/buddypress/activity/type-parts/content-created-group.php
+++ b/src/bp-templates/bp-nouveau/buddypress/activity/type-parts/content-created-group.php
@@ -5,7 +5,7 @@
  * This template is only used to display the `created_group` activity type content.
  *
  * @since 10.0.0
- * @version 10.0.0
+ * @version 12.0.0
  */
 ?>
 <div class="bp-group-activity-preview">
@@ -32,7 +32,7 @@
 		</p>
 
 		<div class="bp-profile-button">
-			<a href="<?php bp_activity_generated_content_part( 'group_url' ); ?>" class="button large primary button-primary" role="button"><?php esc_html_e( 'Visit group', 'buddypress'); ?></a>
+			<a href="<?php bp_activity_generated_content_part( 'group_url' ); ?>" class="button large primary button-primary" role="button"><?php esc_html_e( 'View group', 'buddypress'); ?></a>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Improve consistency about Viewing a group action: use `View` instead of `Visit`.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8887

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
