### PR TITLE
Make sure to display a 404 if a Group’s URL has no match in registered screens

### DIFF
--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -3814,7 +3814,6 @@ function bp_get_group_extension_screens( $context = 'read' ) {
  * @since 12.0.0
  *
  * @param string  $context  The display context. Required. Defaults to `read`.
- *                          Possible values are `read`, `manage` or `create`.
  * @param boolean $built_in True to only get builtin screens. False otherwise.
  * @return array            The list of potential Group screens.
  */

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -3814,6 +3814,7 @@ function bp_get_group_extension_screens( $context = 'read' ) {
  * @since 12.0.0
  *
  * @param string  $context  The display context. Required. Defaults to `read`.
+ *                          Possible values are `read`, `manage` or `create`.
  * @param boolean $built_in True to only get builtin screens. False otherwise.
  * @return array            The list of potential Group screens.
  */

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -329,6 +329,18 @@ class BP_Groups_Component extends BP_Component {
 	}
 
 	/**
+	 * Set up the component actions.
+	 *
+	 * @since 12.0.0
+	 */
+	public function setup_actions() {
+		parent::setup_actions();
+
+		// Check the parsed query is consistent with the Group’s registered screens.
+		add_action( 'bp_parse_query',  array( $this, 'check_parsed_query' ), 999, 0 );
+	}
+
+	/**
 	 * Set up additional globals for the component.
 	 *
 	 * @since 10.0.0
@@ -1189,6 +1201,30 @@ class BP_Groups_Component extends BP_Component {
 		}
 
 		parent::parse_query( $query );
+	}
+
+	/**
+	 * Check the parsed query is consistent with Group’s registered screens.
+	 *
+	 * @since 12.0.0
+	 */
+	public function check_parsed_query() {
+		if ( bp_is_group() ) {
+			$slug    = bp_current_action();
+			$context = 'read';
+
+			if ( 'admin' === $slug ) {
+				$slug    = bp_action_variable( 0 );
+				$context = 'manage';
+			}
+
+			$registered_group_screens = bp_get_group_screens( $context );
+
+			if ( ! isset( $registered_group_screens[ $slug ] ) ) {
+				bp_do_404();
+				return;
+			}
+		}
 	}
 
 	/**

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -329,18 +329,6 @@ class BP_Groups_Component extends BP_Component {
 	}
 
 	/**
-	 * Set up the component actions.
-	 *
-	 * @since 12.0.0
-	 */
-	public function setup_actions() {
-		parent::setup_actions();
-
-		// Check the parsed query is consistent with the Group’s registered screens.
-		add_action( 'bp_parse_query',  array( $this, 'check_parsed_query' ), 999, 0 );
-	}
-
-	/**
 	 * Set up additional globals for the component.
 	 *
 	 * @since 10.0.0
@@ -1201,30 +1189,6 @@ class BP_Groups_Component extends BP_Component {
 		}
 
 		parent::parse_query( $query );
-	}
-
-	/**
-	 * Check the parsed query is consistent with Group’s registered screens.
-	 *
-	 * @since 12.0.0
-	 */
-	public function check_parsed_query() {
-		if ( bp_is_group() ) {
-			$slug    = bp_current_action();
-			$context = 'read';
-
-			if ( 'admin' === $slug ) {
-				$slug    = bp_action_variable( 0 );
-				$context = 'manage';
-			}
-
-			$registered_group_screens = bp_get_group_screens( $context );
-
-			if ( ! isset( $registered_group_screens[ $slug ] ) ) {
-				bp_do_404();
-				return;
-			}
-		}
 	}
 
 	/**


### PR DESCRIPTION
Introduces a `check_parsed_query()` method to the `BP_Groups_Component` class to make sure the requested group URL matches an existing group screen.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8953

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
