### PR TITLE
Make sure `BP_Component::parse_query()` always run

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -505,6 +505,14 @@ class BP_Activity_Component extends BP_Component {
 	 *                        description.
 	 */
 	public function parse_query( $query ) {
+		/*
+		 * If BP Rewrites are not in use, no need to parse BP URI globals another time.
+		 * Legacy Parser should have already set these.
+		 */
+		if ( 'rewrites' !== bp_core_get_query_parser() ) {
+			return parent::parse_query( $query );
+		}
+
 		if ( bp_is_directory_homepage( $this->id ) ) {
 			$query->set( $this->rewrite_ids['directory'], 1 );
 		}

--- a/src/bp-blogs/classes/class-bp-blogs-component.php
+++ b/src/bp-blogs/classes/class-bp-blogs-component.php
@@ -444,7 +444,12 @@ class BP_Blogs_Component extends BP_Component {
 	 *                        description.
 	 */
 	public function parse_query( $query ) {
-		if ( ! is_multisite() ) {
+		/*
+		 * Only Multisite configs have a Sites directory.
+		 * If BP Rewrites are not in use, no need to parse BP URI globals another time.
+		 * Legacy Parser should have already set these.
+		 */
+		if ( ! is_multisite() || 'rewrites' !== bp_core_get_query_parser() ) {
 			return parent::parse_query( $query );
 		}
 

--- a/src/bp-core/bp-core-template-loader.php
+++ b/src/bp-core/bp-core-template-loader.php
@@ -565,10 +565,13 @@ function bp_parse_query( $posts_query ) {
 		return;
 	}
 
-	// Set some needed URI globals.
-	$bp                        = buddypress();
-	$bp->unfiltered_uri        = explode( '/', $GLOBALS['wp']->request );
-	$bp->unfiltered_uri_offset = 0;
+	// Eventually Set some missing URI globals.
+	$bp = buddypress();
+
+	if ( ! $bp->unfiltered_uri ) {
+		$bp->unfiltered_uri        = explode( '/', $GLOBALS['wp']->request );
+		$bp->unfiltered_uri_offset = 0;
+	}
 
 	/**
 	 * Fires at the end of the bp_parse_query function.

--- a/src/bp-core/classes/class-bp-component.php
+++ b/src/bp-core/classes/class-bp-component.php
@@ -577,14 +577,7 @@ class BP_Component {
 		add_action( 'bp_add_permastructs',       array( $this, 'add_permastructs'       ), 10 );
 
 		// Allow components to parse the main query.
-		if ( 'rewrites' === bp_core_get_query_parser() ) {
-			/**
-			 * Only fire this hook when pretty links are disabled.
-			 *
-			 * @todo Remove once BP Rewrites merge process is ended.
-			 */
-			add_action( 'bp_parse_query',  array( $this, 'parse_query' ), 10 );
-		}
+		add_action( 'bp_parse_query',  array( $this, 'parse_query' ), 10 );
 
 		// Generate rewrite rules.
 		add_action( 'bp_generate_rewrite_rules', array( $this, 'generate_rewrite_rules' ), 10 );
@@ -1235,7 +1228,7 @@ class BP_Component {
 	 * @param object $query The main WP_Query.
 	 */
 	public function parse_query( $query ) {
-		if ( is_buddypress() ) {
+		if ( is_buddypress() && 'rewrites' === bp_core_get_query_parser() ) {
 			add_filter( 'posts_pre_query', array( $this, 'pre_query' ), 10, 2 );
 		}
 

--- a/src/bp-core/classes/class-bp-core.php
+++ b/src/bp-core/classes/class-bp-core.php
@@ -423,6 +423,14 @@ class BP_Core extends BP_Component {
 	 *                        description.
 	 */
 	public function parse_query( $query ) {
+		/*
+		 * If BP Rewrites are not in use, no need to parse BP URI globals another time.
+		 * Legacy Parser should have already set these.
+		 */
+		if ( 'rewrites' !== bp_core_get_query_parser() ) {
+			return parent::parse_query( $query );
+		}
+
 		$is_search = $query->get( 'pagename' ) === bp_get_search_slug() || ( isset( $_GET['bp_search'] ) && 1 === (int) $_GET['bp_search'] );
 
 		if ( isset( $_POST['search-terms'] ) && $is_search ) {

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -1066,6 +1066,14 @@ class BP_Groups_Component extends BP_Component {
 	 *                        description.
 	 */
 	public function parse_query( $query ) {
+		/*
+		 * If BP Rewrites are not in use, no need to parse BP URI globals another time.
+		 * Legacy Parser should have already set these.
+		 */
+		if ( 'rewrites' !== bp_core_get_query_parser() ) {
+			return parent::parse_query( $query );
+		}
+
 		if ( bp_is_directory_homepage( $this->id ) ) {
 			$query->set( $this->rewrite_ids['directory'], 1 );
 		}

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -776,6 +776,14 @@ class BP_Members_Component extends BP_Component {
 	 *                        description.
 	 */
 	public function parse_query( $query ) {
+		/*
+		 * If BP Rewrites are not in use, no need to parse BP URI globals another time.
+		 * Legacy Parser should have already set these.
+		 */
+		if ( 'rewrites' !== bp_core_get_query_parser() ) {
+			return parent::parse_query( $query );
+		}
+
 		// Init the current member and member type.
 		$member      = false;
 		$member_type = false;


### PR DESCRIPTION
Make sure `BP_Component::parse_query()` always run. Only running when BP Rewrites are on is not the right way to go as some plugins might have been using WP Rewrites API for a while and might be extending this method from their component's class.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8908

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
