### PR TITLE
Make sure to get the taxonomy when clearing object type cache

### DIFF
--- a/src/bp-core/bp-core-cache.php
+++ b/src/bp-core/bp-core-cache.php
@@ -419,9 +419,9 @@ add_action( 'bp_setup_cache_groups', 'bp_set_object_type_terms_cache_group' );
 function bp_clear_object_type_terms_cache( $type_id = 0, $taxonomy = '' ) {
 	wp_cache_delete( $taxonomy, 'bp_object_terms' );
 }
-add_action( 'bp_type_inserted', 'bp_clear_object_type_terms_cache' );
-add_action( 'bp_type_updated', 'bp_clear_object_type_terms_cache' );
-add_action( 'bp_type_deleted', 'bp_clear_object_type_terms_cache' );
+add_action( 'bp_type_inserted', 'bp_clear_object_type_terms_cache', 10, 2 );
+add_action( 'bp_type_updated', 'bp_clear_object_type_terms_cache', 10, 2 );
+add_action( 'bp_type_deleted', 'bp_clear_object_type_terms_cache', 10, 2 );
 
 /**
  * Resets all incremented bp_optout caches.


### PR DESCRIPTION
2 is the right number or parameters `bp_clear_object_type_terms_cache()` needs to receive from action hooks.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8983

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
