### PR TITLE
Make sure the group’s canonical stack is set the right way

### DIFF
--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -575,16 +575,15 @@ class BP_Groups_Component extends BP_Component {
 			}
 
 			if ( ! empty( $bp->action_variables ) ) {
+				$chunks               = array( $current_action, $bp->action_variables );
 				$key_action_variables = 'single_item_action_variables';
 
 				if ( bp_is_group_admin_page() ) {
 					$context = 'manage';
-				} elseif ( bp_is_group_create() ) {
-					$context              = 'create';
-					$key_action_variables = 'create_single_item_variables';;
+					array_shift( $chunks );
 				}
 
-				$path_chunks                             = bp_groups_get_path_chunks( $bp->action_variables, $context );
+				$path_chunks                             = bp_groups_get_path_chunks( $chunks, $context );
 				$bp->canonical_stack['action_variables'] = bp_action_variables();
 
 				if ( isset( $path_chunks[ $key_action_variables ] ) ) {


### PR DESCRIPTION
If the `manage` context does not need the current action to get the customized slugs for action variables, the `read` context does.

Moreover, as the current group is not set during the creation process, we don't need to get customized action variables for the `create` context.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8940

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
