### PR TITLE
Prevent a PHP 8.1 deprecation notice in Media Extractor class

### DIFF
--- a/src/bp-core/classes/class-bp-media-extractor.php
+++ b/src/bp-core/classes/class-bp-media-extractor.php
@@ -641,7 +641,7 @@ class BP_Media_Extractor {
 			$extension = '.' . $extension;
 
 			foreach ( $links['links'] as $link ) {
-				$path = parse_url( $link['url'], PHP_URL_PATH );
+				$path = (string) wp_parse_url( $link['url'], PHP_URL_PATH );
 
 				// Check this URL's file extension matches that of an accepted audio format.
 				if ( ! $path || substr( untrailingslashit( $path ), -4 ) !== $extension ) {


### PR DESCRIPTION
In `BP_Media_Extractor::extract_audio` make sure `$path is a string.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8921

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
