### PR TITLE
Check the xProfile group is not empty before trying to get field ids

### DIFF
--- a/src/bp-xprofile/bp-xprofile-template.php
+++ b/src/bp-xprofile/bp-xprofile-template.php
@@ -473,13 +473,18 @@ function bp_the_profile_field_ids() {
 		global $profile_template;
 
 		$field_ids = array();
-		foreach ( $profile_template->groups as $group ) {
-			if ( ! empty( $group->fields ) ) {
-				$field_ids = array_merge( $field_ids, wp_list_pluck( $group->fields, 'id' ) );
-			}
-		}
 
-		$field_ids = implode( ',', wp_parse_id_list( $field_ids ) );
+		if ( isset( $profile_template->groups ) && $profile_template->groups ) {
+			foreach ( $profile_template->groups as $group ) {
+				if ( ! empty( $group->fields ) ) {
+					$field_ids = array_merge( $field_ids, wp_list_pluck( $group->fields, 'id' ) );
+				}
+			}
+
+			$field_ids = implode( ',', wp_parse_id_list( $field_ids ) );
+		} else {
+			$field_ids = '';
+		}
 
 		/**
 		 * Filters the comma-separated list of field IDs.

--- a/tests/phpunit/testcases/xprofile/template.php
+++ b/tests/phpunit/testcases/xprofile/template.php
@@ -177,4 +177,56 @@ class BP_Tests_xProfile_Template extends BP_UnitTestCase {
 
 		$profile_template = $reset_profile_template;
 	}
+
+	/**
+	 * @group bp_get_the_profile_field_ids
+	 * @group bp_has_profile
+	 */
+	public function test_bp_get_the_profile_field_ids() {
+		global $profile_template;
+		$reset_profile_template = $profile_template;
+
+		$group     = self::factory()->xprofile_group->create();
+		$fields_in = array(
+			self::factory()->xprofile_field->create(
+				array(
+					'field_group_id' => $group,
+				)
+			),
+			self::factory()->xprofile_field->create(
+				array(
+					'field_group_id' => $group,
+				)
+			)
+		);
+
+		bp_has_profile( array( 'profile_group_id' => $group ) );
+		$this->assertSame( bp_get_the_profile_field_ids(), implode( ',', $fields_in ) );
+
+		foreach ( $fields_in as $field_in_id ) {
+			xprofile_delete_field( $field_in_id );
+		}
+
+		xprofile_delete_field_group( $group );
+
+		$profile_template = $reset_profile_template;
+	}
+
+	/**
+	 * @group bp_get_the_profile_field_ids
+	 */
+	public function test_bp_get_the_profile_field_ids_no_group() {
+		global $profile_template;
+		$reset_profile_template = $profile_template;
+
+		$profile_template = new stdClass();
+
+		$this->assertEquals( '', bp_get_the_profile_field_ids() );
+
+		$profile_template->groups = array();
+
+		$this->assertEquals( '', bp_get_the_profile_field_ids() );
+
+		$profile_template = $reset_profile_template;
+	}
 }


### PR DESCRIPTION
Prevent potential errors in `bp_get_the_profile_field_ids()`.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8789

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
