### PR TITLE
Improve automatic third party component page association

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -850,8 +850,13 @@ function bp_core_add_page_mappings( $components, $existing = 'keep', $return_pag
 
 	$page_titles = bp_core_get_directory_page_default_titles();
 	if ( $return_pages ) {
+		$components_title = wp_list_pluck( $components, 'title' );
+		if ( ! $components_title ) {
+			$components_title = $components;
+		}
+
 		// In this case the `$components` array uses Page titles as values.
-		$page_titles = bp_parse_args( $page_titles, $components );
+		$page_titles = bp_parse_args( $page_titles, $components_title );
 	}
 
 	$pages_to_create = array();
@@ -882,20 +887,26 @@ function bp_core_add_page_mappings( $components, $existing = 'keep', $return_pag
 	}
 
 	// Create the pages.
-	foreach ( $pages_to_create as $component_name => $page_name ) {
+	foreach ( $pages_to_create as $component_name => $page_title ) {
 		$existing_id = bp_core_get_directory_page_id( $component_name );
 
 		// If page already exists, use it.
 		if ( ! empty( $existing_id ) ) {
 			$pages[ $component_name ] = (int) $existing_id;
 		} else {
-			$pages[ $component_name ] = wp_insert_post( array(
+			$postarr = array(
 				'comment_status' => 'closed',
 				'ping_status'    => 'closed',
 				'post_status'    => 'publish',
-				'post_title'     => $page_name,
+				'post_title'     => $page_title,
 				'post_type'      => bp_core_get_directory_post_type(),
-			) );
+			);
+
+			if ( isset( $components[ $component_name ]['name'] ) ) {
+				$postarr['post_name'] = $components[ $component_name ]['name'];
+			}
+
+			$pages[ $component_name ] = wp_insert_post( $postarr );
 		}
 	}
 


### PR DESCRIPTION
1. the `$bp->loaded_components` array uses the component slug as keys (not the component ID). Avoid potential problems when a component slug is very different than the component ID by looping into this array the right way.
2. Makes sure to use the component `$root_slug` and `$directory_title` when automatically creating a `buddypress` post type for orphaned components.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8918

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
