### PR TITLE
Add an action hook before the `<rss/>` tag of Activity feeds

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-feed.php
+++ b/src/bp-activity/classes/class-bp-activity-feed.php
@@ -410,6 +410,13 @@ class BP_Activity_Feed {
 	protected function output() {
 		$this->http_headers();
 		echo '<?xml version="1.0" encoding="' . get_option( 'blog_charset' ) . '"?'.'>';
+
+		/**
+		 * Fires between the xml and rss tags in an Activity feed.
+		 *
+		 * @since 12.0.0
+		 */
+		do_action( 'bp_activity_feed_rss_tag_pre' );
 	?>
 
 <rss version="2.0"


### PR DESCRIPTION
Add an action hook before the `<rss/>` tag of Activity feeds

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8995

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
