### PR TITLE
Remove more never used inited variables in various functions

### DIFF
--- a/src/bp-core/classes/class-bp-block.php
+++ b/src/bp-core/classes/class-bp-block.php
@@ -284,7 +284,7 @@ class BP_Block {
 					$translation_domain = apply_filters( 'bp_block_translation_domain', $textdomain, $this->block->editor_script, $name );
 
 					// Try to load the translation.
-					$translated = wp_set_script_translations( $this->block->editor_script, $translation_domain, $translation_dir );
+					wp_set_script_translations( $this->block->editor_script, $translation_domain, $translation_dir );
 				}
 			}
 		}

--- a/src/bp-core/classes/class-bp-core-bp-options-nav-backcompat.php
+++ b/src/bp-core/classes/class-bp-core-bp-options-nav-backcompat.php
@@ -124,11 +124,11 @@ class BP_Core_BP_Options_Nav_BackCompat extends BP_Core_BP_Nav_BackCompat {
 
 			$nav = array();
 
-			if ( empty( $primary_nav ) ) {
+			if ( empty( $secondary_nav ) ) {
 				return $nav;
 			}
 
-			foreach ( $primary_nav as $item ) {
+			foreach ( $secondary_nav as $item ) {
 				$nav[ $item->slug ] = (array) $item;
 			}
 		}

--- a/src/bp-messages/bp-messages-notifications.php
+++ b/src/bp-messages/bp-messages-notifications.php
@@ -27,7 +27,6 @@ function messages_format_notifications( $action, $item_id, $secondary_item_id, $
 	$total_items = (int) $total_items;
 	$text        = '';
 	$link        = bp_loggedin_user_url( bp_members_get_path_chunks( array( bp_get_messages_slug(), 'inbox' ) ) );
-	$title       = __( 'Inbox', 'buddypress' );
 	$amount      = 'single';
 
 	if ( 'new_message' === $action ) {

--- a/src/bp-templates/bp-nouveau/includes/activity/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/template-tags.php
@@ -3,7 +3,7 @@
  * Activity Template tags
  *
  * @since 3.0.0
- * @version 10.0.0
+ * @version 12.0.0
  */
 
 // Exit if accessed directly.
@@ -551,14 +551,6 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 			} else {
 				$data_element = 'href';
 			}
-
-			$spam_link = bp_rewrites_get_url(
-				array(
-					'component_id'                 => 'activity',
-					'single_item_action'           => 'spam',
-					'single_item_action_variables' => array( bp_get_activity_id() ),
-				)
-			);
 
 			$buttons['activity_spam']['button_attr'][ $data_element ] = wp_nonce_url(
 				bp_rewrites_get_url(

--- a/src/bp-templates/bp-nouveau/includes/blogs/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/blogs/template-tags.php
@@ -3,7 +3,7 @@
  * Blogs Template tags
  *
  * @since 3.0.0
- * @version 6.0.0
+ * @version 12.0.0
  */
 
 // Exit if accessed directly.
@@ -183,23 +183,13 @@ function bp_nouveau_blogs_loop_buttons( $args = array() ) {
 			$parent_element = false;
 		}
 
-		/*
-		 * If we have a arg value for $button_element passed through
-		 * use it to default all the $buttons['button_element'] values
-		 * otherwise default to 'a' (anchor)
-		 * Or override & hardcode the 'element' string on $buttons array.
-		 *
-		 * Icons sets a class for icon display if not using the button element
-		 */
-		$icons = '';
 		if ( ! empty( $args['button_element'] ) ) {
 			$button_element = $args['button_element'] ;
 		} else {
 			$button_element = 'a';
-			$icons = ' icons';
 		}
 
-		// If we pass through parent classes add them to $button array
+		// If we pass through parent classes add them to `$button` array.
 		$parent_class = '';
 		if ( ! empty( $args['parent_attr']['class'] ) ) {
 			$parent_class = $args['parent_attr']['class'];

--- a/src/bp-templates/bp-nouveau/includes/customizer-controls.php
+++ b/src/bp-templates/bp-nouveau/includes/customizer-controls.php
@@ -3,7 +3,7 @@
  * Customizer controls
  *
  * @since 3.0.0
- * @version 3.1.0
+ * @version 12.0.0
  */
 
 // Exit if accessed directly.
@@ -31,7 +31,6 @@ class BP_Nouveau_Nav_Customize_Control extends WP_Customize_Control {
 	 */
 	public function render_content() {
 		$id       = 'customize-control-' . str_replace( '[', '-', str_replace( ']', '', $this->id ) );
-		$class    = 'customize-control customize-control-' . $this->type;
 		$setting  = "bp_nouveau_appearance[{$this->type}_nav_order]";
 		$item_nav = array();
 
@@ -61,8 +60,7 @@ class BP_Nouveau_Nav_Customize_Control extends WP_Customize_Control {
 		// It's a user!
 		} else {
 			$item_nav = bp_nouveau_member_customizer_nav();
-
-			$guide = __( 'Drag each possible member navigation items that are listed below into the order you prefer.', 'buddypress' );
+			$guide    = __( 'Drag each possible member navigation items that are listed below into the order you prefer.', 'buddypress' );
 		}
 		?>
 
@@ -75,11 +73,7 @@ class BP_Nouveau_Nav_Customize_Control extends WP_Customize_Control {
 		<?php if ( ! empty( $item_nav ) ) : ?>
 			<ul id="<?php echo esc_attr( $id ); ?>" class="ui-sortable" style="margin-top: 0px; height: 500px;" data-bp-type="<?php echo esc_attr( $this->type ); ?>">
 
-				<?php
-				$i = 0;
-				foreach ( $item_nav as $item ) :
-					$i += 1;
-				?>
+				<?php foreach ( $item_nav as $item ) : ?>
 					<li data-bp-nav="<?php echo esc_attr( $item->slug ); ?>">
 						<div class="menu-item-bar">
 							<div class="menu-item-handle ui-sortable-handle">

--- a/src/bp-templates/bp-nouveau/includes/groups/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/ajax.php
@@ -3,7 +3,7 @@
  * Groups Ajax functions
  *
  * @since 3.0.0
- * @version 6.3.0
+ * @version 12.0.0
  */
 
 // Exit if accessed directly.
@@ -377,8 +377,6 @@ function bp_nouveau_ajax_get_users_to_invite() {
  * @since 3.0.0
  */
 function bp_nouveau_ajax_send_group_invites() {
-	$bp = buddypress();
-
 	$response = array(
 		'feedback' => __( 'Invites could not be sent. Please try again.', 'buddypress' ),
 		'type'     => 'error',

--- a/src/bp-templates/bp-nouveau/includes/groups/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/functions.php
@@ -521,7 +521,6 @@ function bp_nouveau_groups_screen_invites_restriction() {
  */
 function bp_nouveau_restrict_rest_group_invite_to_friends( $retval, $request ) {
 	if ( true === $retval && bp_is_active( 'friends' ) ) {
-		$group_id   = $request->get_param( 'group_id' );
 		$user_id    = $request->get_param( 'user_id' );
 		$inviter_id = $request->get_param( 'inviter_id' );
 

--- a/src/bp-templates/bp-nouveau/includes/groups/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/template-tags.php
@@ -688,20 +688,10 @@ function bp_nouveau_groups_manage_members_buttons( $args = array() ) {
 			$parent_element = false;
 		}
 
-		/*
-		 * If we have a arg value for $button_element passed through
-		 * use it to default all the $buttons['button_element'] values
-		 * otherwise default to 'a' (anchor) o override & hardcode the
-		 * 'element' string on $buttons array.
-		 *
-		 * Icons sets a class for icon display if not using the button element
-		 */
-		$icons = '';
 		if ( ! empty( $args['button_element'] ) ) {
 			$button_element = $args['button_element'] ;
 		} else {
 			$button_element = 'a';
-			$icons = ' icons';
 		}
 
 		// If we pass through parent classes add them to $button array

--- a/src/bp-templates/bp-nouveau/includes/members/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/members/template-tags.php
@@ -247,20 +247,10 @@ function bp_nouveau_members_loop_buttons( $args = array() ) {
 			$parent_element = $args['parent_element'];
 		}
 
-		/*
-		 * If we have a arg value for $button_element passed through
-		 * use it to default all the $buttons['button_element'] values
-		 * otherwise default to 'a' (anchor)
-		 * Or override & hardcode the 'element' string on $buttons array.
-		 *
-		 * Icons sets a class for icon display if not using the button element
-		 */
-		$icons = '';
 		if ( ! empty( $args['button_element'] ) ) {
 			$button_element = $args['button_element'] ;
 		} else {
 			$button_element = 'button';
-			$icons = ' icons';
 		}
 
 		// If we pass through parent classes add them to $button array

--- a/src/bp-templates/bp-nouveau/includes/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/template-tags.php
@@ -474,11 +474,6 @@ function bp_nouveau_pagination( $position ) {
 			break;
 	}
 
-	$count_class = sprintf( '%1$s-%2$s-count-%3$s', $pagination_type, $screen, $position );
-	$links_class = sprintf( '%1$s-%2$s-links-%3$s', $pagination_type, $screen, $position );
-	?>
-
-	<?php
 	if ( 'bottom' === $position && isset( $bottom_hook ) ) {
 		/**
 		 * Fires after the component directory list.


### PR DESCRIPTION
Remove even more never used inited variables in various functions!

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8892

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
