### PR TITLE
Warning: Object of class `stdClass` could not be converted to `int`

### DIFF
--- a/src/bp-groups/classes/class-bp-groups-list-table.php
+++ b/src/bp-groups/classes/class-bp-groups-list-table.php
@@ -581,14 +581,11 @@ class BP_Groups_List_Table extends WP_List_Table {
 			'view'   => '',
 		);
 
-		// We need the group object for some BP functions.
-		$item_obj = (object) $item;
-
 		// Build actions URLs.
 		$base_url   = bp_get_admin_url( 'admin.php?page=bp-groups&amp;gid=' . $item['id'] );
 		$delete_url = wp_nonce_url( $base_url . "&amp;action=delete", 'bp-groups-delete' );
 		$edit_url   = $base_url . '&amp;action=edit';
-		$view_url   = bp_get_group_url( $item_obj );
+		$view_url   = bp_get_group_url( $item['id'] );
 
 		/**
 		 * Filters the group name for a group's column content.


### PR DESCRIPTION
Getting lots of those warnings in PHP 8.2.

```
[12-Sep-2023 00:43:21 UTC] PHP Warning:  Object of class stdClass could not be converted to int in /var/www/site/wp-content/plugins/buddypress/src/bp-groups/bp-groups-template.php on line 1272
```

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8820

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
