### PR TITLE
Make sure the `buddypress()->active_components` global lists all active components.

### DIFF
--- a/src/bp-core/classes/class-bp-component.php
+++ b/src/bp-core/classes/class-bp-component.php
@@ -255,6 +255,11 @@ class BP_Component {
 			}
 		}
 
+		// Make sure the `buddypress()->active_components` global lists all active components.
+		if ( 'core' !== $this->id && ! isset( buddypress()->active_components[ $this->id ] ) ) {
+			buddypress()->active_components[ $this->id ] = '1';
+		}
+
 		// Move on to the next step.
 		$this->setup_actions();
 	}


### PR DESCRIPTION
It shouldn't be something Plugins/Add-ons need to set.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8933

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
