### PR TITLE
Prevent screen and action files to be loaded more than once

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -121,22 +121,22 @@ class BP_Activity_Component extends BP_Component {
 			if ( is_user_logged_in() &&
 				in_array( bp_current_action(), array( 'delete', 'spam', 'post', 'reply', 'favorite', 'unfavorite' ), true )
 			) {
-				require $this->path . 'bp-activity/actions/' . bp_current_action() . '.php';
+				require_once $this->path . 'bp-activity/actions/' . bp_current_action() . '.php';
 			}
 
 			// RSS feeds.
 			if ( bp_is_current_action( 'feed' ) || bp_is_action_variable( 'feed', 0 ) ) {
-				require $this->path . 'bp-activity/actions/feeds.php';
+				require_once $this->path . 'bp-activity/actions/feeds.php';
 			}
 
 			// Screens - Directory.
 			if ( bp_is_activity_directory() ) {
-				require $this->path . 'bp-activity/screens/directory.php';
+				require_once $this->path . 'bp-activity/screens/directory.php';
 			}
 
 			// Screens - User main nav.
 			if ( bp_is_user() ) {
-				require $this->path . 'bp-activity/screens/just-me.php';
+				require_once $this->path . 'bp-activity/screens/just-me.php';
 			}
 
 			/**
@@ -162,12 +162,12 @@ class BP_Activity_Component extends BP_Component {
 			$slug = bp_current_action();
 
 			if ( bp_is_user() && isset( $filenames[ $slug ] ) ) {
-				require $this->path . 'bp-activity/screens/' . $filenames[ $slug ] . '.php';
+				require_once $this->path . 'bp-activity/screens/' . $filenames[ $slug ] . '.php';
 			}
 
 			// Screens - Single permalink.
 			if ( bp_is_current_action( 'p' ) || is_numeric( bp_current_action() ) ) {
-				require $this->path . 'bp-activity/screens/permalink.php';
+				require_once $this->path . 'bp-activity/screens/permalink.php';
 			}
 
 			// Theme compatibility.

--- a/src/bp-blogs/classes/class-bp-blogs-component.php
+++ b/src/bp-blogs/classes/class-bp-blogs-component.php
@@ -176,19 +176,19 @@ class BP_Blogs_Component extends BP_Component {
 
 		// Actions.
 		if ( isset( $_GET['random-blog'] ) ) {
-			require $this->path . 'bp-blogs/actions/random.php';
+			require_once $this->path . 'bp-blogs/actions/random.php';
 		}
 
 		// Screens.
 		if ( bp_is_user() ) {
-			require $this->path . 'bp-blogs/screens/my-blogs.php';
+			require_once $this->path . 'bp-blogs/screens/my-blogs.php';
 		} else {
 			if ( bp_is_blogs_directory() ) {
-				require $this->path . 'bp-blogs/screens/directory.php';
+				require_once $this->path . 'bp-blogs/screens/directory.php';
 			}
 
 			if ( is_user_logged_in() && bp_is_current_action( 'create' ) ) {
-				require $this->path . 'bp-blogs/screens/create.php';
+				require_once $this->path . 'bp-blogs/screens/create.php';
 			}
 
 			// Theme compatibility.

--- a/src/bp-friends/classes/class-bp-friends-component.php
+++ b/src/bp-friends/classes/class-bp-friends-component.php
@@ -85,13 +85,13 @@ class BP_Friends_Component extends BP_Component {
 			if ( is_user_logged_in() &&
 				in_array( bp_current_action(), array( 'add-friend', 'remove-friend' ), true )
 			) {
-				require $this->path . 'bp-friends/actions/' . bp_current_action() . '.php';
+				require_once $this->path . 'bp-friends/actions/' . bp_current_action() . '.php';
 			}
 
 			// User nav.
-			require $this->path . 'bp-friends/screens/my-friends.php';
+			require_once $this->path . 'bp-friends/screens/my-friends.php';
 			if ( is_user_logged_in() && bp_is_user_friend_requests() ) {
-				require $this->path . 'bp-friends/screens/requests.php';
+				require_once $this->path . 'bp-friends/screens/requests.php';
 			}
 		}
 	}

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -151,29 +151,29 @@ class BP_Members_Component extends BP_Component {
 		if ( bp_is_members_component() ) {
 			// Actions - Random member handler.
 			if ( isset( $_GET['random-member'] ) ) {
-				require $this->path . 'bp-members/actions/random.php';
+				require_once $this->path . 'bp-members/actions/random.php';
 			}
 
 			// Screens - Directory.
 			if ( bp_is_members_directory() ) {
-				require $this->path . 'bp-members/screens/directory.php';
+				require_once $this->path . 'bp-members/screens/directory.php';
 			}
 		}
 
 		// Members - User main nav screen.
 		if ( bp_is_user() ) {
-			require $this->path . 'bp-members/screens/profile.php';
+			require_once $this->path . 'bp-members/screens/profile.php';
 
 			// Action - Delete avatar.
 			if ( is_user_logged_in()&& bp_is_user_change_avatar() && bp_is_action_variable( 'delete-avatar', 0 ) ) {
-				require $this->path . 'bp-members/actions/delete-avatar.php';
+				require_once $this->path . 'bp-members/actions/delete-avatar.php';
 			}
 
 			// Sub-nav items.
 			if ( is_user_logged_in() &&
 				in_array( bp_current_action(), array( 'change-avatar', 'change-cover-image' ), true )
 			) {
-				require $this->path . 'bp-members/screens/' . bp_current_action() . '.php';
+				require_once $this->path . 'bp-members/screens/' . bp_current_action() . '.php';
 			}
 		}
 
@@ -185,9 +185,9 @@ class BP_Members_Component extends BP_Component {
 		// Registration / Activation.
 		if ( bp_is_register_page() || bp_is_activation_page() ) {
 			if ( bp_is_register_page() ) {
-				require $this->path . 'bp-members/screens/register.php';
+				require_once $this->path . 'bp-members/screens/register.php';
 			} else {
-				require $this->path . 'bp-members/screens/activate.php';
+				require_once $this->path . 'bp-members/screens/activate.php';
 			}
 
 			// Theme compatibility.
@@ -198,11 +198,11 @@ class BP_Members_Component extends BP_Component {
 		if ( is_user_logged_in() && bp_is_user_members_invitations() ) {
 			// Actions.
 			if ( isset( $_POST['members_invitations'] ) ) {
-				require $this->path . 'bp-members/actions/invitations-bulk-manage.php';
+				require_once $this->path . 'bp-members/actions/invitations-bulk-manage.php';
 			}
 
 			// Screens.
-			require $this->path . 'bp-members/screens/invitations.php';
+			require_once $this->path . 'bp-members/screens/invitations.php';
 		}
 	}
 

--- a/src/bp-messages/classes/class-bp-messages-component.php
+++ b/src/bp-messages/classes/class-bp-messages-component.php
@@ -97,32 +97,32 @@ class BP_Messages_Component extends BP_Component {
 			if ( is_user_logged_in() &&
 				in_array( bp_current_action(), array( 'compose', 'notices', 'view' ), true )
 			) {
-				require $this->path . 'bp-messages/actions/' . bp_current_action() . '.php';
+				require_once $this->path . 'bp-messages/actions/' . bp_current_action() . '.php';
 			}
 
 			// Authenticated action variables.
 			if ( is_user_logged_in() && bp_action_variable( 0 ) &&
 				in_array( bp_action_variable( 0 ), array( 'delete', 'read', 'unread', 'bulk-manage', 'bulk-delete', 'exit' ), true )
 			) {
-				require $this->path . 'bp-messages/actions/' . bp_action_variable( 0 ) . '.php';
+				require_once $this->path . 'bp-messages/actions/' . bp_action_variable( 0 ) . '.php';
 			}
 
 			// Authenticated actions - Star.
 			if ( is_user_logged_in() && bp_is_active( $this->id, 'star' ) ) {
 				// Single action.
 				if ( in_array( bp_current_action(), array( 'star', 'unstar' ), true ) ) {
-					require $this->path . 'bp-messages/actions/star.php';
+					require_once $this->path . 'bp-messages/actions/star.php';
 				}
 
 				// Bulk-manage.
 				if ( bp_is_action_variable( 'bulk-manage' ) ) {
-					require $this->path . 'bp-messages/actions/bulk-manage-star.php';
+					require_once $this->path . 'bp-messages/actions/bulk-manage-star.php';
 				}
 			}
 
 			// Screens - User profile integration.
 			if ( bp_is_user() ) {
-				require $this->path . 'bp-messages/screens/inbox.php';
+				require_once $this->path . 'bp-messages/screens/inbox.php';
 
 				/*
 				 * Nav items.
@@ -130,12 +130,12 @@ class BP_Messages_Component extends BP_Component {
 				 * 'view' is not a registered nav item, but we add a screen handler manually.
 				 */
 				if ( bp_is_user_messages() && in_array( bp_current_action(), array( 'sentbox', 'compose', 'notices', 'view' ), true ) ) {
-					require $this->path . 'bp-messages/screens/' . bp_current_action() . '.php';
+					require_once $this->path . 'bp-messages/screens/' . bp_current_action() . '.php';
 				}
 
 				// Nav item - Starred.
 				if ( bp_is_active( $this->id, 'star' ) && bp_is_current_action( bp_get_messages_starred_slug() ) ) {
-					require $this->path . 'bp-messages/screens/starred.php';
+					require_once $this->path . 'bp-messages/screens/starred.php';
 				}
 			}
 		}

--- a/src/bp-notifications/classes/class-bp-notifications-component.php
+++ b/src/bp-notifications/classes/class-bp-notifications-component.php
@@ -77,15 +77,15 @@ class BP_Notifications_Component extends BP_Component {
 
 		// Actions.
 		if ( bp_is_post_request() ) {
-			require $this->path . 'bp-notifications/actions/bulk-manage.php';
+			require_once $this->path . 'bp-notifications/actions/bulk-manage.php';
 		} elseif ( bp_is_get_request() ) {
-			require $this->path . 'bp-notifications/actions/delete.php';
+			require_once $this->path . 'bp-notifications/actions/delete.php';
 		}
 
 		// Screens.
-		require $this->path . 'bp-notifications/screens/unread.php';
+		require_once $this->path . 'bp-notifications/screens/unread.php';
 		if ( bp_is_current_action( 'read' ) ) {
-			require $this->path . 'bp-notifications/screens/read.php';
+			require_once $this->path . 'bp-notifications/screens/read.php';
 		}
 	}
 

--- a/src/bp-settings/classes/class-bp-settings-component.php
+++ b/src/bp-settings/classes/class-bp-settings-component.php
@@ -72,21 +72,21 @@ class BP_Settings_Component extends BP_Component {
 		// Authenticated actions.
 		if ( is_user_logged_in() ) {
 			if ( ! bp_current_action() || bp_is_current_action( 'general' ) ) {
-				require $this->path . 'bp-settings/actions/general.php';
+				require_once $this->path . 'bp-settings/actions/general.php';
 
 			// Specific to post requests.
 			} elseif ( bp_is_post_request() && in_array( bp_current_action(), $actions, true ) ) {
-				require $this->path . 'bp-settings/actions/' . bp_current_action() . '.php';
+				require_once $this->path . 'bp-settings/actions/' . bp_current_action() . '.php';
 			}
 		}
 
 		// Screens - User profile integration.
 		if ( bp_is_user() ) {
-			require $this->path . 'bp-settings/screens/general.php';
+			require_once $this->path . 'bp-settings/screens/general.php';
 
 			// Sub-nav items.
 			if ( in_array( bp_current_action(), $actions, true ) ) {
-				require $this->path . 'bp-settings/screens/' . bp_current_action() . '.php';
+				require_once $this->path . 'bp-settings/screens/' . bp_current_action() . '.php';
 			}
 		}
 	}

--- a/src/bp-xprofile/classes/class-bp-xprofile-component.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-component.php
@@ -111,17 +111,17 @@ class BP_XProfile_Component extends BP_Component {
 
 		// User nav.
 		if ( bp_is_profile_component() ) {
-			require $this->path . 'bp-xprofile/screens/public.php';
+			require_once $this->path . 'bp-xprofile/screens/public.php';
 
 			// Sub-nav items.
 			if ( is_user_logged_in() && 'edit' === bp_current_action() ) {
-				require $this->path . 'bp-xprofile/screens/edit.php';
+				require_once $this->path . 'bp-xprofile/screens/edit.php';
 			}
 		}
 
 		// Settings.
 		if ( is_user_logged_in() && bp_is_user_settings_profile() ) {
-			require $this->path . 'bp-xprofile/screens/settings-profile.php';
+			require_once $this->path . 'bp-xprofile/screens/settings-profile.php';
 		}
 	}
 


### PR DESCRIPTION
To avoid potential issues, use `require_once` instead of `require` in all Components class `late_includes()` methods.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8910

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
