### PR TITLE
Move the Blogs confirmation markup into a template

### DIFF
--- a/src/bp-blogs/bp-blogs-template.php
+++ b/src/bp-blogs/bp-blogs-template.php
@@ -1327,26 +1327,13 @@ function bp_blogs_confirm_blog_signup( $domain, $path, $blog_title, $user_name, 
 	$login_url = set_url_scheme( wp_login_url() );
 	restore_current_blog();
 
-	?>
-	<p class="success"><?php esc_html_e( 'Congratulations! You have successfully registered a new site.', 'buddypress' ) ?></p>
-	<p>
-		<?php printf(
-			'%s %s',
-			sprintf(
-				/* translators: %s: the link of the new site */
-				__( '%s is your new site.', 'buddypress' ),
-				sprintf( '<a href="%s">%s</a>', esc_url( $blog_url ), esc_url( $blog_url ) )
-			),
-			sprintf(
-				/* translators: 1: Login URL, 2: User name */
-				__( '<a href="%1$s">Log in</a> as "%2$s" using your existing password.', 'buddypress' ),
-				esc_url( $login_url ),
-				esc_html( $user_name )
-			)
-		); ?>
-	</p>
+	$args = array(
+		'blog_url'  => $blog_url,
+		'login_url' => $login_url,
+		'user_name' => $user_name,
+	);
 
-<?php
+	bp_get_template_part( 'blogs/confirm', null, $args );
 
 	/**
 	 * Fires after the default successful blog registration message markup.

--- a/src/bp-templates/bp-legacy/buddypress/blogs/confirm.php
+++ b/src/bp-templates/bp-legacy/buddypress/blogs/confirm.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * BuddyPress - Blogs Create
+ * BuddyPress - Blogs Confirm
  *
  * @since 12.0.0
  * @version 12.0.0

--- a/src/bp-templates/bp-legacy/buddypress/blogs/confirm.php
+++ b/src/bp-templates/bp-legacy/buddypress/blogs/confirm.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * BuddyPress - Blogs Create
+ *
+ * @since 12.0.0
+ * @version 12.0.0
+ */
+?>
+
+<div id="buddypress">
+
+	<div id="template-notices" role="alert" aria-atomic="true">
+		<?php
+
+		/** This action is documented in bp-templates/bp-legacy/buddypress/activity/index.php */
+		do_action( 'template_notices' ); ?>
+
+	</div>
+
+	<?php
+	/**
+	 * Fires before the display of the blog creation confirmation message.
+	 *
+	 * @since 12.0.0
+	 */
+	do_action( 'bp_before_blog_confirmed_content' ); ?>
+
+	<?php if ( bp_blog_signup_enabled() ) : ?>
+
+		<p class="success"><?php esc_html_e( 'Congratulations! You have successfully registered a new site.', 'buddypress' ) ?></p>
+		<p>
+			<?php printf(
+				'%s %s',
+				sprintf(
+					/* translators: %s: the link of the new site */
+					__( '%s is your new site.', 'buddypress' ),
+					sprintf( '<a href="%s">%s</a>', esc_url( $args['blog_url'] ), esc_url( $args['blog_url'] ) )
+				),
+				sprintf(
+					/* translators: 1: Login URL, 2: User name */
+					__( '<a href="%1$s">Log in</a> as "%2$s" using your existing password.', 'buddypress' ),
+					esc_url( $args['login_url'] ),
+					esc_html( $args['user_name'] )
+				)
+			); ?>
+		</p>
+
+	<?php else : ?>
+
+		<div id="message" class="info">
+			<p><?php esc_html_e( 'Site registration is currently disabled', 'buddypress' ); ?></p>
+		</div>
+
+	<?php endif; ?>
+
+	<?php
+	/**
+	 * Fires before the display of the blog creation confirmation message.
+	 *
+	 * @since 12.0.0
+	 */
+	do_action( 'bp_after_blog_confirmed_content' ); ?>
+
+</div>

--- a/src/bp-templates/bp-legacy/buddypress/blogs/create.php
+++ b/src/bp-templates/bp-legacy/buddypress/blogs/create.php
@@ -4,7 +4,7 @@
  *
  * @package BuddyPress
  * @subpackage bp-legacy
- * @version 3.0.0
+ * @version 12.0.0
  */
 
 /**
@@ -40,7 +40,7 @@ do_action( 'bp_before_create_blog_content_template' ); ?>
 	<?php else: ?>
 
 		<div id="message" class="info">
-			<p><?php _e( 'Site registration is currently disabled', 'buddypress' ); ?></p>
+			<p><?php esc_html_e( 'Site registration is currently disabled', 'buddypress' ); ?></p>
 		</div>
 
 	<?php endif; ?>

--- a/src/bp-templates/bp-legacy/buddypress/blogs/index.php
+++ b/src/bp-templates/bp-legacy/buddypress/blogs/index.php
@@ -61,7 +61,7 @@ do_action( 'bp_before_directory_blogs_page' ); ?>
 		<div class="item-list-tabs" aria-label="<?php esc_attr_e( 'Sites directory main navigation', 'buddypress' ); ?>" role="navigation">
 			<ul>
 				<li class="selected" id="blogs-all">
-					<a href="<?php bp_blogs_directory_permalink(); ?>">
+					<a href="<?php bp_blogs_directory_url(); ?>">
 						<?php
 						/* translators: %s: all blogs count */
 						printf( __( 'All Sites %s', 'buddypress' ), '<span>' . bp_get_total_blog_count() . '</span>' ); ?>

--- a/src/bp-templates/bp-nouveau/buddypress/blogs/confirm.php
+++ b/src/bp-templates/bp-nouveau/buddypress/blogs/confirm.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * BuddyPress - Blogs Create
+ * BuddyPress - Blogs Confirm
  *
  * @since 12.0.0
  * @version 12.0.0

--- a/src/bp-templates/bp-nouveau/buddypress/blogs/confirm.php
+++ b/src/bp-templates/bp-nouveau/buddypress/blogs/confirm.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * BuddyPress - Blogs Create
+ *
+ * @since 12.0.0
+ * @version 12.0.0
+ */
+
+bp_nouveau_template_notices(); ?>
+
+<?php bp_nouveau_blogs_confirm_hook( 'before', 'content' ); ?>
+
+<?php if ( bp_blog_signup_enabled() ) : ?>
+
+	<p class="success"><?php esc_html_e( 'Congratulations! You have successfully registered a new site.', 'buddypress' ) ?></p>
+	<p>
+		<?php printf(
+			'%s %s',
+			sprintf(
+				/* translators: %s: the link of the new site */
+				__( '%s is your new site.', 'buddypress' ),
+				sprintf( '<a href="%s">%s</a>', esc_url( $args['blog_url'] ), esc_url( $args['blog_url'] ) )
+			),
+			sprintf(
+				/* translators: 1: Login URL, 2: User name */
+				__( '<a href="%1$s">Log in</a> as "%2$s" using your existing password.', 'buddypress' ),
+				esc_url( $args['login_url'] ),
+				esc_html( $args['user_name'] )
+			)
+		); ?>
+	</p>
+
+<?php
+else :
+
+	bp_nouveau_user_feedback( 'blogs-no-signup' );
+
+endif;
+?>
+
+<?php
+bp_nouveau_blogs_confirm_hook( 'after', 'content' );

--- a/src/bp-templates/bp-nouveau/includes/blogs/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/blogs/template-tags.php
@@ -99,6 +99,31 @@ function bp_nouveau_blogs_create_hook( $when = '', $suffix = '' ) {
 }
 
 /**
+ * Fire specific hooks into the blogs confirm template
+ *
+ * @since 12.0.0
+ *
+ * @param string $when   Optional. Either 'before' or 'after'.
+ * @param string $suffix Optional. Use it to add terms at the end of the hook name.
+ */
+function bp_nouveau_blogs_confirm_hook( $when = '', $suffix = '' ) {
+	$hook = array( 'bp' );
+
+	if ( $when ) {
+		$hook[] = $when;
+	}
+
+	// It's a create a blog hook
+	$hook[] = 'blog_confirmed';
+
+	if ( $suffix ) {
+		$hook[] = $suffix;
+	}
+
+	bp_nouveau_hook( $hook );
+}
+
+/**
  * Fire an isolated hook inside the blogs loop
  *
  * @since 3.0.0


### PR DESCRIPTION
The fact it's possible since BP 7.0 to pass arguments to a template (see #8350) made the fix a lot more easier!

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8068

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
