### PR TITLE
Improve `BP_Members_Component::check_parsed_query()` 

### DIFF
--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -991,10 +991,27 @@ class BP_Members_Component extends BP_Component {
 			}
 
 			$bp = buddypress();
-			if ( isset( $bp->{$single_item_component}, $bp->{$single_item_component}->sub_nav ) ) {
-				$screen_functions = wp_list_pluck( $bp->{$single_item_component}->sub_nav, 'screen_function', 'slug' );
+			if ( isset( $bp->{$single_item_component} ) ) {
+				$screen_function = '';
 
-				if ( ! $single_item_action || ! isset( $screen_functions[ $single_item_action ] ) || ! is_callable( $screen_functions[ $single_item_action ] ) ) {
+				if ( isset( $bp->{$single_item_component}->sub_nav ) ) {
+					$screen_functions = wp_list_pluck( $bp->{$single_item_component}->sub_nav, 'screen_function', 'slug' );
+
+					if ( isset( $screen_functions[ $single_item_action ] ) ) {
+						$screen_function = $screen_functions[ $single_item_action ];
+					}
+				}
+
+				// Check if this nav item has been added from outside the Component's class.
+				if ( ! $screen_function ) {
+					$sub_nav = $this->nav->get( $single_item_component . '/' . $single_item_action );
+
+					if ( isset( $sub_nav->screen_function ) && $sub_nav->screen_function ) {
+						$screen_function = $sub_nav->screen_function;
+					}
+				}
+
+				if ( ! $single_item_action || ! $screen_function || ! is_callable( $screen_function ) ) {
 					bp_do_404();
 					return;
 				}


### PR DESCRIPTION
Make sure to check for nav items added from outside component classes.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8996

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
