### PR TITLE
Bring back Logged-in Member WP Nav Menu

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -2807,7 +2807,34 @@ function bp_nav_menu_get_loggedin_pages() {
 	}
 
 	// Pull up a list of items registered in BP's primary nav for the member.
-	$bp_menu_items = $bp->members->nav->get_primary();
+	$bp_menu_items = array();
+
+	if ( 'rewrites' !== bp_core_get_query_parser() ) {
+		$bp_menu_items = $bp->members->nav->get_primary();
+	} else {
+		$members_navigation = bp_get_component_navigations();
+
+		// Remove the members component navigation when needed.
+		if ( bp_is_active( 'xprofile' ) ) {
+			unset( $members_navigation['members'] );
+		}
+
+		foreach ( $members_navigation as $component_id => $member_navigation ) {
+			if ( ! isset( $member_navigation['main_nav'] ) ) {
+				continue;
+			}
+
+			$bp_menu_items[] = array(
+				'name' => $member_navigation['main_nav']['name'],
+				'slug' => $member_navigation['main_nav']['slug'],
+				'link' => bp_loggedin_user_url(
+					array(
+						'single_item_component' => $member_navigation['main_nav']['slug'],
+					)
+				),
+			);
+		}
+	}
 
 	// Some BP nav menu items will not be represented in bp_nav, because
 	// they are not real BP components. We add them manually here.


### PR DESCRIPTION
As the `'bp_parse_query'` is not fired inside WP Admin context, we need to use the `bp_get_component_navigations()` function instead of trying to access the Members primary `BP_Core_Nav`.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8971

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
