### PR TITLE
Check theme compat is active before using `bp_nouveau()`

### DIFF
--- a/src/bp-activity/bp-activity-blocks.php
+++ b/src/bp-activity/bp-activity-blocks.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Callback function to render the Latest Activities Block.
  *
  * @since 9.0.0
- * 
+ *
  * @global BP_Activity_Template $activities_template The Activity template loop.
  *
  * @param array $attributes The block attributes.
@@ -80,7 +80,7 @@ function bp_activity_render_latest_activities_block( $attributes = array() ) {
 	);
 
 	// Build the activity loop.
-	if ( 'nouveau' === bp_get_theme_compat_id() ) {
+	if ( bp_is_theme_compat_active() && 'nouveau' === bp_get_theme_compat_id() ) {
 		$bp_nouveau = bp_nouveau();
 
 		// Globalize the activity widget arguments.


### PR DESCRIPTION
Check theme compat is active before using `bp_nouveau()`

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8962

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
