### PR TITLE
BP Rewrites: Optimize code to build URLs

### DIFF
--- a/src/bp-activity/actions/feeds.php
+++ b/src/bp-activity/actions/feeds.php
@@ -54,12 +54,7 @@ function bp_activity_action_personal_feed() {
 		return false;
 	}
 
-	$activity_slug = bp_get_activity_slug();
-	$link          = bp_displayed_user_url(
-		array(
-			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
-		)
-	);
+	$link = bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_activity_slug() ) ) );
 
 	// Setup the feed.
 	buddypress()->activity->feed = new BP_Activity_Feed(
@@ -94,14 +89,7 @@ function bp_activity_action_friends_feed() {
 		return false;
 	}
 
-	$activity_slug = bp_get_activity_slug();
-	$friends_slug  = bp_get_friends_slug();
-	$link          = bp_displayed_user_url(
-		array(
-			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
-			'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_' . $friends_slug, $friends_slug ),
-		)
-	);
+	$link = bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_activity_slug(), bp_get_friends_slug() ) ) );
 
 	// Setup the feed.
 	buddypress()->activity->feed = new BP_Activity_Feed(
@@ -137,16 +125,9 @@ function bp_activity_action_my_groups_feed() {
 	}
 
 	// Get displayed user's group IDs.
-	$groups        = groups_get_user_groups();
-	$group_ids     = implode( ',', $groups['groups'] );
-	$activity_slug = bp_get_activity_slug();
-	$groups_slug   = bp_get_groups_slug();
-	$link          = bp_displayed_user_url(
-		array(
-			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
-			'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_' . $groups_slug, $groups_slug ),
-		)
-	);
+	$groups    = groups_get_user_groups();
+	$group_ids = implode( ',', $groups['groups'] );
+	$link      = bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_activity_slug(), bp_get_groups_slug() ) ) );
 
 	// Setup the feed.
 	buddypress()->activity->feed = new BP_Activity_Feed(
@@ -189,13 +170,7 @@ function bp_activity_action_mentions_feed() {
 		return false;
 	}
 
-	$activity_slug = bp_get_activity_slug();
-	$link          = bp_displayed_user_url(
-		array(
-			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
-			'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_mentions', 'mentions' ),
-		)
-	);
+	$link = bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_activity_slug(), 'mentions' ) ) );
 
 	// Setup the feed.
 	buddypress()->activity->feed = new BP_Activity_Feed(
@@ -233,15 +208,9 @@ function bp_activity_action_favorites_feed() {
 	}
 
 	// Get displayed user's favorite activity IDs.
-	$favs          = bp_activity_get_user_favorites( bp_displayed_user_id() );
-	$fav_ids       = implode( ',', (array) $favs );
-	$activity_slug = bp_get_activity_slug();
-	$link          = bp_displayed_user_url(
-		array(
-			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
-			'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_favorites', 'favorites' ),
-		)
-	);
+	$favs    = bp_activity_get_user_favorites( bp_displayed_user_id() );
+	$fav_ids = implode( ',', (array) $favs );
+	$link    = bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_activity_slug(), 'favorites' ) ) );
 
 	// Setup the feed.
 	buddypress()->activity->feed = new BP_Activity_Feed(

--- a/src/bp-activity/bp-activity-notifications.php
+++ b/src/bp-activity/bp-activity-notifications.php
@@ -34,12 +34,7 @@ function bp_activity_format_notifications( $action, $item_id, $secondary_item_id
 	switch ( $action ) {
 		case 'new_at_mention':
 			$action_filter = 'at_mentions';
-			$link          = bp_loggedin_user_url(
-				array(
-					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
-					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_mentions', 'mentions' ),
-				)
-			);
+			$link          = bp_loggedin_user_url( bp_members_get_path_chunks( array( $activity_slug, 'mentions' ) ) );
 
 			/* translators: %s: the current user display name */
 			$text   = sprintf( __( '@%s Mentions', 'buddypress' ), bp_get_loggedin_user_username() );

--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -3891,40 +3891,36 @@ function bp_member_activity_feed_link() {
 	 */
 	function bp_get_member_activity_feed_link() {
 		$activity_slug = bp_get_activity_slug();
-		$path_chunks   = array(
-			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
-		);
+		$path_chunks   = array( $activity_slug );
 
 		// Single member activity feed link.
 		if ( bp_is_profile_component() || bp_is_current_action( 'just-me' ) ) {
-			$path_chunks['single_item_action'] = 'feed';
-			$link                              = bp_displayed_user_url( $path_chunks );
+			$path_chunks[] = 'feed';
+			$link          = bp_displayed_user_url( bp_members_get_path_chunks( $path_chunks ) );
 
 		// Friend feed link.
 		} elseif ( bp_is_active( 'friends' ) && bp_is_current_action( bp_get_friends_slug() ) ) {
-			$friends_slug                                = bp_get_friends_slug();
-			$path_chunks['single_item_action']           = bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_' . $friends_slug, $friends_slug );
-			$path_chunks['single_item_action_variables'] = array( 'feed' );
-			$link                                        = bp_displayed_user_url( $path_chunks );
+			$path_chunks[] = bp_get_friends_slug();
+			$path_chunks[] = array( 'feed' );
+			$link          = bp_displayed_user_url( bp_members_get_path_chunks( $path_chunks ) );
 
 		// Group feed link.
 		} elseif ( bp_is_active( 'groups'  ) && bp_is_current_action( bp_get_groups_slug()  ) ) {
-			$groups_slug                                 = bp_get_groups_slug();
-			$path_chunks['single_item_action']           = bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_' . $groups_slug, $groups_slug );
-			$path_chunks['single_item_action_variables'] = array( 'feed' );
-			$link                                        = bp_displayed_user_url( $path_chunks );
+			$path_chunks[] = bp_get_groups_slug();
+			$path_chunks[] = array( 'feed' );
+			$link          = bp_displayed_user_url( bp_members_get_path_chunks( $path_chunks ) );
 
 		// Favorites activity feed link.
 		} elseif ( 'favorites' === bp_current_action() ) {
-			$path_chunks['single_item_action']           = bp_rewrites_get_slug( 'members', 'member_'  . $activity_slug . '_favorites', 'favorites' );
-			$path_chunks['single_item_action_variables'] = array( 'feed' );
-			$link                                        = bp_displayed_user_url( $path_chunks );
+			$path_chunks[] = 'favorites';
+			$path_chunks[] = array( 'feed' );
+			$link          = bp_displayed_user_url( bp_members_get_path_chunks( $path_chunks ) );
 
 		// Mentions activity feed link.
 		} elseif ( ( 'mentions' === bp_current_action() ) && bp_activity_do_mentions() ) {
-			$path_chunks['single_item_action']           = bp_rewrites_get_slug( 'members', 'member_'  . $activity_slug . '_mentions', 'mentions' );
-			$path_chunks['single_item_action_variables'] = array( 'feed' );
-			$link                                        = bp_displayed_user_url( $path_chunks );
+			$path_chunks[] = 'mentions';
+			$path_chunks[] = array( 'feed' );
+			$link          = bp_displayed_user_url( bp_members_get_path_chunks( $path_chunks ) );
 
 		// No feed link.
 		} else {

--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -335,13 +335,12 @@ class BP_Activity_Component extends BP_Component {
 		if ( is_user_logged_in() ) {
 
 			// Setup the logged in user variables.
-			$activity_slug        = bp_get_activity_slug();
-			$custom_activity_slug = bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug );
+			$activity_slug = bp_get_activity_slug();
 
 			// Unread message count.
 			if ( bp_activity_do_mentions() ) {
 				$count = bp_get_total_mention_count_for_user( bp_loggedin_user_id() );
-				if ( !empty( $count ) ) {
+				if ( ! empty( $count ) ) {
 					$title = sprintf(
 						/* translators: %s: Unread mention count for the current user */
 						_x( 'Mentions %s', 'Toolbar Mention logged in user', 'buddypress' ),
@@ -357,11 +356,7 @@ class BP_Activity_Component extends BP_Component {
 				'parent' => buddypress()->my_account_menu_id,
 				'id'     => 'my-account-' . $this->id,
 				'title'  => _x( 'Activity', 'My Account Activity sub nav', 'buddypress' ),
-				'href'   => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_activity_slug,
-					)
-				),
+				'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $activity_slug ) ) ),
 			);
 
 			// Personal.
@@ -369,12 +364,7 @@ class BP_Activity_Component extends BP_Component {
 				'parent'   => 'my-account-' . $this->id,
 				'id'       => 'my-account-' . $this->id . '-personal',
 				'title'    => _x( 'Personal', 'My Account Activity sub nav', 'buddypress' ),
-				'href'     => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_activity_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_just_me', 'just-me' ),
-					)
-				),
+				'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $activity_slug, 'just-me' ) ) ),
 				'position' => 10,
 			);
 
@@ -384,12 +374,7 @@ class BP_Activity_Component extends BP_Component {
 					'parent'   => 'my-account-' . $this->id,
 					'id'       => 'my-account-' . $this->id . '-mentions',
 					'title'    => $title,
-					'href'     => bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_activity_slug,
-							'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_mentions', 'mentions' ),
-						)
-					),
+					'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $activity_slug, 'mentions' ) ) ),
 					'position' => 20,
 				);
 			}
@@ -400,46 +385,29 @@ class BP_Activity_Component extends BP_Component {
 					'parent'   => 'my-account-' . $this->id,
 					'id'       => 'my-account-' . $this->id . '-favorites',
 					'title'    => _x( 'Favorites', 'My Account Activity sub nav', 'buddypress' ),
-					'href'     => bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_activity_slug,
-							'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_favorites', 'favorites' ),
-						)
-					),
+					'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $activity_slug, 'favorites' ) ) ),
 					'position' => 30,
 				);
 			}
 
 			// Friends?
 			if ( bp_is_active( 'friends' ) ) {
-				$friends_slug   = bp_get_friends_slug();
 				$wp_admin_nav[] = array(
 					'parent'   => 'my-account-' . $this->id,
 					'id'       => 'my-account-' . $this->id . '-friends',
 					'title'    => _x( 'Friends', 'My Account Activity sub nav', 'buddypress' ),
-					'href'     => bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_activity_slug,
-							'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_' . $friends_slug, $friends_slug ),
-						)
-					),
+					'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $activity_slug, bp_get_friends_slug() ) ) ),
 					'position' => 40,
 				);
 			}
 
 			// Groups?
 			if ( bp_is_active( 'groups' ) ) {
-				$groups_slug    = bp_get_groups_slug();
 				$wp_admin_nav[] = array(
 					'parent'   => 'my-account-' . $this->id,
 					'id'       => 'my-account-' . $this->id . '-groups',
 					'title'    => _x( 'Groups', 'My Account Activity sub nav', 'buddypress' ),
-					'href'     => bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_activity_slug,
-							'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_' . $groups_slug, $groups_slug ),
-						)
-					),
+					'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $activity_slug, bp_get_groups_slug() ) ) ),
 					'position' => 50
 				);
 			}

--- a/src/bp-activity/screens/permalink.php
+++ b/src/bp-activity/screens/permalink.php
@@ -38,10 +38,7 @@ function bp_activity_action_permalink_router() {
 
 	// Do not redirect at default.
 	$redirect    = false;
-	$path_chunks = array(
-		'single_item_component' => bp_rewrites_get_slug( 'members', 'member_activity', bp_get_activity_slug() ),
-		'single_item_action'    => $activity->id,
-	);
+	$path_chunks = bp_members_get_path_chunks( array( bp_get_activity_slug(), $activity->id ) );
 
 	// Redirect based on the type of activity.
 	if ( bp_is_active( 'groups' ) && $activity->component == buddypress()->groups->id ) {

--- a/src/bp-blogs/classes/class-bp-blogs-component.php
+++ b/src/bp-blogs/classes/class-bp-blogs-component.php
@@ -299,19 +299,14 @@ class BP_Blogs_Component extends BP_Component {
 		if ( is_user_logged_in() ) {
 
 			// Setup the logged in user variables.
-			$blogs_slug        = bp_get_blogs_slug();
-			$custom_blogs_slug = bp_rewrites_get_slug( 'members', 'member_' . $blogs_slug, $blogs_slug );
+			$blogs_slug = bp_get_blogs_slug();
 
 			// Add the "Sites" sub menu.
 			$wp_admin_nav[] = array(
 				'parent' => buddypress()->my_account_menu_id,
 				'id'     => 'my-account-' . $this->id,
 				'title'  => __( 'Sites', 'buddypress' ),
-				'href'   => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_blogs_slug,
-					)
-				),
+				'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $blogs_slug ) ) ),
 			);
 
 			// My Sites.
@@ -319,12 +314,7 @@ class BP_Blogs_Component extends BP_Component {
 				'parent'   => 'my-account-' . $this->id,
 				'id'       => 'my-account-' . $this->id . '-my-sites',
 				'title'    => __( 'My Sites', 'buddypress' ),
-				'href'     => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_blogs_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $blogs_slug . '_my_sites', 'my-sites' ),
-					)
-				),
+				'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $blogs_slug, 'my-sites' ) ) ),
 				'position' => 10,
 			);
 

--- a/src/bp-core/bp-core-buddybar.php
+++ b/src/bp-core/bp-core-buddybar.php
@@ -754,20 +754,11 @@ function bp_core_maybe_hook_new_subnav_screen_function( $subnav_item, $component
 				} else {
 					// Try 'activity' first.
 					if ( bp_is_active( 'activity' ) && isset( $bp->pages->activity ) ) {
-						$activity_slug = bp_get_activity_slug();
-						$redirect_to   = bp_displayed_user_url(
-							array(
-								'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
-							)
-						);
-					// Then try 'profile'.
+						$redirect_to = bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_activity_slug() ) ) );
+
+						// Then try 'profile'.
 					} else {
-						$profile_slug  = bp_get_profile_slug();
-						$redirect_to   = bp_displayed_user_url(
-							array(
-								'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug, $profile_slug ),
-							)
-						);
+						$redirect_to = bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_profile_slug() ) ) );
 					}
 
 					$message = '';

--- a/src/bp-core/bp-core-filters.php
+++ b/src/bp-core/bp-core-filters.php
@@ -1251,10 +1251,7 @@ function bp_email_set_default_tokens( $tokens, $property_name, $transform, $emai
 				$tokens['unsubscribe'] = esc_url(
 					bp_members_get_user_url(
 						$user_obj->ID,
-						array(
-							'single_item_component' => bp_rewrites_get_slug( 'members', 'member_settings', bp_get_settings_slug() ),
-							'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_settings_notifications', 'notifications' ),
-						)
+						bp_members_get_path_chunks( array( bp_get_settings_slug(), 'notifications' ) )
 					)
 				);
 			}

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -4361,10 +4361,7 @@ function bp_email_unsubscribe_handler() {
 		if ( bp_is_active( 'settings' ) ) {
 			$redirect_to = bp_members_get_user_url(
 				get_current_user_id(),
-				array(
-					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_settings', bp_get_settings_slug() ),
-					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_settings_notifications', 'notifications' ),
-				)
+				bp_members_get_path_chunks( array( bp_get_settings_slug(), 'notifications' ) )
 			);
 		} else {
 			$redirect_to = bp_members_get_user_url( get_current_user_id() );
@@ -4393,10 +4390,7 @@ function bp_email_unsubscribe_handler() {
 		if ( bp_is_active( 'settings' ) ) {
 			$redirect_to = bp_members_get_user_url(
 				$raw_user_id,
-				array(
-					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_settings', bp_get_settings_slug() ),
-					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_settings_notifications', 'notifications' ),
-				)
+				bp_members_get_path_chunks( array( bp_get_settings_slug(), 'notifications' ) )
 			);
 		} else {
 			$redirect_to = bp_members_get_user_url( $raw_user_id );

--- a/src/bp-core/deprecated/12.0.php
+++ b/src/bp-core/deprecated/12.0.php
@@ -1423,15 +1423,8 @@ function bp_friends_random_members( $total_members = 5 ) {
  */
 function bp_friend_search_form() {
 	_deprecated_function( __FUNCTION__, '12.0.0' );
-	$label        = __( 'Filter Friends', 'buddypress' );
-	$friends_slug = bp_get_friends_slug();
-	$action       = bp_displayed_user_url(
-		array(
-			'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug, $friends_slug ),
-			'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_my_friends', 'my-friends' ),
-			'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_search', 'search' ) ),
-		)
-	);
+	$label  = __( 'Filter Friends', 'buddypress' );
+	$action = bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_friends_slug(), 'my-friends', array( 'search' ) ) ) );
 	?>
 
 		<form action="<?php echo esc_url( $action ) ?>" id="friend-search-form" method="post">
@@ -1501,16 +1494,9 @@ function bp_get_group_all_members_permalink( $group = false ) {
  */
 function bp_group_search_form() {
 	_deprecated_function( __FUNCTION__, '12.0.0' );
-	$label       = __('Filter Groups', 'buddypress');
-	$name        = 'group-filter-box';
-	$groups_slug = bp_get_groups_slug();
-	$action      = bp_displayed_user_url(
-		array(
-			'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $groups_slug, $groups_slug ),
-			'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $groups_slug . '_my_groups', 'my-groups' ),
-			'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $groups_slug . '_search', 'search' ) ),
-		)
-	);
+	$label  = __('Filter Groups', 'buddypress');
+	$name   = 'group-filter-box';
+	$action = bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_groups_slug(), 'my-groups', array( 'search' ) ) ) );
 
 	$search_form_html = '<form action="' . esc_url( $action ) . '" id="group-search-form" method="post">
 		<label for="'. $name .'" id="'. $name .'-label">'. esc_html( $label ) .'</label>

--- a/src/bp-friends/bp-friends-blocks.php
+++ b/src/bp-friends/bp-friends-blocks.php
@@ -112,9 +112,7 @@ function bp_friends_render_friends_block( $attributes = array() ) {
 
 	$link = bp_members_get_user_url(
 		$user_id,
-		array(
-			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_friends', bp_get_friends_slug() ),
-		)
+		bp_members_get_path_chunks( array( bp_get_friends_slug() ) )
 	);
 
 	/* translators: %s: member name */

--- a/src/bp-friends/bp-friends-functions.php
+++ b/src/bp-friends/bp-friends-functions.php
@@ -880,10 +880,7 @@ function friends_notification_new_request( $friendship_id, $initiator_id, $frien
 			'friend-requests.url' => esc_url(
 				bp_members_get_user_url(
 					$friend_id,
-					array(
-						'single_item_component' => bp_rewrites_get_slug( 'members', 'member_friends', bp_get_friends_slug() ),
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_friends_requests', 'requests' ),
-					)
+					bp_members_get_path_chunks( array( bp_get_friends_slug(), 'requests' ) )
 				)
 			),
 			'friend.id'           => $friend_id,

--- a/src/bp-friends/bp-friends-notifications.php
+++ b/src/bp-friends/bp-friends-notifications.php
@@ -28,17 +28,11 @@ defined( 'ABSPATH' ) || exit;
  * @return array|string
  */
 function friends_format_notifications( $action, $item_id, $secondary_item_id, $total_items, $format = 'string' ) {
-	$friends_slug        = bp_get_friends_slug();
-	$custom_friends_slug = bp_rewrites_get_slug( 'members', 'member_' . $friends_slug, $friends_slug );
+	$friends_slug = bp_get_friends_slug();
 
 	switch ( $action ) {
 		case 'friendship_accepted':
-			$link = bp_loggedin_user_url(
-				array(
-					'single_item_component' => $custom_friends_slug,
-					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_my_friends', 'my-friends' ),
-				)
-			);
+			$link = bp_loggedin_user_url( bp_members_get_path_chunks( array( $friends_slug, 'my-friends' ) ) );
 
 			// $action and $amount are used to generate dynamic filter names.
 			$action = 'accepted';
@@ -60,12 +54,7 @@ function friends_format_notifications( $action, $item_id, $secondary_item_id, $t
 			$link = add_query_arg(
 				'new',
 				1,
-				bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_friends_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_requests', 'requests' ),
-					)
-				)
+				bp_loggedin_user_url( bp_members_get_path_chunks( array( $friends_slug, 'requests' ) ) )
 			);
 
 			$action = 'request';

--- a/src/bp-friends/bp-friends-template.php
+++ b/src/bp-friends/bp-friends-template.php
@@ -221,8 +221,7 @@ function bp_add_friend_button( $potential_friend_id = 0, $friend_status = false 
 		}
 
 		$friendship_status = bp_is_friend( $potential_friend_id );
-		$friends_slug        = bp_get_friends_slug();
-		$custom_friends_slug = bp_rewrites_get_slug( 'members', 'member_' . $friends_slug, $friends_slug );
+		$friends_slug      = bp_get_friends_slug();
 
 		if ( empty( $friendship_status ) ) {
 			return $button_args;
@@ -238,13 +237,7 @@ function bp_add_friend_button( $potential_friend_id = 0, $friend_status = false 
 					'wrapper_class'     => 'friendship-button pending_friend',
 					'wrapper_id'        => 'friendship-button-' . $potential_friend_id,
 					'link_href'         => wp_nonce_url(
-						bp_loggedin_user_url(
-							array(
-								'single_item_component'        => $custom_friends_slug,
-								'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_requests', 'requests' ),
-								'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_requests_cancel', 'cancel' ), $potential_friend_id ),
-							)
-						),
+						bp_loggedin_user_url( bp_members_get_path_chunks( array( $friends_slug, 'requests', array( 'cancel', $potential_friend_id ) ) ) ),
 						'friends_withdraw_friendship'
 					),
 					'link_text'         => __( 'Cancel Friendship Request', 'buddypress' ),
@@ -263,12 +256,7 @@ function bp_add_friend_button( $potential_friend_id = 0, $friend_status = false 
 					'block_self'        => true,
 					'wrapper_class'     => 'friendship-button awaiting_response_friend',
 					'wrapper_id'        => 'friendship-button-' . $potential_friend_id,
-					'link_href'         => bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_friends_slug,
-							'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_requests', 'requests' ),
-						)
-					),
+					'link_href'         => bp_loggedin_user_url( bp_members_get_path_chunks( array( $friends_slug, 'requests' ) ) ),
 					'link_text'         => __( 'Friendship Requested', 'buddypress' ),
 					'link_title'        => __( 'Friendship Requested', 'buddypress' ),
 					'link_id'           => 'friend-' . $potential_friend_id,
@@ -286,13 +274,7 @@ function bp_add_friend_button( $potential_friend_id = 0, $friend_status = false 
 					'wrapper_class'     => 'friendship-button is_friend',
 					'wrapper_id'        => 'friendship-button-' . $potential_friend_id,
 					'link_href'         => wp_nonce_url(
-						bp_loggedin_user_url(
-							array(
-								'single_item_component'        => $custom_friends_slug,
-								'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_remove_friend', 'remove-friend' ),
-								'single_item_action_variables' => array( $potential_friend_id ),
-							)
-						),
+						bp_loggedin_user_url( bp_members_get_path_chunks( array( $friends_slug, 'remove-friend', array( $potential_friend_id ) ) ) ),
 						'friends_remove_friend'
 					),
 					'link_text'         => __( 'Cancel Friendship', 'buddypress' ),
@@ -312,13 +294,7 @@ function bp_add_friend_button( $potential_friend_id = 0, $friend_status = false 
 					'wrapper_class'     => 'friendship-button not_friends',
 					'wrapper_id'        => 'friendship-button-' . $potential_friend_id,
 					'link_href'         => wp_nonce_url(
-						bp_loggedin_user_url(
-							array(
-								'single_item_component'        => $custom_friends_slug,
-								'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_add_friend', 'add-friend' ),
-								'single_item_action_variables' => array( $potential_friend_id ),
-							)
-						),
+						bp_loggedin_user_url( bp_members_get_path_chunks( array( $friends_slug, 'add-friend', array( $potential_friend_id ) ) ) ),
 						'friends_add_friend'
 					),
 					'link_text'         => __( 'Add Friend', 'buddypress' ),
@@ -487,15 +463,8 @@ function bp_friend_accept_request_link() {
 			wp_cache_set( 'friendship_id_' . $members_template->member->id . '_' . bp_loggedin_user_id(), $friendship_id, 'bp' );
 		}
 
-		$friends_slug = bp_get_friends_slug();
-		$url          = wp_nonce_url(
-			bp_loggedin_user_url(
-				array(
-					'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug, $friends_slug ),
-					'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_requests', 'requests' ),
-					'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_requests_accept', 'accept' ), $friendship_id ),
-				)
-			),
+		$url = wp_nonce_url(
+			bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_friends_slug(), 'requests', array( 'accept', $friendship_id ) ) ) ),
 			'friends_accept_friendship'
 		);
 
@@ -536,15 +505,8 @@ function bp_friend_reject_request_link() {
 			wp_cache_set( 'friendship_id_' . $members_template->member->id . '_' . bp_loggedin_user_id(), $friendship_id, 'bp' );
 		}
 
-		$friends_slug = bp_get_friends_slug();
-		$url          = wp_nonce_url(
-			bp_loggedin_user_url(
-				array(
-					'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug, $friends_slug ),
-					'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_requests', 'requests' ),
-					'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_requests_reject', 'reject' ), $friendship_id ),
-				)
-			),
+		$url = wp_nonce_url(
+			bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_friends_slug(), 'requests', array( 'reject', $friendship_id ) ) ) ),
 			'friends_reject_friendship'
 		);
 

--- a/src/bp-friends/classes/class-bp-friends-component.php
+++ b/src/bp-friends/classes/class-bp-friends-component.php
@@ -241,8 +241,7 @@ class BP_Friends_Component extends BP_Component {
 		if ( is_user_logged_in() ) {
 
 			// Setup the logged in user variables.
-			$friends_slug        = bp_get_friends_slug();
-			$custom_friends_slug = bp_rewrites_get_slug( 'members', 'member_' . $friends_slug, $friends_slug );
+			$friends_slug = bp_get_friends_slug();
 
 			// Pending friend requests.
 			$count = count( friends_get_friendship_request_user_ids( bp_loggedin_user_id() ) );
@@ -267,11 +266,7 @@ class BP_Friends_Component extends BP_Component {
 				'parent' => buddypress()->my_account_menu_id,
 				'id'     => 'my-account-' . $this->id,
 				'title'  => $title,
-				'href'   => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_friends_slug,
-					)
-				),
+				'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $friends_slug ) ) ),
 			);
 
 			// My Friends.
@@ -279,12 +274,7 @@ class BP_Friends_Component extends BP_Component {
 				'parent'   => 'my-account-' . $this->id,
 				'id'       => 'my-account-' . $this->id . '-friendships',
 				'title'    => _x( 'Friendships', 'My Account Friends menu sub nav', 'buddypress' ),
-				'href'     => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_friends_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_my_friends', 'my-friends' ),
-					)
-				),
+				'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $friends_slug, 'my-friends' ) ) ),
 				'position' => 10,
 			);
 
@@ -293,12 +283,7 @@ class BP_Friends_Component extends BP_Component {
 				'parent'   => 'my-account-' . $this->id,
 				'id'       => 'my-account-' . $this->id . '-requests',
 				'title'    => $pending,
-				'href'     => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_friends_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_requests', 'requests' ),
-					)
-				),
+				'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $friends_slug, 'requests' ) ) ),
 				'position' => 20,
 			);
 		}

--- a/src/bp-friends/screens/requests.php
+++ b/src/bp-friends/screens/requests.php
@@ -53,14 +53,9 @@ function friends_screen_requests() {
 	}
 
 	if ( $redirect ) {
-		$friends_slug = bp_get_friends_slug();
-
 		bp_core_redirect(
 			bp_loggedin_user_url(
-				array(
-					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug, $friends_slug ),
-					'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_requests', 'requests' ),
-				)
+				bp_members_get_path_chunks( array( bp_get_friends_slug(), 'requests' ) )
 			)
 		);
 	}

--- a/src/bp-groups/actions/leave-group.php
+++ b/src/bp-groups/actions/leave-group.php
@@ -49,12 +49,7 @@ function groups_action_leave_group() {
 		$redirect = bp_get_group_url( $group );
 
 		if ( ! $group->is_visible ) {
-			$groups_slug = bp_get_groups_slug();
-			$redirect    = bp_loggedin_user_url(
-				array(
-					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $groups_slug, $groups_slug ),
-				)
-			);
+			$redirect = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_groups_slug() ) ) );
 		}
 
 		bp_core_redirect( $redirect );

--- a/src/bp-groups/bp-groups-adminbar.php
+++ b/src/bp-groups/bp-groups-adminbar.php
@@ -82,12 +82,9 @@ function bp_groups_group_admin_menu() {
 					'parent' => $bp->group_admin_menu_id,
 					'id'     => $menu->slug,
 					'title'  => $title,
-					'href'   => bp_get_group_url(
+					'href'   => bp_get_group_manage_url(
 						$bp->groups->current_group,
-						array(
-							'single_item_action'           => bp_rewrites_get_slug( 'groups', 'bp_group_read_admin', 'admin' ),
-							'single_item_action_variables' => bp_rewrites_get_slug( 'groups', $manage_screens[ $menu->slug ]['rewrite_id'], $menu->slug ),
-						)
+						bp_groups_get_path_chunks( array( $menu->slug ), 'manage' )
 					),
 				)
 			);

--- a/src/bp-groups/bp-groups-notifications.php
+++ b/src/bp-groups/bp-groups-notifications.php
@@ -339,10 +339,7 @@ function groups_notification_group_invites( &$group, &$member, $inviter_user_id 
 
 	$invited_link = bp_members_get_user_url(
 		$invited_user_id,
-		array(
-			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_groups', bp_get_groups_slug() ),
-			'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_groups_invites', 'invites' ),
-		)
+		bp_members_get_path_chunks( array( bp_get_groups_slug(), 'invites' ) )
 	);
 
 	$unsubscribe_args = array(
@@ -417,12 +414,9 @@ function groups_format_notifications( $action, $item_id, $secondary_item_id, $to
 					array(
 						'n' => 1,
 					),
-					bp_get_group_url(
+					bp_get_group_manage_url(
 						$group,
-						array(
-							'single_item_action'           => bp_rewrites_get_slug( 'groups', 'bp_group_read_admin', 'admin' ),
-							'single_item_action_variables' => array( bp_rewrites_get_slug( 'groups', 'bp_group_manage_membership_requests', 'membership-requests' ) ),
-						)
+						bp_groups_get_path_chunks( array( 'membership-requests' ), 'manage' )
 					)
 				);
 
@@ -475,12 +469,9 @@ function groups_format_notifications( $action, $item_id, $secondary_item_id, $to
 					array(
 						'n' => 1,
 					),
-					bp_get_group_url(
+					bp_get_group_manage_url(
 						$group,
-						array(
-							'single_item_action'           => bp_rewrites_get_slug( 'groups', 'bp_group_read_admin', 'admin' ),
-							'single_item_action_variables' => array( bp_rewrites_get_slug( 'groups', 'bp_group_manage_membership_requests', 'membership-requests' ) ),
-						)
+						bp_groups_get_path_chunks( array( 'membership-requests' ), 'manage' )
 					)
 				);
 
@@ -531,11 +522,9 @@ function groups_format_notifications( $action, $item_id, $secondary_item_id, $to
 		case 'membership_request_accepted':
 			$group_id = $item_id;
 
-			$group              = groups_get_group( $group_id );
-			$group_link         = bp_get_group_url( $group );
-			$groups_slug        = bp_get_groups_slug();
-			$custom_groups_slug = bp_rewrites_get_slug( 'members', 'member_' . $groups_slug, $groups_slug );
-			$amount             = 'single';
+			$group      = groups_get_group( $group_id );
+			$group_link = bp_get_group_url( $group );
+			$amount     = 'single';
 
 			if ( (int) $total_items > 1 ) {
 				/* translators: 1: number of accepted group membership requests. 2: group name. */
@@ -544,11 +533,7 @@ function groups_format_notifications( $action, $item_id, $secondary_item_id, $to
 				$notification_link = add_query_arg(
 					'n',
 					1,
-					bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_groups_slug,
-						)
-					)
+					bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_groups_slug() ) ) )
 				);
 
 				if ( 'string' == $format ) {
@@ -632,11 +617,9 @@ function groups_format_notifications( $action, $item_id, $secondary_item_id, $to
 		case 'membership_request_rejected':
 			$group_id = $item_id;
 
-			$group              = groups_get_group( $group_id );
-			$group_link         = bp_get_group_url( $group );
-			$groups_slug        = bp_get_groups_slug();
-			$custom_groups_slug = bp_rewrites_get_slug( 'members', 'member_' . $groups_slug, $groups_slug );
-			$amount             = 'single';
+			$group      = groups_get_group( $group_id );
+			$group_link = bp_get_group_url( $group );
+			$amount     = 'single';
 
 			if ( (int) $total_items > 1 ) {
 				/* translators: 1: number of accepted group membership requests. 2: group name. */
@@ -645,11 +628,7 @@ function groups_format_notifications( $action, $item_id, $secondary_item_id, $to
 				$notification_link = add_query_arg(
 					'n',
 					1,
-					bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_groups_slug,
-						)
-					)
+					bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_groups_slug() ) ) )
 				);
 
 				if ( 'string' == $format ) {
@@ -732,11 +711,9 @@ function groups_format_notifications( $action, $item_id, $secondary_item_id, $to
 		case 'member_promoted_to_admin':
 			$group_id = $item_id;
 
-			$group              = groups_get_group( $group_id );
-			$group_link         = bp_get_group_url( $group );
-			$groups_slug        = bp_get_groups_slug();
-			$custom_groups_slug = bp_rewrites_get_slug( 'members', 'member_' . $groups_slug, $groups_slug );
-			$amount             = 'single';
+			$group      = groups_get_group( $group_id );
+			$group_link = bp_get_group_url( $group );
+			$amount     = 'single';
 
 			if ( (int) $total_items > 1 ) {
 				/* translators: %d: number of groups the user has been promoted admin for */
@@ -745,11 +722,7 @@ function groups_format_notifications( $action, $item_id, $secondary_item_id, $to
 				$notification_link = add_query_arg(
 					'n',
 					1,
-					bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_groups_slug,
-						)
-					)
+					bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_groups_slug() ) ) )
 				);
 
 				if ( 'string' == $format ) {
@@ -826,11 +799,9 @@ function groups_format_notifications( $action, $item_id, $secondary_item_id, $to
 		case 'member_promoted_to_mod':
 			$group_id = $item_id;
 
-			$group              = groups_get_group( $group_id );
-			$group_link         = bp_get_group_url( $group );
-			$groups_slug        = bp_get_groups_slug();
-			$custom_groups_slug = bp_rewrites_get_slug( 'members', 'member_' . $groups_slug, $groups_slug );
-			$amount             = 'single';
+			$group      = groups_get_group( $group_id );
+			$group_link = bp_get_group_url( $group );
+			$amount     = 'single';
 
 			if ( (int) $total_items > 1 ) {
 				/* translators: %d: number of groups the user has been promoted mod for */
@@ -839,11 +810,7 @@ function groups_format_notifications( $action, $item_id, $secondary_item_id, $to
 				$notification_link = add_query_arg(
 					'n',
 					1,
-					bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_groups_slug,
-						)
-					)
+					bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_groups_slug() ) ) )
 				);
 
 				if ( 'string' == $format ) {
@@ -921,18 +888,11 @@ function groups_format_notifications( $action, $item_id, $secondary_item_id, $to
 			$group_id           = $item_id;
 			$group              = groups_get_group( $group_id );
 			$group_link         = bp_get_group_url( $group );
-			$groups_slug        = bp_get_groups_slug();
-			$custom_groups_slug = bp_rewrites_get_slug( 'members', 'member_' . $groups_slug, $groups_slug );
 			$amount             = 'single';
 			$notification_link  = add_query_arg(
 				'n',
 				1,
-				bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_groups_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $groups_slug . '_invites', 'invites' ),
-					)
-				)
+				bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_groups_slug(), 'invites' ) ) )
 			);
 
 			if ( (int) $total_items > 1 ) {
@@ -1336,9 +1296,7 @@ function groups_email_notification_membership_request_completed_by_admin( $user_
 			'leave-group.url' => esc_url(
 				bp_members_get_user_url(
 					$user_id,
-					array(
-						'single_item_component' => bp_rewrites_get_slug( 'members', 'member_groups', bp_get_groups_slug() ),
-					)
+					bp_members_get_path_chunks( array( bp_get_groups_slug() ) )
 				)
 			),
 		),

--- a/src/bp-groups/bp-groups-template.php
+++ b/src/bp-groups/bp-groups-template.php
@@ -2944,22 +2944,19 @@ function bp_group_form_action( $page, $group = false ) {
 	 */
 	function bp_get_group_form_action( $page, $group = false ) {
 		$group = bp_get_group( $group );
+		$url   = '';
 
 		if ( empty( $group->id ) || empty( $page ) ) {
-			return '';
+			return $url;
 		}
 
 		$screens = bp_get_group_screens( 'read' );
 		if ( isset( $screens[ $page ]['rewrite_id'] ) ) {
-			$page = bp_rewrites_get_slug( 'groups', $screens[ $page ]['rewrite_id'], $page );
+			$url = bp_get_group_url(
+				$group,
+				bp_groups_get_path_chunks( array( $page ) )
+			);
 		}
-
-		$url = bp_get_group_url(
-			$group,
-			array(
-				'single_item_action' => $page,
-			)
-		);
 
 		/**
 		 * Filters the 'action' attribute for a group form.
@@ -3000,9 +2997,10 @@ function bp_group_admin_form_action( $page = false, $group = false ) {
 	 */
 	function bp_get_group_admin_form_action( $page = false, $group = false ) {
 		$group = bp_get_group( $group );
+		$url   = '';
 
 		if ( empty( $group->id ) ) {
-			return '';
+			return $url;
 		}
 
 		if ( empty( $page ) ) {
@@ -3011,16 +3009,11 @@ function bp_group_admin_form_action( $page = false, $group = false ) {
 
 		$screens = bp_get_group_screens( 'manage' );
 		if ( isset( $screens[ $page ]['rewrite_id'] ) ) {
-			$page = bp_rewrites_get_slug( 'groups', $screens[ $page ]['rewrite_id'], $page );
+			$url = bp_get_group_manage_url(
+				$group,
+				bp_groups_get_path_chunks( array( $page ), 'manage' )
+			);
 		}
-
-		$url = bp_get_group_url(
-			$group,
-			array(
-				'single_item_action'           => bp_rewrites_get_slug( 'groups', 'bp_group_read_admin', 'admin' ),
-				'single_item_action_variables' => $page,
-			)
-		);
 
 		/**
 		 * Filters the 'action' attribute for a group admin form.
@@ -3211,12 +3204,7 @@ function bp_group_accept_invite_link() {
 			$group =& $groups_template->group;
 		}
 
-		$groups_slug = bp_get_groups_slug();
-		$path_chunks = array(
-			'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $groups_slug, $groups_slug ),
-			'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $groups_slug . '_invites', 'invites' ),
-			'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $groups_slug . '_invites_accept', 'accept' ), $group->id ),
-		);
+		$path_chunks = bp_members_get_path_chunks( array( bp_get_groups_slug(), 'invites', array( 'accept', $group->id ) ) );
 
 		if ( bp_is_user() ) {
 			$user_domain = bp_displayed_user_url( $path_chunks );
@@ -3264,12 +3252,7 @@ function bp_group_reject_invite_link() {
 			$group =& $groups_template->group;
 		}
 
-		$groups_slug = bp_get_groups_slug();
-		$path_chunks = array(
-			'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $groups_slug, $groups_slug ),
-			'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $groups_slug . '_invites', 'invites' ),
-			'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $groups_slug . '_invites_reject', 'reject' ), $group->id ),
-		);
+		$path_chunks = bp_members_get_path_chunks( array( bp_get_groups_slug(), 'invites', array( 'reject', $group->id ) ) );
 
 		if ( bp_is_user() ) {
 			$user_domain = bp_displayed_user_url( $path_chunks );

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -764,13 +764,7 @@ class BP_Groups_Component extends BP_Component {
 			// If the user is a group admin, then show the group admin nav item.
 			if ( bp_is_item_admin() ) {
 				// Get the "manage" screens.
-				$manage_screens    = bp_get_group_screens( 'manage', true );
-				$admin_link        = bp_get_group_url(
-					$this->current_group,
-					array(
-						'single_item_action' => bp_rewrites_get_slug( 'groups', 'bp_group_read_admin', 'admin' ),
-					)
-				);
+				$manage_screens = bp_get_group_screens( 'manage', true );
 
 				// Common params to all nav items.
 				$default_params = array(
@@ -839,8 +833,7 @@ class BP_Groups_Component extends BP_Component {
 		if ( is_user_logged_in() ) {
 
 			// Setup the logged in user variables.
-			$groups_slug        = bp_get_groups_slug();
-			$custom_groups_slug = bp_rewrites_get_slug( 'members', 'member_' . $groups_slug, $groups_slug );
+			$groups_slug = bp_get_groups_slug();
 
 			$title   = _x( 'Groups', 'My Account Groups', 'buddypress' );
 			$pending = _x( 'No Pending Invites', 'My Account Groups sub nav', 'buddypress' );
@@ -868,11 +861,7 @@ class BP_Groups_Component extends BP_Component {
 				'parent' => buddypress()->my_account_menu_id,
 				'id'     => 'my-account-' . $this->id,
 				'title'  => $title,
-				'href'   => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_groups_slug,
-					)
-				),
+				'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $groups_slug ) ) ),
 			);
 
 			// My Groups.
@@ -880,12 +869,7 @@ class BP_Groups_Component extends BP_Component {
 				'parent'   => 'my-account-' . $this->id,
 				'id'       => 'my-account-' . $this->id . '-memberships',
 				'title'    => _x( 'Memberships', 'My Account Groups sub nav', 'buddypress' ),
-				'href'     => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_groups_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $groups_slug . '_my_groups', 'my-groups' ),
-					)
-				),
+				'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $groups_slug, 'my-groups' ) ) ),
 				'position' => 10,
 			);
 
@@ -895,12 +879,7 @@ class BP_Groups_Component extends BP_Component {
 					'parent'   => 'my-account-' . $this->id,
 					'id'       => 'my-account-' . $this->id . '-invites',
 					'title'    => $pending,
-					'href'     => bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_groups_slug,
-							'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $groups_slug . '_invites', 'invites' ),
-						)
-					),
+					'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $groups_slug, 'invites' ) ) ),
 					'position' => 30,
 				);
 			}

--- a/src/bp-groups/screens/single/admin/delete-group.php
+++ b/src/bp-groups/screens/single/admin/delete-group.php
@@ -18,7 +18,7 @@ function groups_screen_group_admin_delete_group() {
 		return false;
 	}
 
-	if ( ! bp_is_item_admin() && !bp_current_user_can( 'bp_moderate' ) ) {
+	if ( ! bp_is_item_admin() && ! bp_current_user_can( 'bp_moderate' ) ) {
 		return false;
 	}
 
@@ -26,11 +26,7 @@ function groups_screen_group_admin_delete_group() {
 
 	if ( isset( $_REQUEST['delete-group-button'] ) && isset( $_REQUEST['delete-group-understand'] ) ) {
 		$groups_slug = bp_get_groups_slug();
-		$redirect    = bp_loggedin_user_url(
-			array(
-				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $groups_slug, $groups_slug ),
-			)
-		);
+		$redirect    = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_groups_slug() ) ) );
 
 		// Check the nonce first.
 		if ( ! check_admin_referer( 'groups_delete_group' ) ) {

--- a/src/bp-members/actions/invitations-bulk-manage.php
+++ b/src/bp-members/actions/invitations-bulk-manage.php
@@ -76,14 +76,9 @@ function bp_members_invitations_action_bulk_manage() {
 			break;
 	}
 
-	$invite_slug       = bp_get_members_invitations_slug();
-	$action_slug       = bp_current_action();
-	$action_rewrite_id = str_replace( '-', '_', $action_slug );
-
-	$path_chunks = array(
-		'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $invite_slug, $invite_slug ),
-		'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $invite_slug . '_' . $action_rewrite_id, $action_slug ),
-	);
+	$invite_slug = bp_get_members_invitations_slug();
+	$action_slug = bp_current_action();
+	$path_chunks = bp_members_get_path_chunks( array( $invite_slug, $action_slug ) );
 
 	// Redirect.
 	bp_core_redirect( bp_displayed_user_url( $path_chunks ) );

--- a/src/bp-members/bp-members-adminbar.php
+++ b/src/bp-members/bp-members-adminbar.php
@@ -210,20 +210,15 @@ function bp_members_admin_bar_add_invitations_menu() {
 	}
 
 	if ( bp_current_user_can( 'bp_members_invitations_view_screens' ) ) {
-		$bp                 = buddypress();
-		$invite_slug        = bp_get_members_invitations_slug();
-		$custom_invite_slug = bp_rewrites_get_slug( 'members', 'member_' . $invite_slug, $invite_slug );
+		$bp          = buddypress();
+		$invite_slug = bp_get_members_invitations_slug();
 
 		$wp_admin_bar->add_node(
 			array(
 				'id'     => $bp->my_account_menu_id . '-invitations',
 				'parent' => $bp->my_account_menu_id,
 				'title'  => __( 'Invitations', 'buddypress' ),
-				'href'   => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_invite_slug,
-					)
-				),
+				'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $invite_slug ) ) ),
 				'meta'   => array(
 					'class'  => 'ab-sub-secondary'
 				)
@@ -236,12 +231,7 @@ function bp_members_admin_bar_add_invitations_menu() {
 					'id'     => $bp->my_account_menu_id . '-invitations-send',
 					'parent' => $bp->my_account_menu_id . '-invitations',
 					'title'  => __( 'Send Invites', 'buddypress' ),
-					'href'   => bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_invite_slug,
-							'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $invite_slug . '_send_invites', 'send-invites' ),
-						)
-					),
+					'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $invite_slug, 'send-invites' ) ) ),
 					'meta'   => array(
 						'class'  => 'ab-sub-secondary'
 					)
@@ -254,12 +244,7 @@ function bp_members_admin_bar_add_invitations_menu() {
 				'id'     => $bp->my_account_menu_id . '-invitations-list',
 				'parent' => $bp->my_account_menu_id . '-invitations',
 				'title'  => __( 'Pending Invites', 'buddypress' ),
-				'href'   => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_invite_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $invite_slug . '_list_invites', 'list-invites' ),
-					)
-				),
+				'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $invite_slug, 'list-invites' ) ) ),
 				'meta'   => array(
 					'class'  => 'ab-sub-secondary'
 				)

--- a/src/bp-members/bp-members-filters.php
+++ b/src/bp-members/bp-members-filters.php
@@ -110,10 +110,7 @@ function bp_members_edit_profile_url( $url, $user_id, $scheme = 'admin' ) {
 	if ( ! is_admin() && bp_is_active( 'xprofile' ) ) {
 		$profile_link = bp_members_get_user_url(
 			$user_id,
-			array(
-				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_profile', bp_get_profile_slug() ),
-				'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_profile_edit', 'edit' ),
-			)
+			bp_members_get_path_chunks( array( bp_get_profile_slug(), 'edit' ) )
 		);
 
 	} else {

--- a/src/bp-members/bp-members-template.php
+++ b/src/bp-members/bp-members-template.php
@@ -3093,17 +3093,17 @@ function bp_members_component_link( $component, $action = '', $query_args = '', 
 			$component = 'profile';
 		}
 
-		$path_chunks = array(
-			'single_item_component' => $bp->{$component}->slug,
-		);
+		$path_chunks = array( $bp->{$component}->slug );
 
-		// Append $action to $url if there is no $type.
+		// Append $action to $url if needed.
 		if ( ! empty( $action ) ) {
-			$action_rewrite_id                 = 'member_' . str_replace( '-', '_', $action );
-			$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'members', $action_rewrite_id, $action );
+			$path_chunks[] = $action;
 		}
 
-		// Add a slash at the end of our user url.
+		// Check for slugs customization.
+		$path_chunks = bp_members_get_path_chunks( $path_chunks );
+
+		// Generate user url.
 		$url = bp_displayed_user_url( $path_chunks );
 
 		// Add possible query arg.
@@ -3146,11 +3146,7 @@ function bp_avatar_delete_link() {
 		$profile_slug = bp_get_profile_slug();
 		$url          = wp_nonce_url(
 			bp_displayed_user_url(
-				array(
-					'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug, $profile_slug ),
-					'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_change_avatar', 'change-avatar' ),
-					'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_delete_avatar', 'delete-avatar' ) ),
-				)
+				bp_members_get_path_chunks( array( $profile_slug, 'change-avatar', array( 'delete-avatar' ) ) )
 			),
 			'bp_delete_avatar_link'
 		);
@@ -3678,10 +3674,7 @@ function bp_members_invitations_list_invites_permalink( $user_id = 0 ) {
 
 		$retval = bp_members_get_user_url(
 			(int) $user_id,
-			array(
-				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_invitations', bp_get_members_invitations_slug() ),
-				'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_invitations_list_invites', 'list-invites' ),
-			)
+			bp_members_get_path_chunks( array( bp_get_members_invitations_slug(), 'list-invites' ) )
 		);
 
 		/**
@@ -3720,10 +3713,7 @@ function bp_members_invitations_send_invites_permalink( $user_id = 0 ) {
 
 		$retval = bp_members_get_user_url(
 			(int) $user_id,
-			array(
-				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_invitations', bp_get_members_invitations_slug() ),
-				'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_invitations_send_invites', 'send-invites' ),
-			)
+			bp_members_get_path_chunks( array( bp_get_members_invitations_slug(), 'send-invites' ) )
 		);
 
 		/**

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -533,9 +533,8 @@ class BP_Members_Component extends BP_Component {
 	 * @return array                     The Avatar and Cover image admin navs.
 	 */
 	public function get_avatar_cover_image_admin_navs( $admin_bar_menu_id = '' ) {
-		$wp_admin_nav        = array();
-		$profile_slug        = bp_get_profile_slug();
-		$custom_profile_slug = bp_rewrites_get_slug( 'members', 'member_' . $profile_slug, $profile_slug );
+		$wp_admin_nav = array();
+		$profile_slug = bp_get_profile_slug();
 
 		if ( ! $admin_bar_menu_id ) {
 			$admin_bar_menu_id = $this->id;
@@ -547,12 +546,7 @@ class BP_Members_Component extends BP_Component {
 				'parent'   => 'my-account-' . $admin_bar_menu_id,
 				'id'       => 'my-account-' . $admin_bar_menu_id . '-change-avatar',
 				'title'    => _x( 'Change Profile Photo', 'My Account Profile sub nav', 'buddypress' ),
-				'href'     => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_profile_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_change_avatar', 'change-avatar' ),
-					)
-				),
+				'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $profile_slug, 'change-avatar' ) ) ),
 				'position' => 30,
 			);
 		}
@@ -563,12 +557,7 @@ class BP_Members_Component extends BP_Component {
 				'parent'   => 'my-account-' . $admin_bar_menu_id,
 				'id'       => 'my-account-' . $admin_bar_menu_id . '-change-cover-image',
 				'title'    => _x( 'Change Cover Image', 'My Account Profile sub nav', 'buddypress' ),
-				'href'     => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_profile_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_change_cover_image', 'change-cover-image' ),
-					)
-				),
+				'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $profile_slug, 'change-cover-image' ) ) ),
 				'position' => 40,
 			);
 		}
@@ -586,8 +575,7 @@ class BP_Members_Component extends BP_Component {
 	public function setup_admin_bar( $wp_admin_nav = array() ) {
 		// Menus for logged in user.
 		if ( is_user_logged_in() ) {
-			$profile_slug        = bp_get_profile_slug();
-			$custom_profile_slug = bp_rewrites_get_slug( 'members', 'member_' . $profile_slug, $profile_slug );
+			$profile_slug = bp_get_profile_slug();
 
 			if ( ! bp_is_active( 'xprofile' ) ) {
 				// Add the "Profile" sub menu.
@@ -595,11 +583,7 @@ class BP_Members_Component extends BP_Component {
 					'parent' => buddypress()->my_account_menu_id,
 					'id'     => 'my-account-' . $this->id,
 					'title'  => _x( 'Profile', 'My Account Profile', 'buddypress' ),
-					'href'   => bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_profile_slug,
-						)
-					),
+					'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $profile_slug ) ) ),
 				);
 
 				// View Profile.
@@ -607,12 +591,7 @@ class BP_Members_Component extends BP_Component {
 					'parent'   => 'my-account-' . $this->id,
 					'id'       => 'my-account-' . $this->id . '-public',
 					'title'    => _x( 'View', 'My Account Profile sub nav', 'buddypress' ),
-					'href'     => bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_profile_slug,
-							'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_public', 'public' ),
-						)
-					),
+					'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $profile_slug, 'public' ) ) ),
 					'position' => 10,
 				);
 

--- a/src/bp-messages/actions/compose.php
+++ b/src/bp-messages/actions/compose.php
@@ -43,21 +43,17 @@ function bp_messages_action_create_message() {
 	} else {
 
 		// Setup the link to the logged-in user's messages.
-		$message_slug        = bp_get_messages_slug();
-		$custom_message_slug = bp_rewrites_get_slug( 'members', 'member_' . $message_slug, $message_slug );
-		$path_chunks         = array(
-			'single_item_component' => $custom_message_slug,
-		);
+		$path_chunks = array( bp_get_messages_slug() );
 
 		// Site-wide notice.
 		if ( isset( $_POST['send-notice'] ) ) {
 
 			// Attempt to save the notice and redirect to notices.
 			if ( messages_send_notice( $_POST['subject'], $_POST['content'] ) ) {
-				$success                           = true;
-				$feedback                          = __( 'Notice successfully created.', 'buddypress' );
-				$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_notices', 'notices' );
-				$redirect_to = bp_loggedin_user_url( $path_chunks );
+				$success       = true;
+				$feedback      = __( 'Notice successfully created.', 'buddypress' );
+				$path_chunks[] = 'notices';
+				$redirect_to   = bp_loggedin_user_url( bp_members_get_path_chunks( $path_chunks ) );
 
 			// Notice could not be sent.
 			} else {
@@ -92,11 +88,11 @@ function bp_messages_action_create_message() {
 
 			// Send the message and redirect to it.
 			if ( true === is_int( $send ) ) {
-				$success                                     = true;
-				$feedback                                    = __( 'Message successfully sent.', 'buddypress' );
-				$path_chunks['single_item_action']           = bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_view', 'view' );
-				$path_chunks['single_item_action_variables'] = array( $send );
-				$redirect_to                                 = bp_loggedin_user_url( $path_chunks );
+				$success       = true;
+				$feedback      = __( 'Message successfully sent.', 'buddypress' );
+				$path_chunks[] = 'view';
+				$path_chunks[] = array( $send );
+				$redirect_to   = bp_loggedin_user_url( bp_members_get_path_chunks( $path_chunks ) );
 
 			// Message could not be sent.
 			} else {

--- a/src/bp-messages/actions/notices.php
+++ b/src/bp-messages/actions/notices.php
@@ -86,14 +86,7 @@ function bp_messages_action_edit_notice() {
 	}
 
 	// Redirect.
-	$message_slug        = bp_get_messages_slug();
-	$custom_message_slug = bp_rewrites_get_slug( 'members', 'member_' . $message_slug, $message_slug );
-	$redirect_to         = bp_loggedin_user_url(
-		array(
-			'single_item_component' => $custom_message_slug,
-			'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_notices', 'notices' ),
-		)
-	);
+	$redirect_to = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_messages_slug(), 'notices' ) ) );
 
 	bp_core_redirect( $redirect_to );
 }
@@ -137,13 +130,7 @@ function bp_messages_action_dismiss_notice() {
 	bp_core_add_message( $feedback, $type );
 
 	// Redirect.
-	$message_slug        = bp_get_messages_slug();
-	$custom_message_slug = bp_rewrites_get_slug( 'members', 'member_' . $message_slug, $message_slug );
-	$redirect_to         = bp_loggedin_user_url(
-		array(
-			'single_item_component' => $custom_message_slug,
-		)
-	);
+	$redirect_to = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_messages_slug() ) ) );
 
 	bp_core_redirect( $redirect_to );
 }

--- a/src/bp-messages/actions/star.php
+++ b/src/bp-messages/actions/star.php
@@ -41,12 +41,7 @@ function bp_messages_star_action_handler() {
 	$redirect = wp_get_referer();
 
 	if ( ! $redirect ) {
-		$messages_slug = bp_get_messages_slug();
-		$redirect      = bp_displayed_user_url(
-			array(
-				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $messages_slug, $messages_slug ),
-			)
-		);
+		$redirect = bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_messages_slug() ) ) );
 	}
 
 	bp_core_redirect( $redirect );

--- a/src/bp-messages/bp-messages-functions.php
+++ b/src/bp-messages/bp-messages-functions.php
@@ -629,11 +629,7 @@ function messages_notification_new_message( $raw_args = array() ) {
 				'message.url' => esc_url(
 					bp_members_get_user_url(
 						$recipient->user_id,
-						array(
-							'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_messages', bp_get_messages_slug() ),
-							'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_messages_view', 'view' ),
-							'single_item_action_variables' => array( $thread_id ),
-						)
+						bp_members_get_path_chunks( array( bp_get_messages_slug(), 'view', array( $thread_id ) ) )
 					)
 				),
 				'sender.name' => $sender_name,

--- a/src/bp-messages/bp-messages-notifications.php
+++ b/src/bp-messages/bp-messages-notifications.php
@@ -24,18 +24,11 @@ defined( 'ABSPATH' ) || exit;
  * @return string|array Formatted notifications.
  */
 function messages_format_notifications( $action, $item_id, $secondary_item_id, $total_items, $format = 'string' ) {
-	$total_items         = (int) $total_items;
-	$text                = '';
-	$message_slug        = bp_get_messages_slug();
-	$custom_message_slug = bp_rewrites_get_slug( 'members', 'member_' . $message_slug, $message_slug );
-	$link                = bp_loggedin_user_url(
-		array(
-			'single_item_component' => $custom_message_slug,
-			'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_inbox', 'inbox' ),
-		)
-	);
-	$title               = __( 'Inbox', 'buddypress' );
-	$amount              = 'single';
+	$total_items = (int) $total_items;
+	$text        = '';
+	$link        = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_messages_slug(), 'inbox' ) ) );
+	$title       = __( 'Inbox', 'buddypress' );
+	$amount      = 'single';
 
 	if ( 'new_message' === $action ) {
 		if ( $total_items > 1 ) {

--- a/src/bp-messages/bp-messages-star.php
+++ b/src/bp-messages/bp-messages-star.php
@@ -113,21 +113,14 @@ function bp_the_message_star_action_link( $args = array() ) {
 			'messages_star_action_link'
 		);
 
-		// Check user ID and determine base user slug.
-		$user_slug = bp_members_get_user_slug( $r['user_id'] );
-
-		// Bail if no user domain was calculated.
-		if ( empty( $user_slug ) ) {
+		// Check user ID.
+		$user_id = (int) $r['user_id'];
+		if ( empty( $user_id ) ) {
 			return '';
 		}
 
-		$message_slug        = bp_get_messages_slug();
-		$custom_message_slug = bp_rewrites_get_slug( 'members', 'member_' . $message_slug, $message_slug );
-		$path_chunks         = array(
-			'component_id'          => 'members',
-			'single_item'           => $user_slug,
-			'single_item_component' => $custom_message_slug,
-		);
+		// Init path chunks.
+		$path_chunks = array( bp_get_messages_slug() );
 
 		// Define local variables.
 		$retval = $bulk_attr = '';
@@ -174,14 +167,14 @@ function bp_the_message_star_action_link( $args = array() ) {
 			$nonce = wp_create_nonce( "bp-messages-star-{$message_id}" );
 
 			if ( true === $is_starred ) {
-				$action                                      = 'unstar';
-				$bulk_attr                                   = ' data-star-bulk="1"';
-				$path_chunks['single_item_action']           = bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_unstar', 'unstar' );
-				$path_chunks['single_item_action_variables'] = array( $message_id, $nonce, bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_all', 'all' ) );
+				$action        = 'unstar';
+				$bulk_attr     = ' data-star-bulk="1"';
+				$path_chunks[] = $action;
+				$path_chunks[] = array( $message_id, $nonce, 'all' );
 			} else {
-				$action                                      = 'star';
-				$path_chunks['single_item_action']           = bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_star', 'star' );
-				$path_chunks['single_item_action_variables'] = array( $message_id, $nonce );
+				$action        = 'star';
+				$path_chunks[] = $action;
+				$path_chunks[] = array( $message_id, $nonce );
 			}
 
 			$title = $r["title_{$action}_thread"];
@@ -193,19 +186,17 @@ function bp_the_message_star_action_link( $args = array() ) {
 			$nonce      = wp_create_nonce( "bp-messages-star-{$message_id}" );
 
 			if ( true === $is_starred ) {
-				$action                                      = 'unstar';
-				$path_chunks['single_item_action']           = bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_unstar', 'unstar' );
-				$path_chunks['single_item_action_variables'] = array( $message_id, $nonce );
+				$action = 'unstar';
 			} else {
-				$action                                      = 'star';
-				$path_chunks['single_item_action']           = bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_star', 'star' );
-				$path_chunks['single_item_action_variables'] = array( $message_id, $nonce );
+				$action = 'star';
 			}
 
-			$title = $r["title_{$action}"];
+			$path_chunks[] = $action;
+			$path_chunks[] = array( $message_id, $nonce );
+			$title         = $r["title_{$action}"];
 		}
 
-		$url = bp_rewrites_get_url( $path_chunks );
+		$url = bp_members_get_user_url( $user_id, bp_members_get_path_chunks( $path_chunks ) );
 
 		/**
 		 * Filters the star action URL for starring / unstarring a message.

--- a/src/bp-messages/bp-messages-template.php
+++ b/src/bp-messages/bp-messages-template.php
@@ -339,11 +339,7 @@ function bp_message_thread_view_link( $thread_id = 0, $user_id = null ) {
 
 		$url = bp_members_get_user_url(
 			$user_id,
-			array(
-				'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_messages', bp_get_messages_slug() ),
-				'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_messages_view', 'view' ),
-				'single_item_action_variables' => array( $thread_id ),
-			)
+			bp_members_get_path_chunks( array( bp_get_messages_slug(), 'view', array( $thread_id ) ) )
 		);
 
 		/**
@@ -389,17 +385,9 @@ function bp_message_thread_delete_link( $user_id = null ) {
 			$user_id = bp_loggedin_user_id();
 		}
 
-		$current_action_slug         = bp_current_action();
-		$current_action_rewrite_id   = 'member_messages_' . $current_action_slug;
-		$action_variable_delete_slug = bp_rewrites_get_slug( 'members', $current_action_rewrite_id . '_delete', 'delete' );
-
 		$url = bp_members_get_user_url(
 			$user_id,
-			array(
-				'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_messages', bp_get_messages_slug() ),
-				'single_item_action'           => bp_rewrites_get_slug( 'members', $current_action_rewrite_id, $current_action_slug ),
-				'single_item_action_variables' => array( $action_variable_delete_slug, $messages_template->thread->thread_id ),
-			)
+			bp_members_get_path_chunks( array( bp_get_messages_slug(), bp_current_action(), array( 'delete', $messages_template->thread->thread_id ) ) )
 		);
 
 		/**
@@ -452,18 +440,9 @@ function bp_the_message_thread_mark_unread_url( $user_id = null ) {
 			$user_id = bp_loggedin_user_id();
 		}
 
-		$current_action_slug         = bp_current_action();
-		$current_action_rewrite_id   = 'member_messages_' . $current_action_slug;
-		$action_variable_unread_slug = bp_rewrites_get_slug( 'members', $current_action_rewrite_id . '_unread', 'unread' );
-
-		// Base unread URL.
 		$url = bp_members_get_user_url(
 			$user_id,
-			array(
-				'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_messages', bp_get_messages_slug() ),
-				'single_item_action'           => bp_rewrites_get_slug( 'members', $current_action_rewrite_id, $current_action_slug ),
-				'single_item_action_variables' => array( $action_variable_unread_slug ),
-			)
+			bp_members_get_path_chunks( array( bp_get_messages_slug(), bp_current_action(), array( 'unread' ) ) )
 		);
 
 		// Add the args to the URL.
@@ -523,18 +502,9 @@ function bp_the_message_thread_mark_read_url( $user_id = null ) {
 			$user_id = bp_loggedin_user_id();
 		}
 
-		$current_action_slug         = bp_current_action();
-		$current_action_rewrite_id   = 'member_messages_' . $current_action_slug;
-		$action_variable_read_slug = bp_rewrites_get_slug( 'members', $current_action_rewrite_id . '_read', 'read' );
-
-		// Base read URL.
 		$url = bp_members_get_user_url(
 			$user_id,
-			array(
-				'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_messages', bp_get_messages_slug() ),
-				'single_item_action'           => bp_rewrites_get_slug( 'members', $current_action_rewrite_id, $current_action_slug ),
-				'single_item_action_variables' => array( $action_variable_read_slug ),
-			)
+			bp_members_get_path_chunks( array( bp_get_messages_slug(), bp_current_action(), array( 'read' ) ) )
 		);
 
 		// Add the args to the URL.
@@ -1336,19 +1306,8 @@ function bp_message_notice_delete_link() {
 	function bp_get_message_notice_delete_link() {
 		global $messages_template;
 
-		$message_slug        = bp_get_messages_slug();
-		$custom_message_slug = bp_rewrites_get_slug( 'members', 'member_' . $message_slug, $message_slug );
-		$url                 = wp_nonce_url(
-			bp_loggedin_user_url(
-				array(
-					'single_item_component'        => $custom_message_slug,
-					'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_notices', 'notices' ),
-					'single_item_action_variables' => array(
-						bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_notices_delete', 'delete' ),
-						$messages_template->thread->id,
-					),
-				)
-			),
+		$url = wp_nonce_url(
+			bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_messages_slug(), 'notices', array( 'delete', $messages_template->thread->id ) ) ) ),
 			'messages_delete_notice'
 		);
 
@@ -1378,28 +1337,17 @@ function bp_message_activate_deactivate_link() {
 	function bp_get_message_activate_deactivate_link() {
 		global $messages_template;
 
-		$message_slug        = bp_get_messages_slug();
-		$custom_message_slug = bp_rewrites_get_slug( 'members', 'member_' . $message_slug, $message_slug );
-		$path_chunks         = array(
-			'single_item_component' => $custom_message_slug,
-			'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_notices', 'notices' ),
-		);
+		$path_chunks = array( bp_get_messages_slug(), 'notices' );
 
 		if ( 1 === (int) $messages_template->thread->is_active ) {
-			$nonce                                       = 'messages_deactivate_notice';
-			$path_chunks['single_item_action_variables'] = array(
-				bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_notices_deactivate', 'deactivate' ),
-				$messages_template->thread->id,
-			);
+			$nonce         = 'messages_deactivate_notice';
+			$path_chunks[] = array( 'deactivate', $messages_template->thread->id );
 		} else {
-			$nonce                                       = 'messages_activate_notice';
-			$path_chunks['single_item_action_variables'] = array(
-				bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_notices_activate', 'activate' ),
-				$messages_template->thread->id,
-			);
+			$nonce         = 'messages_activate_notice';
+			$path_chunks[] = array( 'activate', $messages_template->thread->id );
 		}
 
-		$link = wp_nonce_url( bp_loggedin_user_url( $path_chunks ), $nonce );
+		$link = wp_nonce_url( bp_loggedin_user_url( bp_members_get_path_chunks( $path_chunks ) ), $nonce );
 
 		/**
 		 * Filters the URL for deactivating the current notice.
@@ -1458,16 +1406,8 @@ function bp_message_notice_dismiss_link() {
 	 * @return string URL for dismissing the current notice for the current user.
 	 */
 	function bp_get_message_notice_dismiss_link() {
-		$message_slug        = bp_get_messages_slug();
-		$custom_message_slug = bp_rewrites_get_slug( 'members', 'member_' . $message_slug, $message_slug );
-		$link                = wp_nonce_url(
-			bp_loggedin_user_url(
-				array(
-					'single_item_component'        => $custom_message_slug,
-					'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_notices', 'notices' ),
-					'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_notices_dismiss', 'dismiss' ) ),
-				)
-			),
+		$link = wp_nonce_url(
+			bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_messages_slug(), 'notices', array( 'dismiss' ) ) ) ),
 			'messages_dismiss_notice'
 		);
 
@@ -1556,19 +1496,11 @@ function bp_send_private_message_link() {
 			return false;
 		}
 
-		$message_slug        = bp_get_messages_slug();
-		$custom_message_slug = bp_rewrites_get_slug( 'members', 'member_' . $message_slug, $message_slug );
-		$url                 = wp_nonce_url(
+		$url = wp_nonce_url(
 			add_query_arg(
 				'r',
 				bp_members_get_user_slug( bp_displayed_user_id() ),
-				bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_message_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_compose', 'compose' ),
-					)
-				)
-
+				bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_messages_slug(), 'compose' ) ) )
 			)
 		);
 

--- a/src/bp-messages/classes/class-bp-messages-component.php
+++ b/src/bp-messages/classes/class-bp-messages-component.php
@@ -309,8 +309,7 @@ class BP_Messages_Component extends BP_Component {
 
 		// Menus for logged in user.
 		if ( is_user_logged_in() ) {
-			$message_slug        = bp_get_messages_slug();
-			$custom_message_slug = bp_rewrites_get_slug( 'members', 'member_' . $message_slug, $message_slug );
+			$message_slug = bp_get_messages_slug();
 
 			// Unread message count.
 			$count = messages_get_unread_count( bp_loggedin_user_id() );
@@ -335,11 +334,7 @@ class BP_Messages_Component extends BP_Component {
 				'parent' => buddypress()->my_account_menu_id,
 				'id'     => 'my-account-' . $this->id,
 				'title'  => $title,
-				'href'   => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_message_slug,
-					)
-				),
+				'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $message_slug ) ) ),
 			);
 
 			// Inbox.
@@ -347,28 +342,17 @@ class BP_Messages_Component extends BP_Component {
 				'parent'   => 'my-account-' . $this->id,
 				'id'       => 'my-account-' . $this->id . '-inbox',
 				'title'    => $inbox,
-				'href'     => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_message_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_inbox', 'inbox' ),
-					)
-				),
+				'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $message_slug, 'inbox' ) ) ),
 				'position' => 10,
 			);
 
 			// Starred.
 			if ( bp_is_active( $this->id, 'star' ) ) {
-				$star_slug      = bp_get_messages_starred_slug();
 				$wp_admin_nav[] = array(
 					'parent'   => 'my-account-' . $this->id,
 					'id'       => 'my-account-' . $this->id . '-starred',
 					'title'    => __( 'Starred', 'buddypress' ),
-					'href'     => bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_message_slug,
-							'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_' . $star_slug, $star_slug ),
-						)
-					),
+					'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $message_slug, bp_get_messages_starred_slug() ) ) ),
 					'position' => 11,
 				);
 			}
@@ -378,12 +362,7 @@ class BP_Messages_Component extends BP_Component {
 				'parent'   => 'my-account-' . $this->id,
 				'id'       => 'my-account-' . $this->id . '-sentbox',
 				'title'    => __( 'Sent', 'buddypress' ),
-				'href'     => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_message_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_sentbox', 'sentbox' ),
-					)
-				),
+				'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $message_slug, 'sentbox' ) ) ),
 				'position' => 20,
 			);
 
@@ -392,12 +371,7 @@ class BP_Messages_Component extends BP_Component {
 				'parent'   => 'my-account-' . $this->id,
 				'id'       => 'my-account-' . $this->id . '-compose',
 				'title'    => __( 'Compose', 'buddypress' ),
-				'href'     => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_message_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_compose', 'compose' ),
-					)
-				),
+				'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $message_slug, 'compose' ) ) ),
 				'position' => 30,
 			);
 
@@ -407,12 +381,7 @@ class BP_Messages_Component extends BP_Component {
 					'parent'   => 'my-account-' . $this->id,
 					'id'       => 'my-account-' . $this->id . '-notices',
 					'title'    => __( 'Site Notices', 'buddypress' ),
-					'href'     => bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_message_slug,
-							'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $message_slug . '_notices', 'notices' ),
-						)
-					),
+					'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $message_slug, 'notices' ) ) ),
 					'position' => 90,
 				);
 			}

--- a/src/bp-messages/screens/view.php
+++ b/src/bp-messages/screens/view.php
@@ -21,9 +21,7 @@ function messages_screen_conversation() {
 		return false;
 	}
 
-	$thread_id           = (int) bp_action_variable( 0 );
-	$message_slug        = bp_get_messages_slug();
-	$custom_message_slug = bp_rewrites_get_slug( 'members', 'member_' . $message_slug, $message_slug );
+	$thread_id = (int) bp_action_variable( 0 );
 
 	if ( empty( $thread_id ) || ! messages_is_valid_thread( $thread_id ) ) {
 		if ( is_user_logged_in() ) {
@@ -31,11 +29,7 @@ function messages_screen_conversation() {
 		}
 
 		bp_core_redirect(
-			bp_loggedin_user_url(
-				array(
-					'single_item_component' => $custom_message_slug,
-				)
-			)
+			bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_messages_slug() ) ) )
 		);
 	}
 
@@ -51,11 +45,7 @@ function messages_screen_conversation() {
 			bp_core_add_message( __( 'You do not have access to that conversation.', 'buddypress' ), 'error' );
 
 			bp_core_redirect(
-				bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_message_slug,
-					)
-				)
+				bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_messages_slug() ) ) )
 			);
 		}
 	}

--- a/src/bp-notifications/bp-notifications-adminbar.php
+++ b/src/bp-notifications/bp-notifications-adminbar.php
@@ -29,16 +29,10 @@ function bp_notifications_toolbar_menu() {
 	}
 
 	$notifications = bp_notifications_get_notifications_for_user( bp_loggedin_user_id(), 'object' );
-	$count         = ! empty( $notifications ) ? count( $notifications ) : 0;
-	$alert_class   = (int) $count > 0 ? 'pending-count alert' : 'count no-alert';
-	$menu_title    = '<span id="ab-pending-notifications" class="' . $alert_class . '">' . number_format_i18n( $count ) . '</span>';
-	$notifications_slug        = bp_get_notifications_slug();
-	$custom_notifications_slug = bp_rewrites_get_slug( 'members', 'member_' . $notifications_slug, $notifications_slug );
-	$menu_link                 = bp_loggedin_user_url(
-		array(
-			'single_item_component' => $custom_notifications_slug,
-		)
-	);
+	$count       = ! empty( $notifications ) ? count( $notifications ) : 0;
+	$alert_class = (int) $count > 0 ? 'pending-count alert' : 'count no-alert';
+	$menu_title  = '<span id="ab-pending-notifications" class="' . $alert_class . '">' . number_format_i18n( $count ) . '</span>';
+	$menu_link   = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_notifications_slug() ) ) );
 
 	// Add the top-level Notifications button.
 	$wp_admin_bar->add_node( array(

--- a/src/bp-notifications/bp-notifications-template.php
+++ b/src/bp-notifications/bp-notifications-template.php
@@ -64,9 +64,7 @@ function bp_notifications_permalink( $user_id = 0 ) {
 
 		$retval = bp_members_get_user_url(
 			$user_id,
-			array(
-				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_notifications', bp_get_notifications_slug() ),
-			)
+			bp_members_get_path_chunks( array( bp_get_notifications_slug() ) )
 		);
 
 		/**
@@ -107,10 +105,7 @@ function bp_notifications_unread_permalink( $user_id = 0 ) {
 
 		$retval = bp_members_get_user_url(
 			$user_id,
-			array(
-				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_notifications', bp_get_notifications_slug() ),
-				'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_notifications_unread', 'unread' ),
-			)
+			bp_members_get_path_chunks( array( bp_get_notifications_slug(), 'unread' ) )
 		);
 
 		/**
@@ -150,10 +145,7 @@ function bp_notifications_read_permalink( $user_id = 0 ) {
 
 		$retval = bp_members_get_user_url(
 			$user_id,
-			array(
-				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_notifications', bp_get_notifications_slug() ),
-				'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_notifications_read', 'read' ),
-			)
+			bp_members_get_path_chunks( array( bp_get_notifications_slug(), 'read' ) )
 		);
 
 		/**

--- a/src/bp-notifications/classes/class-bp-notifications-component.php
+++ b/src/bp-notifications/classes/class-bp-notifications-component.php
@@ -231,8 +231,7 @@ class BP_Notifications_Component extends BP_Component {
 
 		// Menus for logged in user.
 		if ( is_user_logged_in() ) {
-			$notifications_slug        = bp_get_notifications_slug();
-			$custom_notifications_slug = bp_rewrites_get_slug( 'members', 'member_' . $notifications_slug, $notifications_slug );
+			$notifications_slug = bp_get_notifications_slug();
 
 			// Pending notification requests.
 			$count = bp_notifications_get_unread_notification_count( bp_loggedin_user_id() );
@@ -257,11 +256,7 @@ class BP_Notifications_Component extends BP_Component {
 				'parent' => buddypress()->my_account_menu_id,
 				'id'     => 'my-account-' . $this->id,
 				'title'  => $title,
-				'href'   => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_notifications_slug,
-					)
-				),
+				'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $notifications_slug ) ) ),
 			);
 
 			// Unread.
@@ -269,12 +264,7 @@ class BP_Notifications_Component extends BP_Component {
 				'parent'   => 'my-account-' . $this->id,
 				'id'       => 'my-account-' . $this->id . '-unread',
 				'title'    => $unread,
-				'href'     => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_notifications_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $notifications_slug . '_unread', 'unread' ),
-					)
-				),
+				'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $notifications_slug, 'unread' ) ) ),
 				'position' => 10,
 			);
 
@@ -283,12 +273,7 @@ class BP_Notifications_Component extends BP_Component {
 				'parent'   => 'my-account-' . $this->id,
 				'id'       => 'my-account-' . $this->id . '-read',
 				'title'    => _x( 'Read', 'My Account Notification sub nav', 'buddypress' ),
-				'href'     => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_notifications_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $notifications_slug . '_read', 'read' ),
-					)
-				),
+				'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $notifications_slug, 'read' ) ) ),
 				'position' => 20,
 			);
 		}

--- a/src/bp-settings/actions/general.php
+++ b/src/bp-settings/actions/general.php
@@ -50,10 +50,7 @@ function bp_settings_action_general() {
 	$feedback_type = 'error';                // success|error
 	$feedback      = array();                // array of strings for feedback.
 	$user_id       = bp_displayed_user_id(); // The ID of the user being displayed.
-	$settings_slug = bp_get_settings_slug();
-	$path_chunks   = array(
-		'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug, $settings_slug ),
-	);
+	$path_chunks   = array( bp_get_settings_slug() );
 
 	// Nonce check.
 	check_admin_referer( 'bp_settings_general' );
@@ -234,8 +231,8 @@ function bp_settings_action_general() {
 	}
 
 	// Set the URL to redirect the user to.
-	$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'members', 'member_' . $settings_slug . '_general', 'general' );
-	$redirect_to = bp_displayed_user_url( $path_chunks );
+	$path_chunks[] = 'general';
+	$redirect_to   = bp_displayed_user_url( bp_members_get_path_chunks( $path_chunks ) );
 
 	/**
 	 * Fires after the general settings have been saved, and before redirect.
@@ -270,11 +267,7 @@ function bp_settings_verify_email_change() {
 		return;
 	}
 
-	$settings_slug = bp_get_settings_slug();
-	$path_chunks   = array(
-		'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug, $settings_slug )
-	);
-	$redirect_to = bp_displayed_user_url( $path_chunks );
+	$redirect_to = bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_settings_slug() ) ) );
 
 	// Email change is being verified.
 	if ( isset( $_GET['verify_email_change'] ) ) {

--- a/src/bp-settings/actions/notifications.php
+++ b/src/bp-settings/actions/notifications.php
@@ -53,12 +53,8 @@ function bp_settings_action_notifications() {
 	 */
 	do_action( 'bp_core_notification_settings_after_save' );
 
-	$settings_slug = bp_get_settings_slug();
-	$path_chunks   = array(
-		'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug, $settings_slug ),
-		'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug . '_notifications', 'notifications' ),
+	bp_core_redirect(
+		bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_settings_slug(), 'notifications' ) ) )
 	);
-
-	bp_core_redirect( bp_displayed_user_url( $path_chunks ) );
 }
 add_action( 'bp_actions', 'bp_settings_action_notifications' );

--- a/src/bp-settings/bp-settings-template.php
+++ b/src/bp-settings/bp-settings-template.php
@@ -80,15 +80,12 @@ function bp_settings_pending_email_notice() {
 		return;
 	}
 
-	$settings_slug = bp_get_settings_slug();
-	$dismiss_url   = wp_nonce_url(
+	$dismiss_url = wp_nonce_url(
 		add_query_arg(
 			'dismiss_email_change',
 			1,
 			bp_displayed_user_url(
-				array(
-					'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug, $settings_slug ),
-				)
+				bp_members_get_path_chunks( array( bp_get_settings_slug() ) )
 			)
 		),
 		'bp_dismiss_email_change'

--- a/src/bp-settings/classes/class-bp-settings-component.php
+++ b/src/bp-settings/classes/class-bp-settings-component.php
@@ -239,19 +239,14 @@ class BP_Settings_Component extends BP_Component {
 
 		// Menus for logged in user.
 		if ( is_user_logged_in() ) {
-			$settings_slug        = bp_get_settings_slug();
-			$custom_settings_slug = bp_rewrites_get_slug( 'members', 'member_' . $settings_slug, $settings_slug );
+			$settings_slug = bp_get_settings_slug();
 
 			// Add main Settings menu.
 			$wp_admin_nav[] = array(
 				'parent' => buddypress()->my_account_menu_id,
 				'id'     => 'my-account-' . $this->id,
 				'title'  => __( 'Settings', 'buddypress' ),
-				'href'   => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_settings_slug,
-					)
-				),
+				'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $settings_slug ) ) ),
 			);
 
 			// General Account.
@@ -259,12 +254,7 @@ class BP_Settings_Component extends BP_Component {
 				'parent'   => 'my-account-' . $this->id,
 				'id'       => 'my-account-' . $this->id . '-general',
 				'title'    => __( 'General', 'buddypress' ),
-				'href'     => bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_settings_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug . '_general', 'general' ),
-					)
-				),
+				'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $settings_slug, 'general' ) ) ),
 				'position' => 10,
 			);
 
@@ -274,12 +264,7 @@ class BP_Settings_Component extends BP_Component {
 					'parent'   => 'my-account-' . $this->id,
 					'id'       => 'my-account-' . $this->id . '-notifications',
 					'title'    => __( 'Email', 'buddypress' ),
-					'href'     => bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_settings_slug,
-							'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug . '_notifications', 'notifications' ),
-						)
-					),
+					'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $settings_slug, 'notifications' ) ) ),
 					'position' => 20,
 				);
 			}
@@ -293,28 +278,18 @@ class BP_Settings_Component extends BP_Component {
 					'parent'   => 'my-account-' . $this->id,
 					'id'       => 'my-account-' . $this->id . '-data',
 					'title'    => __( 'Export Data', 'buddypress' ),
-					'href'     => bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_settings_slug,
-							'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug . '_data', 'data' ),
-						)
-					),
+					'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $settings_slug, 'data' ) ) ),
 					'position' => 89,
 				);
 			}
 
 			// Delete Account
-			if ( !bp_current_user_can( 'bp_moderate' ) && ! bp_core_get_root_option( 'bp-disable-account-deletion' ) ) {
+			if ( ! bp_current_user_can( 'bp_moderate' ) && ! bp_core_get_root_option( 'bp-disable-account-deletion' ) ) {
 				$wp_admin_nav[] = array(
 					'parent'   => 'my-account-' . $this->id,
 					'id'       => 'my-account-' . $this->id . '-delete-account',
 					'title'    => __( 'Delete Account', 'buddypress' ),
-					'href'     => bp_loggedin_user_url(
-						array(
-							'single_item_component' => $custom_settings_slug,
-							'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug . '_delete_account', 'delete-account' ),
-						)
-					),
+					'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $settings_slug, 'delete-account' ) ) ),
 					'position' => 90,
 				);
 			}

--- a/src/bp-templates/bp-legacy/buddypress-functions.php
+++ b/src/bp-templates/bp-legacy/buddypress-functions.php
@@ -914,46 +914,19 @@ function bp_legacy_theme_activity_template_loader() {
 		$scope = $_POST['scope'];
 	}
 
-	$activity_slug        = bp_get_activity_slug();
-	$custom_activity_slug = bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug );
-
 	// We need to calculate and return the feed URL for each scope.
 	switch ( $scope ) {
 		case 'friends':
-			$feed_url = bp_loggedin_user_url(
-				array(
-					'single_item_component'        => $custom_activity_slug,
-					'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_friends', 'friends' ),
-					'single_item_action_variables' => array( 'feed' ),
-				)
-			);
+			$feed_url = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_activity_slug(), 'friends', array( 'feed' ) ) ) );
 			break;
 		case 'groups':
-			$feed_url = bp_loggedin_user_url(
-				array(
-					'single_item_component'        => $custom_activity_slug,
-					'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_groups', 'groups' ),
-					'single_item_action_variables' => array( 'feed' ),
-				)
-			);
+			$feed_url = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_activity_slug(), 'groups', array( 'feed' ) ) ) );
 			break;
 		case 'favorites':
-			$feed_url = bp_loggedin_user_url(
-				array(
-					'single_item_component'        => $custom_activity_slug,
-					'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_favorites', 'favorites' ),
-					'single_item_action_variables' => array( 'feed' ),
-				)
-			);
+			$feed_url = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_activity_slug(), 'favorites', array( 'feed' ) ) ) );
 			break;
 		case 'mentions':
-			$feed_url = bp_loggedin_user_url(
-				array(
-					'single_item_component'        => $custom_activity_slug,
-					'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_mentions', 'mentions' ),
-					'single_item_action_variables' => array( 'feed' ),
-				)
-			);
+			$feed_url = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_activity_slug(), 'mentions', array( 'feed' ) ) ) );
 
 			if ( isset( $_POST['_wpnonce_activity_filter'] ) && wp_verify_nonce( wp_unslash( $_POST['_wpnonce_activity_filter'] ), 'activity_filter' ) ) {
 				bp_activity_clear_new_mentions( bp_loggedin_user_id() );
@@ -1491,9 +1464,6 @@ function bp_legacy_theme_ajax_addremove_friend() {
 		die( __( 'No member found by that ID.', 'buddypress' ) );
 	}
 
-	$friends_slug        = bp_get_friends_slug();
-	$custom_friends_slug = bp_rewrites_get_slug( 'members', 'member_' . $friends_slug, $friends_slug );
-
 	// Trying to cancel friendship.
 	if ( 'is_friend' == BP_Friends_Friendship::check_is_friend( bp_loggedin_user_id(), $friend_id ) ) {
 		check_ajax_referer( 'friends_remove_friend' );
@@ -1501,13 +1471,7 @@ function bp_legacy_theme_ajax_addremove_friend() {
 		if ( ! friends_remove_friend( bp_loggedin_user_id(), $friend_id ) ) {
 			echo __( 'Friendship could not be canceled.', 'buddypress' );
 		} else {
-			$url = bp_loggedin_user_url(
-				array(
-					'single_item_component'        => $custom_friends_slug,
-					'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_add_friend', 'add-friend' ),
-					'single_item_action_variables' => array( $friend_id ),
-				)
-			);
+			$url = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_friends_slug(), 'add-friend', array( $friend_id ) ) ) );
 			echo '<a id="friend-' . esc_attr( $friend_id ) . '" class="friendship-button not_friends add" rel="add" href="' . wp_nonce_url( $url, 'friends_add_friend' ) . '">' . __( 'Add Friend', 'buddypress' ) . '</a>';
 		}
 
@@ -1518,16 +1482,7 @@ function bp_legacy_theme_ajax_addremove_friend() {
 		if ( ! friends_add_friend( bp_loggedin_user_id(), $friend_id ) ) {
 			echo __(' Friendship could not be requested.', 'buddypress' );
 		} else {
-			$url = bp_loggedin_user_url(
-				array(
-					'single_item_component'        => $custom_friends_slug,
-					'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_requests', 'requests' ),
-					'single_item_action_variables' => array(
-						bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_requests_cancel', 'cancel' ),
-						$friend_id,
-					),
-				)
-			);
+			$url = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_friends_slug(), 'requests', array( 'cancel', $friend_id ) ) ) );
 			echo '<a id="friend-' . esc_attr( $friend_id ) . '" class="remove friendship-button pending_friend requested" rel="remove" href="' . wp_nonce_url( $url, 'friends_withdraw_friendship' ) . '" class="requested">' . __( 'Cancel Friendship Request', 'buddypress' ) . '</a>';
 		}
 
@@ -1536,15 +1491,7 @@ function bp_legacy_theme_ajax_addremove_friend() {
 		check_ajax_referer( 'friends_withdraw_friendship' );
 
 		if ( friends_withdraw_friendship( bp_loggedin_user_id(), $friend_id ) ) {
-			$url = bp_loggedin_user_url(
-				array(
-					'single_item_component'        => $custom_friends_slug,
-					'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_add_friend', 'add-friend' ),
-					'single_item_action_variables' => array(
-						$friend_id,
-					),
-				)
-			);
+			$url = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_friends_slug(), 'add-friend', array( $friend_id ) ) ) );
 			echo '<a id="friend-' . esc_attr( $friend_id ) . '" class="friendship-button not_friends add" rel="add" href="' . wp_nonce_url( $url, 'friends_add_friend' ) . '">' . __( 'Add Friend', 'buddypress' ) . '</a>';
 		} else {
 			echo __("Friendship request could not be cancelled.", 'buddypress');

--- a/src/bp-templates/bp-nouveau/includes/activity/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/ajax.php
@@ -114,14 +114,7 @@ function bp_nouveau_ajax_mark_activity_favorite() {
 			$fav_count = (int) bp_get_total_favorite_count_for_user( bp_loggedin_user_id() );
 
 			if ( 1 === $fav_count ) {
-				$activity_slug          = bp_nouveau_get_component_slug( 'activity' );
-				$custom_activity_slug   = bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug );
-				$activity_favorites_url = bp_loggedin_user_url(
-					array(
-						'single_item_component' => $custom_activity_slug,
-						'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_favorites', 'favorites' ),
-					)
-				);
+				$activity_favorites_url = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_nouveau_get_component_slug( 'activity' ), 'favorites' ) ) );
 
 				$response['directory_tab'] = '<li id="activity-favorites" data-bp-scope="favorites" data-bp-object="activity">
 					<a href="' . esc_url( $activity_favorites_url ). '">

--- a/src/bp-templates/bp-nouveau/includes/activity/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/functions.php
@@ -219,20 +219,15 @@ function bp_nouveau_get_activity_directory_nav_items() {
 				array( 'bp_before_activity_type_tab_favorites', 'activity', 26 ),
 			)
 		);
-		$activity_slug = bp_nouveau_get_component_slug( 'activity' );
-		$path_chunks   = array(
-			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug ),
-		);
+		$activity_slug    = bp_nouveau_get_component_slug( 'activity' );
 
 		// If the user has favorite create a nav item
 		if ( bp_get_total_favorite_count_for_user( bp_loggedin_user_id() ) ) {
-			$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_favorites', 'favorites' );
-
 			$nav_items['favorites'] = array(
 				'component' => 'activity',
 				'slug'      => 'favorites', // slug is used because BP_Core_Nav requires it, but it's the scope
 				'li_class'  => array(),
-				'link'      => bp_loggedin_user_url( $path_chunks ),
+				'link'      => bp_loggedin_user_url( bp_members_get_path_chunks( array( $activity_slug, 'favorites' ) ) ),
 				'text'      => __( 'My Favorites', 'buddypress' ),
 				'count'     => false,
 				'position'  => 35,
@@ -241,14 +236,11 @@ function bp_nouveau_get_activity_directory_nav_items() {
 
 		// The friends component is active and user has friends
 		if ( bp_is_active( 'friends' ) && bp_get_total_friend_count( bp_loggedin_user_id() ) ) {
-			$friends_slug                      = bp_nouveau_get_component_slug( 'friends' );
-			$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_' . $friends_slug, $friends_slug );
-
 			$nav_items['friends'] = array(
 				'component' => 'activity',
 				'slug'      => 'friends', // slug is used because BP_Core_Nav requires it, but it's the scope
 				'li_class'  => array( 'dynamic' ),
-				'link'      =>  bp_loggedin_user_url( $path_chunks ),
+				'link'      =>  bp_loggedin_user_url( bp_members_get_path_chunks( array( $activity_slug, bp_nouveau_get_component_slug( 'friends' ) ) ) ),
 				'text'      => __( 'My Friends', 'buddypress' ),
 				'count'     => '',
 				'position'  => 15,
@@ -257,14 +249,11 @@ function bp_nouveau_get_activity_directory_nav_items() {
 
 		// The groups component is active and user has groups
 		if ( bp_is_active( 'groups' ) && bp_get_total_group_count_for_user( bp_loggedin_user_id() ) ) {
-			$groups_slug                       = bp_nouveau_get_component_slug( 'groups' );
-			$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_' . $groups_slug, $groups_slug );
-
 			$nav_items['groups'] = array(
 				'component' => 'activity',
 				'slug'      => 'groups', // slug is used because BP_Core_Nav requires it, but it's the scope
 				'li_class'  => array( 'dynamic' ),
-				'link'      => bp_loggedin_user_url( $path_chunks ),
+				'link'      => bp_loggedin_user_url( bp_members_get_path_chunks( array( $activity_slug, bp_nouveau_get_component_slug( 'groups' ) ) ) ),
 				'text'      => __( 'My Groups', 'buddypress' ),
 				'count'     => '',
 				'position'  => 25,
@@ -273,10 +262,9 @@ function bp_nouveau_get_activity_directory_nav_items() {
 
 		// Mentions are allowed
 		if ( bp_activity_do_mentions() ) {
-			$deprecated_hooks[]                = array( 'bp_before_activity_type_tab_mentions', 'activity', 36 );
-			$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_mentions', 'mentions' );
+			$deprecated_hooks[] = array( 'bp_before_activity_type_tab_mentions', 'activity', 36 );
+			$count              = '';
 
-			$count = '';
 			if ( bp_get_total_mention_count_for_user( bp_loggedin_user_id() ) ) {
 				$count = bp_get_total_mention_count_for_user( bp_loggedin_user_id() );
 			}
@@ -285,7 +273,7 @@ function bp_nouveau_get_activity_directory_nav_items() {
 				'component' => 'activity',
 				'slug'      => 'mentions', // slug is used because BP_Core_Nav requires it, but it's the scope
 				'li_class'  => array( 'dynamic' ),
-				'link'      => bp_loggedin_user_url( $path_chunks ),
+				'link'      => bp_loggedin_user_url( bp_members_get_path_chunks( array( $activity_slug, 'mentions' ) ) ),
 				'text'      => __( 'Mentions', 'buddypress' ),
 				'count'     => $count,
 				'position'  => 45,

--- a/src/bp-templates/bp-nouveau/includes/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/ajax.php
@@ -53,46 +53,19 @@ function bp_nouveau_ajax_object_template_loader() {
 			$scope = sanitize_text_field( $post_vars['scope'] );
 		}
 
-		$activity_slug        = bp_nouveau_get_component_slug( 'activity' );
-		$custom_activity_slug = bp_rewrites_get_slug( 'members', 'member_' . $activity_slug, $activity_slug );
-
 		// We need to calculate and return the feed URL for each scope.
 		switch ( $scope ) {
 			case 'friends':
-				$feed_url = bp_loggedin_user_url(
-					array(
-						'single_item_component'        => $custom_activity_slug,
-						'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_friends', 'friends' ),
-						'single_item_action_variables' => array( 'feed' ),
-					)
-				);
+				$feed_url = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_nouveau_get_component_slug( 'activity' ), 'friends', array( 'feed' ) ) ) );
 				break;
 			case 'groups':
-				$feed_url = bp_loggedin_user_url(
-					array(
-						'single_item_component'        => $custom_activity_slug,
-						'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_groups', 'groups' ),
-						'single_item_action_variables' => array( 'feed' ),
-					)
-				);
+				$feed_url = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_nouveau_get_component_slug( 'activity' ), 'groups', array( 'feed' ) ) ) );
 				break;
 			case 'favorites':
-				$feed_url = bp_loggedin_user_url(
-					array(
-						'single_item_component'        => $custom_activity_slug,
-						'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_favorites', 'favorites' ),
-						'single_item_action_variables' => array( 'feed' ),
-					)
-				);
+				$feed_url = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_nouveau_get_component_slug( 'activity' ), 'favorites', array( 'feed' ) ) ) );
 				break;
 			case 'mentions':
-				$feed_url = bp_loggedin_user_url(
-					array(
-						'single_item_component'        => $custom_activity_slug,
-						'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $activity_slug . '_mentions', 'mentions' ),
-						'single_item_action_variables' => array( 'feed' ),
-					)
-				);
+				$feed_url = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_nouveau_get_component_slug( 'activity' ), 'mentions', array( 'feed' ) ) ) );
 
 				// Get user new mentions
 				$new_mentions = bp_get_user_meta( bp_loggedin_user_id(), 'bp_new_mentions', true );

--- a/src/bp-templates/bp-nouveau/includes/blogs/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/blogs/functions.php
@@ -27,10 +27,6 @@ function bp_nouveau_get_blogs_directory_nav_items() {
 
 	if ( is_user_logged_in() ) {
 		$my_blogs_count = bp_get_total_blog_count_for_user( bp_loggedin_user_id() );
-		$blogs_slug     = bp_nouveau_get_component_slug( 'blogs' );
-		$path_chunks    = array(
-			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $blogs_slug, $blogs_slug ),
-		);
 
 		// If the user has blogs create a nav item
 		if ( $my_blogs_count ) {
@@ -38,7 +34,7 @@ function bp_nouveau_get_blogs_directory_nav_items() {
 				'component' => 'blogs',
 				'slug'      => 'personal', // slug is used because BP_Core_Nav requires it, but it's the scope
 				'li_class'  => array(),
-				'link'      => bp_loggedin_user_url( $path_chunks ),
+				'link'      => bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_nouveau_get_component_slug( 'blogs' ) ) ) ),
 				'text'      => __( 'My Sites', 'buddypress' ),
 				'count'     => $my_blogs_count,
 				'position'  => 15,

--- a/src/bp-templates/bp-nouveau/includes/groups/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/functions.php
@@ -463,12 +463,7 @@ function bp_nouveau_groups_invites_restriction_admin_nav( $wp_admin_nav ) {
 		'parent' => 'my-account-' . buddypress()->settings->id,
 		'id'     => 'my-account-' . buddypress()->settings->id . '-invites',
 		'title'  => _x( 'Group Invites', 'Group invitations main menu title', 'buddypress' ),
-		'href'   => bp_loggedin_user_url(
-			array(
-				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug, $settings_slug ),
-				'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug . '_invites', 'invites' ),
-			)
-		),
+		'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $settings_slug, 'invites' ) ) ),
 	);
 
 	return $wp_admin_nav;
@@ -567,20 +562,14 @@ function bp_nouveau_get_groups_directory_nav_items() {
 
 	if ( is_user_logged_in() ) {
 		$my_groups_count = bp_get_total_group_count_for_user( bp_loggedin_user_id() );
-		$groups_slug     = bp_nouveau_get_component_slug( 'groups' );
-		$path_chunks     = array(
-			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $groups_slug, $groups_slug ),
-		);
 
 		// If the user has groups create a nav item
 		if ( $my_groups_count ) {
-			$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'members', 'member_' . $groups_slug . '_my_groups', 'my-groups' );
-
 			$nav_items['personal'] = array(
 				'component' => 'groups',
 				'slug'      => 'personal', // slug is used because BP_Core_Nav requires it, but it's the scope
 				'li_class'  => array(),
-				'link'      => bp_loggedin_user_url( $path_chunks ),
+				'link'      => bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_nouveau_get_component_slug( 'groups' ), 'my-groups' ) ) ),
 				'text'      => __( 'My Groups', 'buddypress' ),
 				'count'     => $my_groups_count,
 				'position'  => 15,

--- a/src/bp-templates/bp-nouveau/includes/members/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/members/functions.php
@@ -77,17 +77,11 @@ function bp_nouveau_get_members_directory_nav_items() {
 	if ( is_user_logged_in() ) {
 		// If friends component is active and the user has friends
 		if ( bp_is_active( 'friends' ) && bp_get_total_friend_count( bp_loggedin_user_id() ) ) {
-			$friends_slug = bp_nouveau_get_component_slug( 'friends' );
-			$path_chunks   = array(
-				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug, $friends_slug ),
-				'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $friends_slug . '_my_friends', 'my-friends' ),
-			);
-
 			$nav_items['personal'] = array(
 				'component' => 'members',
 				'slug'      => 'personal', // slug is used because BP_Core_Nav requires it, but it's the scope
 				'li_class'  => array(),
-				'link'      => bp_loggedin_user_url( $path_chunks ),
+				'link'      => bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_nouveau_get_component_slug( 'friends' ), 'my-friends' ) ) ),
 				'text'      => __( 'My Friends', 'buddypress' ),
 				'count'     => bp_get_total_friend_count( bp_loggedin_user_id() ),
 				'position'  => 15,

--- a/src/bp-xprofile/bp-xprofile-activity.php
+++ b/src/bp-xprofile/bp-xprofile-activity.php
@@ -57,9 +57,7 @@ function bp_xprofile_format_activity_action_updated_profile( $action, $activity 
 	 */
 	$profile_link = bp_members_get_user_url(
 		$activity->user_id,
-		array(
-			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_profile', bp_get_profile_slug() ),
-		)
+		bp_members_get_path_chunks( array( bp_get_profile_slug() ) )
 	);
 
 	/* translators: %s: user profile link */
@@ -254,9 +252,7 @@ function bp_xprofile_updated_profile_activity( $user_id, $field_ids = array(), $
 	// If we've reached this point, assemble and post the activity item.
 	$profile_link = bp_members_get_user_url(
 		$user_id,
-		array(
-			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_profile', bp_get_profile_slug() ),
-		)
+		bp_members_get_path_chunks( array( bp_get_profile_slug() ) )
 	);
 
 	return (bool) xprofile_record_activity( array(

--- a/src/bp-xprofile/bp-xprofile-template.php
+++ b/src/bp-xprofile/bp-xprofile-template.php
@@ -407,13 +407,7 @@ function bp_the_profile_group_edit_form_action() {
 		global $group;
 
 		// Build the form action URL.
-		$profile_slug = bp_get_profile_slug();
-		$path_chunks  = array(
-			'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug, $profile_slug ),
-			'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit', 'edit' ),
-			'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit_group', 'group' ), $group->id ),
-		);
-		$form_action = bp_displayed_user_url( $path_chunks );
+		$form_action = bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_profile_slug(), 'edit', array( 'group', $group->id ) ) ) );
 
 		/**
 		 * Filters the action for the XProfile group edit form.
@@ -1128,13 +1122,7 @@ function bp_get_profile_group_tabs() {
 		}
 
 		// Build the profile field group link.
-		$profile_slug = bp_get_profile_slug();
-		$path_chunks  = array(
-			'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug, $profile_slug ),
-			'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit', 'edit' ),
-			'single_item_action_variables' => array( bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit_group', 'group' ), $groups[ $i ]->id ),
-		);
-		$link         = bp_displayed_user_url( $path_chunks );
+		$link = bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_profile_slug(), 'edit', array( 'group', $groups[ $i ]->id ) ) ) );
 
 		// Add tab to end of tabs array.
 		$tabs[] = sprintf(
@@ -1292,18 +1280,12 @@ function bp_current_profile_group_id() {
  * @since 1.0.0
  */
 function bp_edit_profile_button() {
-	$profile_slug = bp_get_profile_slug();
-	$path_chunks  = array(
-		'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug, $profile_slug ),
-		'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit', 'edit' ),
-	);
-
 	bp_button( array(
 		'id'                => 'edit_profile',
 		'component'         => 'xprofile',
 		'must_be_logged_in' => true,
 		'block_self'        => true,
-		'link_href'         => bp_displayed_user_url( $path_chunks ),
+		'link_href'         => bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_profile_slug(), 'edit' ) ) ),
 		'link_class'        => 'edit',
 		'link_text'         => __( 'Edit Profile', 'buddypress' ),
 	) );

--- a/src/bp-xprofile/classes/class-bp-xprofile-component.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-component.php
@@ -288,37 +288,30 @@ class BP_XProfile_Component extends BP_Component {
 		// Menus for logged in user.
 		if ( is_user_logged_in() ) {
 			$profile_slug = bp_get_profile_slug();
-			$path_chunks  = array(
-				'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug, $profile_slug ),
-			);
 
 			// Add the "Profile" sub menu.
 			$wp_admin_nav[] = array(
 				'parent' => buddypress()->my_account_menu_id,
 				'id'     => 'my-account-' . $this->id,
 				'title'  => _x( 'Profile', 'My Account Profile', 'buddypress' ),
-				'href'   => bp_loggedin_user_url( $path_chunks ),
+				'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $profile_slug ) ) ),
 			);
-
-			$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_public', 'public' );
 
 			// View Profile.
 			$wp_admin_nav[] = array(
 				'parent'   => 'my-account-' . $this->id,
 				'id'       => 'my-account-' . $this->id . '-public',
 				'title'    => _x( 'View', 'My Account Profile sub nav', 'buddypress' ),
-				'href'     => bp_loggedin_user_url( $path_chunks ),
+				'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $profile_slug, 'public' ) ) ),
 				'position' => 10,
 			);
-
-			$path_chunks['single_item_action'] = bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit', 'edit' );
 
 			// Edit Profile.
 			$wp_admin_nav[] = array(
 				'parent'   => 'my-account-' . $this->id,
 				'id'       => 'my-account-' . $this->id . '-edit',
 				'title'    => _x( 'Edit', 'My Account Profile sub nav', 'buddypress' ),
-				'href'     => bp_loggedin_user_url( $path_chunks ),
+				'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $profile_slug, 'edit' ) ) ),
 				'position' => 20,
 			);
 		}
@@ -391,20 +384,12 @@ class BP_XProfile_Component extends BP_Component {
 	 * @return array
 	 */
 	public function setup_settings_admin_nav( $wp_admin_nav ) {
-
-		// Setup the logged in user variables.
-		$settings_slug = bp_get_settings_slug();
-		$path_chunks   = array(
-			'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug, $settings_slug ),
-			'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug . '_profile', 'profile' ),
-		);
-
 		// Add the "Profile" subnav item.
 		$wp_admin_nav[] = array(
 			'parent' => 'my-account-' . buddypress()->settings->id,
 			'id'     => 'my-account-' . buddypress()->settings->id . '-profile',
 			'title'  => _x( 'Profile', 'My Account Settings sub nav', 'buddypress' ),
-			'href'   => bp_loggedin_user_url( $path_chunks ),
+			'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_settings_slug(), 'profile' ) ) ),
 		);
 
 		return $wp_admin_nav;

--- a/src/bp-xprofile/screens/edit.php
+++ b/src/bp-xprofile/screens/edit.php
@@ -20,17 +20,11 @@ function xprofile_screen_edit_profile() {
 		return false;
 	}
 
-	$profile_slug = bp_get_profile_slug();
-	$path_chunks  = array(
-		'single_item_component' => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug, $profile_slug ),
-		'single_item_action'    => bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit', 'edit' ),
-	);
-
-
 	// Make sure a group is set.
 	if ( ! bp_action_variable( 1 ) ) {
-		$path_chunks['single_item_action_variables'] = array( bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit_group', 'group' ), 1 );
-		bp_core_redirect( bp_displayed_user_url( $path_chunks ) );
+		bp_core_redirect(
+			bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_profile_slug(), 'edit', array( 'group', 1 ) ) ) )
+		);
 	}
 
 	// Check the field group exists.
@@ -40,7 +34,8 @@ function xprofile_screen_edit_profile() {
 	}
 
 	// No errors.
-	$errors = false;
+	$errors      = false;
+	$path_chunks = array( bp_get_profile_slug(), 'edit' );
 
 	// Check to see if any new information has been submitted.
 	if ( isset( $_POST['field_ids'] ) ) {
@@ -50,8 +45,8 @@ function xprofile_screen_edit_profile() {
 
 		// Check we have field ID's.
 		if ( empty( $_POST['field_ids'] ) ) {
-			$path_chunks['single_item_action_variables'] = array( bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit_group', 'group' ), bp_action_variable( 1 ) );
-			bp_core_redirect( bp_displayed_user_url( $path_chunks ) );
+			$path_chunks[] = array( 'group', bp_action_variable( 1 ) );
+			bp_core_redirect( bp_displayed_user_url( bp_members_get_path_chunks( $path_chunks ) ) );
 		}
 
 		// Explode the posted field IDs into an array so we know which
@@ -164,8 +159,8 @@ function xprofile_screen_edit_profile() {
 			}
 
 			// Redirect back to the edit screen to display the updates and message.
-			$path_chunks['single_item_action_variables'] = array( bp_rewrites_get_slug( 'members', 'member_' . $profile_slug . '_edit_group', 'group' ), bp_action_variable( 1 ) );
-			bp_core_redirect( bp_displayed_user_url( $path_chunks ) );
+			$path_chunks[] = array( 'group', bp_action_variable( 1 ) );
+			bp_core_redirect( bp_displayed_user_url( bp_members_get_path_chunks( $path_chunks ) ) );
 		}
 	}
 

--- a/src/bp-xprofile/screens/settings-profile.php
+++ b/src/bp-xprofile/screens/settings-profile.php
@@ -109,12 +109,9 @@ function bp_xprofile_action_settings() {
 	 */
 	do_action( 'bp_xprofile_settings_after_save' );
 
-	// Redirect to the root domain.
-	$settings_slug = bp_get_settings_slug();
-	$path_chunks   = array(
-		'single_item_component'        => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug, $settings_slug ),
-		'single_item_action'           => bp_rewrites_get_slug( 'members', 'member_' . $settings_slug . '_profile', 'profile' ),
+	// Redirect to the User's profile settings.
+	bp_core_redirect(
+		bp_displayed_user_url( bp_members_get_path_chunks( array( bp_get_settings_slug(), 'profile' ) ) )
 	);
-	bp_core_redirect( bp_displayed_user_url( $path_chunks ) );
 }
 add_action( 'bp_actions', 'bp_xprofile_action_settings' );

--- a/tests/phpunit/testcases/groups/template.php
+++ b/tests/phpunit/testcases/groups/template.php
@@ -1005,7 +1005,7 @@ class BP_Tests_Groups_Template extends BP_UnitTestCase {
 	 */
 	public function test_bp_bp_get_group_form_action() {
 		$g   = $this->factory->group->create();
-		$p   = 2;
+		$p   = 'members';
 		$url = bp_get_group_url(
 			$g,
 			array(


### PR DESCRIPTION
BP Rewrites: Optimizing code to build URLs

Use less  the `bp_rewrites_get_slug()` function and more the `bp_members_get_path_chunks()` & `bp_groups_get_path_chunks()` ones

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8923

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
