### PR TITLE
Make sure directory rewrite rules only match directory slugs

### DIFF
--- a/src/bp-core/classes/class-bp-component.php
+++ b/src/bp-core/classes/class-bp-component.php
@@ -1124,7 +1124,7 @@ class BP_Component {
 					$regex = $this->root_slug;
 					$query = 'index.php?' . $this->rewrite_ids['directory'] . '=1';
 
-					$rules[ $rule_key ]['regex'] = $regex;
+					$rules[ $rule_key ]['regex'] = $regex . '/?$';
 					$rules[ $rule_key ]['query'] = $query;
 				} else {
 					$regex  = trailingslashit( $regex ) . $rule_information['regex'];


### PR DESCRIPTION
Adds a missing  `. '/?$'` at the end of line 1127 of `src/bp-core/classes/class-bp-component.php`

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8938

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
