### PR TITLE
Bypass the navigation check when viewing a single activity

### DIFF
--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -977,23 +977,27 @@ class BP_Members_Component extends BP_Component {
 	 * @since 12.0.0
 	 */
 	public function check_parsed_query() {
-		$single_item_component = '';
 		if ( bp_is_user() ) {
 			$single_item_component = bp_current_component();
-		}
 
-		$single_item_action = '';
-		if ( $single_item_component ) {
-			$single_item_action = bp_current_action();
-		}
+			$single_item_action = '';
+			if ( $single_item_component ) {
+				$single_item_action = bp_current_action();
+			}
 
-		$bp = buddypress();
-		if ( isset( $bp->{$single_item_component}, $bp->{$single_item_component}->sub_nav ) ) {
-			$screen_functions = wp_list_pluck( $bp->{$single_item_component}->sub_nav, 'screen_function', 'slug' );
-
-			if ( ! $single_item_action || ! isset( $screen_functions[ $single_item_action ] ) || ! is_callable( $screen_functions[ $single_item_action ] ) ) {
-				bp_do_404();
+			// Viewing a single activity.
+			if ( 'activity' === $single_item_component && is_numeric( $single_item_action ) ) {
 				return;
+			}
+
+			$bp = buddypress();
+			if ( isset( $bp->{$single_item_component}, $bp->{$single_item_component}->sub_nav ) ) {
+				$screen_functions = wp_list_pluck( $bp->{$single_item_component}->sub_nav, 'screen_function', 'slug' );
+
+				if ( ! $single_item_action || ! isset( $screen_functions[ $single_item_action ] ) || ! is_callable( $screen_functions[ $single_item_action ] ) ) {
+					bp_do_404();
+					return;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When viewing a single activity, do not try to find a BP Nav having the activity ID as slug.
Only perform the parse query check when viewing a single user.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8956

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
