### PR TITLE
Use WP Emojis in Messages subject, excerpt & content

### DIFF
--- a/src/bp-messages/bp-messages-filters.php
+++ b/src/bp-messages/bp-messages-filters.php
@@ -77,6 +77,12 @@ add_filter( 'bp_get_the_thread_message_content',      'stripslashes_deep'    );
 add_filter( 'bp_get_the_thread_subject',              'stripslashes_deep'    );
 add_filter( 'bp_get_message_thread_content',          'stripslashes_deep', 1 );
 
+add_filter( 'bp_get_the_thread_subject', 'wp_staticize_emoji', 12 );
+add_filter( 'bp_get_message_thread_subject', 'wp_staticize_emoji', 12 );
+add_filter( 'bp_get_message_thread_excerpt', 'wp_staticize_emoji', 12 );
+add_filter( 'bp_get_the_thread_message_content', 'wp_staticize_emoji', 12 );
+add_filter( 'bp_get_message_thread_content', 'wp_staticize_emoji', 12 );
+
 add_filter( 'bp_get_the_thread_message_content', 'bp_core_add_loading_lazy_attribute' );
 
 // Personal data export.

--- a/src/bp-templates/bp-nouveau/buddypress/common/js-templates/messages/index.php
+++ b/src/bp-templates/bp-nouveau/buddypress/common/js-templates/messages/index.php
@@ -6,7 +6,7 @@
  * dealing with user's private messages.
  *
  * @since 3.0.0
- * @version 10.0.0
+ * @version 12.0.0
  */
 
 // Backward Compatibility for plugins still needing the placeholders to be located into this file.
@@ -155,9 +155,9 @@ if ( ! did_action( '_bp_nouveau_messages_print_placeholders' ) ) {
 	<div class="thread-content" data-thread-id="{{data.id}}">
 		<div class="thread-subject">
 			<span class="thread-count">({{data.count}})</span>
-			<a class="subject" href="./view/{{data.id}}/">{{data.subject}}</a>
+			<a class="subject" href="./view/{{data.id}}/">{{{data.subject}}}</a>
 		</div>
-		<p class="excerpt">{{data.excerpt}}</p>
+		<p class="excerpt">{{{data.excerpt}}}</p>
 	</div>
 	<div class="thread-date">
 		<time datetime="{{data.date.toISOString()}}">{{data.display_date}}</time>

--- a/src/bp-templates/bp-nouveau/includes/messages/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/messages/ajax.php
@@ -3,7 +3,7 @@
  * Messages Ajax functions
  *
  * @since 3.0.0
- * @version 10.0.0
+ * @version 12.0.0
  */
 
 // Exit if accessed directly.
@@ -336,8 +336,8 @@ function bp_nouveau_ajax_get_user_message_threads() {
 		$threads->threads[ $i ] = array(
 			'id'            => bp_get_message_thread_id(),
 			'message_id'    => (int) $last_message_id,
-			'subject'       => strip_tags( bp_get_message_thread_subject() ),
-			'excerpt'       => strip_tags( bp_get_message_thread_excerpt() ),
+			'subject'       => bp_get_message_thread_subject(),
+			'excerpt'       => bp_get_message_thread_excerpt(),
 			'content'       => do_shortcode( bp_get_message_thread_content() ),
 			'unread'        => bp_message_thread_has_unread(),
 			'sender_name'   => bp_core_get_user_displayname( $messages_template->thread->last_sender_id ),


### PR DESCRIPTION
- Filter subject, excerpt & content template functions using the `wp_staticize_emoji` callback.
- Update some Nouveau templates/ajax function to make sure these WP Emojis are rightly rendered.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8928

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
