### PR TITLE
Only check if the directory is homepage if the requested URL is homepage

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -481,7 +481,7 @@ class BP_Activity_Component extends BP_Component {
 			return parent::parse_query( $query );
 		}
 
-		if ( bp_is_directory_homepage( $this->id ) ) {
+		if ( home_url( '/' ) === bp_get_requested_url() && bp_is_directory_homepage( $this->id ) ) {
 			$query->set( $this->rewrite_ids['directory'], 1 );
 		}
 

--- a/src/bp-blogs/classes/class-bp-blogs-component.php
+++ b/src/bp-blogs/classes/class-bp-blogs-component.php
@@ -460,7 +460,7 @@ class BP_Blogs_Component extends BP_Component {
 		// Get the BuddyPress main instance.
 		$bp = buddypress();
 
-		if ( bp_is_directory_homepage( $this->id ) ) {
+		if ( home_url( '/' ) === bp_get_requested_url() && bp_is_directory_homepage( $this->id ) ) {
 			$query->set( $this->rewrite_ids['directory'], 1 );
 		}
 

--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -563,7 +563,7 @@ function bp_get_canonical_url( $args = array() ) {
 		 * type directory.
 		 */
 		if ( false !== $front_page_component && bp_is_current_component( $front_page_component ) && ! bp_current_action() && ! bp_get_current_member_type() ) {
-			$bp->canonical_stack['canonical_url'] = bp_get_root_url();
+			$bp->canonical_stack['canonical_url'] = trailingslashit( bp_get_root_url() );
 
 		// Except when the front page is set to the registration page
 		// and the current user is logged in. In this case we send to

--- a/src/bp-core/bp-core-filters.php
+++ b/src/bp-core/bp-core-filters.php
@@ -976,7 +976,7 @@ function bp_core_include_directory_on_front( $pages = array(), $args = array() )
 			}
 
 			$post = (object) array(
-				'ID'                    => $directory->id,
+				'ID'                    => (int) $directory->id,
 				'post_author'           => 0,
 				'post_date'             => $null,
 				'post_date_gmt'         => $null,

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -1053,7 +1053,7 @@ class BP_Groups_Component extends BP_Component {
 			return parent::parse_query( $query );
 		}
 
-		if ( bp_is_directory_homepage( $this->id ) ) {
+		if ( home_url( '/' ) === bp_get_requested_url() && bp_is_directory_homepage( $this->id ) ) {
 			$query->set( $this->rewrite_ids['directory'], 1 );
 		}
 

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -790,7 +790,7 @@ class BP_Members_Component extends BP_Component {
 			add_action( 'bp_screens', 'bp_members_screen_display_profile', 3 );
 		}
 
-		if ( bp_is_directory_homepage( $this->id ) ) {
+		if ( home_url( '/' ) === bp_get_requested_url() && bp_is_directory_homepage( $this->id ) ) {
 			$query->set( $this->rewrite_ids['directory'], 1 );
 		}
 


### PR DESCRIPTION
To avoid infinite loops or redirecting all pages to the homepage of the site, make sure to check if a component's directory is set as homepage only if the home page was requested.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8939

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
