### PR TITLE
Improve the tool to reset BP URLs

### DIFF
--- a/src/bp-core/admin/bp-core-admin-tools.php
+++ b/src/bp-core/admin/bp-core-admin-tools.php
@@ -193,10 +193,7 @@ function bp_admin_reset_slugs() {
 	/* translators: %s: the result of the action performed by the repair tool */
 	$statement = __( 'Removing all custom slugs and resetting default ones&hellip; %s', 'buddypress' );
 
-	$bp_pages = bp_core_get_directory_page_ids( 'all' );
-	foreach ( $bp_pages as $page_id ) {
-		delete_post_meta( $page_id, '_bp_component_slugs' );
-	}
+	bp_core_add_page_mappings( buddypress()->active_components, 'delete' );
 
 	// Delete BP Pages cache and rewrite rules.
 	wp_cache_delete( 'directory_pages', 'bp_pages' );


### PR DESCRIPTION
This tool was added in https://buddypress.trac.wordpress.org/changeset/13468

Instead of only deleting the post meta, let's completely remap `buddypress` post types to their component directories.

This PR will need further testing with a third party component once https://github.com/buddypress/buddypress/pull/127 is merged.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8934

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
