### PR TITLE
Create a "ghost" nav item for the Messages view action

### DIFF
--- a/src/bp-messages/classes/class-bp-messages-component.php
+++ b/src/bp-messages/classes/class-bp-messages-component.php
@@ -254,6 +254,17 @@ class BP_Messages_Component extends BP_Component {
 			'user_has_access_callback' => 'bp_is_my_profile',
 		);
 
+		$sub_nav[] = array(
+			'name'                     => __( 'View', 'buddypress' ),
+			'slug'                     => 'view',
+			'parent_slug'              => $slug,
+			'screen_function'          => 'messages_screen_conversation',
+			'position'                 => 0,
+			'user_has_access'          => false,
+			'user_has_access_callback' => 'bp_core_can_edit_settings',
+			'generate'                 => false,
+		);
+
 		// Show "Notices" to community admins only.
 		$sub_nav[] = array(
 			'name'                     => __( 'Notices', 'buddypress' ),


### PR DESCRIPTION
To make sure the Messages component's view action is not considered as a 404, we now need to register it as a Member's navigation item without rendering it once the query is parsed. This move also allows site administrators to customize this action's slug from the URLs BuddyPress settings tab.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8975

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
