### PR TITLE
Make sure to load the right JS asset in Admin Extended Profile screen

### DIFF
--- a/src/bp-members/classes/class-bp-members-admin.php
+++ b/src/bp-members/classes/class-bp-members-admin.php
@@ -831,7 +831,7 @@ class BP_Members_Admin {
 
 			// Only load JavaScript for BuddyPress profile.
 			if ( get_current_screen()->id == $this->user_page ) {
-				$js = $this->js_url . "admin{$min}.js";
+				$js = $this->js_url . 'admin.js';
 
 				/**
 				 * Filters the JS URL to enqueue in the Members admin area.


### PR DESCRIPTION
This file is not minified using the Grunt task anymore but directly using Webpack. The source file can be found inside `/src/js/admin/bp-members`.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8985

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
