### PR TITLE
Remove the Avatar style Customizer option

### DIFF
--- a/src/bp-templates/bp-nouveau/common-styles/_bp_generic_and_typography.scss
+++ b/src/bp-templates/bp-nouveau/common-styles/_bp_generic_and_typography.scss
@@ -141,15 +141,6 @@ body.buddypress { // add weight
 
 @include clearfix-element(".bp-wrap");
 
-// General site avatars round or square ?
-// User set
-.buddypress-wrap.round-avatars {
-
-	.avatar {
-		border-radius: 50%;
-	}
-}
-
 // ====== BP Typographic Elements ======
 
 // === Font sizing ===

--- a/src/bp-templates/bp-nouveau/css/buddypress-rtl.css
+++ b/src/bp-templates/bp-nouveau/css/buddypress-rtl.css
@@ -133,10 +133,6 @@ body.buddypress .buddypress-wrap h2:before {
 	clear: both;
 }
 
-.buddypress-wrap.round-avatars .avatar {
-	border-radius: 50%;
-}
-
 body.buddypress article.page > .entry-header {
 	margin-bottom: 2em;
 	padding: 0;

--- a/src/bp-templates/bp-nouveau/css/buddypress.css
+++ b/src/bp-templates/bp-nouveau/css/buddypress.css
@@ -133,10 +133,6 @@ body.buddypress .buddypress-wrap h2:before {
 	clear: both;
 }
 
-.buddypress-wrap.round-avatars .avatar {
-	border-radius: 50%;
-}
-
 body.buddypress article.page > .entry-header {
 	margin-bottom: 2em;
 	padding: 0;

--- a/src/bp-templates/bp-nouveau/includes/customizer.php
+++ b/src/bp-templates/bp-nouveau/includes/customizer.php
@@ -3,7 +3,7 @@
  * Code to hook into the WP Customizer
  *
  * @since 3.0.0
- * @version 10.0.0
+ * @version 12.0.0
  */
 
 /**
@@ -82,13 +82,6 @@ function bp_nouveau_customize_register( WP_Customize_Manager $wp_customize ) {
 	 * @param array $value Array of Customizer settings.
 	 */
 	$settings = apply_filters( 'bp_nouveau_customizer_settings', array(
-		'bp_nouveau_appearance[avatar_style]' => array(
-			'index'             => 'avatar_style',
-			'capability'        => 'bp_moderate',
-			'sanitize_callback' => 'absint',
-			'transport'         => 'refresh',
-			'type'              => 'option',
-		),
 		'bp_nouveau_appearance[user_front_page]' => array(
 			'index'             => 'user_front_page',
 			'capability'        => 'bp_moderate',
@@ -227,12 +220,6 @@ function bp_nouveau_customize_register( WP_Customize_Manager $wp_customize ) {
 	}
 
 	$controls = array(
-		'bp_site_avatars' => array(
-			'label'      => __( 'Use the round style for member and group avatars.', 'buddypress' ),
-			'section'    => 'bp_nouveau_general_settings',
-			'settings'   => 'bp_nouveau_appearance[avatar_style]',
-			'type'       => 'checkbox',
-		),
 		'user_front_page' => array(
 			'label'      => __( 'Enable default front page for member profiles.', 'buddypress' ),
 			'section'    => 'bp_nouveau_user_front_page',

--- a/src/bp-templates/bp-nouveau/includes/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/functions.php
@@ -3,7 +3,7 @@
  * Common functions
  *
  * @since 3.0.0
- * @version 10.0.0
+ * @version 12.0.0
  */
 
 // Exit if accessed directly.
@@ -640,7 +640,6 @@ function bp_nouveau_get_temporary_setting( $option = '', $retval = false ) {
  */
 function bp_nouveau_get_appearance_settings( $option = '' ) {
 	$default_args = array(
-		'avatar_style'       => 0,
 		'global_alignment'   => 'alignwide',
 		'user_front_page'    => 0,
 		'user_front_bio'     => 0,

--- a/src/bp-templates/bp-nouveau/includes/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/template-tags.php
@@ -1513,12 +1513,6 @@ function bp_nouveau_container_classes() {
 
 		// Add classes according to site owners preferences. These are options set via Customizer.
 
-		// These are general site wide Cust options falling outside component checks
-		$general_settings = bp_nouveau_get_temporary_setting( 'avatar_style', bp_nouveau_get_appearance_settings( 'avatar_style' ) );
-		if ( $general_settings ) {
-			$classes[] = 'round-avatars';
-		}
-
 		// Set via earlier switch for component check to provide correct option key.
 		if ( $customizer_option ) {
 			$layout_prefs  = bp_nouveau_get_temporary_setting( $customizer_option, bp_nouveau_get_appearance_settings( $customizer_option ) );


### PR DESCRIPTION
Let the theme deal with Avatar style so that it's rendered consistently everywhere on the site.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8273

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
