### PR TITLE
BP Legacy: improve private messages feedback management

### DIFF
--- a/src/bp-messages/actions/compose.php
+++ b/src/bp-messages/actions/compose.php
@@ -28,46 +28,95 @@ function bp_messages_action_create_message() {
 	$redirect_to = '';
 	$feedback    = '';
 	$success     = false;
+	$is_notice   = isset( $_POST['send-notice'] );
+	$path_chunks = array( bp_get_messages_slug() );
 
-	// Missing subject or content.
-	if ( empty( $_POST['subject'] ) || empty( $_POST['content'] ) ) {
-		$success  = false;
+	// List required vars and error messages.
+	$required_vars = array(
+		'subject' => __( 'Please enter a subject line.', 'buddypress' ),
+		'content' => __( 'Please enter some content.', 'buddypress' ),
+	);
 
-		if ( empty( $_POST['subject'] ) ) {
-			$feedback = __( 'Your message was not sent. Please enter a subject line.', 'buddypress' );
-		} else {
-			$feedback = __( 'Your message was not sent. Please enter some content.', 'buddypress' );
+	// The username is only needed for private messages.
+	if ( ! $is_notice ) {
+		$required_vars = array_merge(
+			array(
+				'send_to_usernames' => __( 'Please enter a username or Friend\'s name.', 'buddypress' ),
+			),
+			$required_vars
+		);
+	}
+
+	// Calculate whether some required vars are missing.
+	$needed_keys    = array_intersect_key( $_POST, $required_vars );
+	$needs_feedback = count( array_filter( $needed_keys ) ) !== count( $required_vars );
+
+	// Prevent notice errors.
+	$required_args = array_map(
+		'wp_unslash',
+		bp_parse_args(
+			$needed_keys,
+			array(
+				'send_to_usernames' => '',
+				'subject'           => '',
+				'content'           => ''
+			)
+		)
+	);
+
+	// Use cookies to preserve existing values.
+	messages_add_callback_values(
+		implode( ' ', wp_parse_list( $required_args['send_to_usernames'] ) ),
+		esc_html( $required_args['subject'] ),
+		esc_textarea( $required_args['content'] )
+	);
+
+	// Handle required vars.
+	if ( $needs_feedback ) {
+		$success       = false;
+		$path_chunks[] = 'compose';
+		$feedbacks     = array( __( 'Your message was not sent.', 'buddypress' ) );
+
+		foreach ( $required_vars as $required_key => $required_var_feedback ) {
+			if ( ! $required_args[ $required_key ] ) {
+				$feedbacks[] = $required_var_feedback;
+			}
 		}
 
-	// Subject and content present.
+		// Set the feedback message.
+		$feedback    = implode( "\n", $feedbacks );
+		$redirect_to = bp_loggedin_user_url( bp_members_get_path_chunks( $path_chunks ) );
 	} else {
 
-		// Setup the link to the logged-in user's messages.
-		$path_chunks = array( bp_get_messages_slug() );
-
 		// Site-wide notice.
-		if ( isset( $_POST['send-notice'] ) ) {
+		if ( $is_notice ) {
 
 			// Attempt to save the notice and redirect to notices.
-			if ( messages_send_notice( $_POST['subject'], $_POST['content'] ) ) {
+			if ( messages_send_notice( $required_args['subject'], $required_args['content'] ) ) {
 				$success       = true;
 				$feedback      = __( 'Notice successfully created.', 'buddypress' );
 				$path_chunks[] = 'notices';
-				$redirect_to   = bp_loggedin_user_url( bp_members_get_path_chunks( $path_chunks ) );
 
-			// Notice could not be sent.
+				// Notice could not be sent.
 			} else {
-				$success  = false;
-				$feedback = __( 'Notice was not created. Please try again.', 'buddypress' );
+				$success       = false;
+				$path_chunks[] = 'compose';
+				$feedback      = __( 'Notice was not created. Please try again.', 'buddypress' );
 			}
 
-		// Private conversation.
+			$redirect_to = bp_loggedin_user_url( bp_members_get_path_chunks( $path_chunks ) );
+
+			// Private conversation.
 		} else {
 
 			// Filter recipients into the format we need - array( 'username/userid', 'username/userid' ).
-			$autocomplete_recipients = (array) explode( ',', $_POST['send-to-input'] );
-			$typed_recipients        = (array) explode( ' ', $_POST['send_to_usernames'] );
-			$recipients              = array_merge( $autocomplete_recipients, $typed_recipients );
+			$autocomplete_recipients = array();
+			if ( isset( $_POST['send-to-input'] ) && $_POST['send-to-input'] ) {
+				$autocomplete_recipients = (array) explode( ',', $_POST['send-to-input'] );
+			}
+
+			$typed_recipients = (array) explode( ' ', $required_args['send_to_usernames'] );
+			$recipients       = array_merge( $autocomplete_recipients, $typed_recipients );
 
 			/**
 			 * Filters the array of recipients to receive the composed message.
@@ -79,12 +128,14 @@ function bp_messages_action_create_message() {
 			$recipients = apply_filters( 'bp_messages_recipients', $recipients );
 
 			// Attempt to send the message.
-			$send = messages_new_message( array(
-				'recipients' => $recipients,
-				'subject'    => $_POST['subject'],
-				'content'    => $_POST['content'],
-				'error_type' => 'wp_error',
-			) );
+			$send = messages_new_message(
+				array(
+					'recipients' => $recipients,
+					'subject'    => $required_args['subject'],
+					'content'    => $required_args['content'],
+					'error_type' => 'wp_error',
+				)
+			);
 
 			// Send the message and redirect to it.
 			if ( true === is_int( $send ) ) {
@@ -92,13 +143,15 @@ function bp_messages_action_create_message() {
 				$feedback      = __( 'Message successfully sent.', 'buddypress' );
 				$path_chunks[] = 'view';
 				$path_chunks[] = array( $send );
-				$redirect_to   = bp_loggedin_user_url( bp_members_get_path_chunks( $path_chunks ) );
 
-			// Message could not be sent.
+				// Message could not be sent.
 			} else {
-				$success  = false;
-				$feedback = $send->get_error_message();
+				$success       = false;
+				$path_chunks[] = 'compose';
+				$feedback      = $send->get_error_message();
 			}
+
+			$redirect_to = bp_loggedin_user_url( bp_members_get_path_chunks( $path_chunks ) );
 		}
 	}
 

--- a/src/bp-messages/bp-messages-template.php
+++ b/src/bp-messages/bp-messages-template.php
@@ -1003,9 +1003,12 @@ function bp_messages_subject_value() {
 	function bp_get_messages_subject_value() {
 
 		// Sanitized in bp-messages-filters.php.
-		$subject = ! empty( $_POST['subject'] )
-			? $_POST['subject']
-			: '';
+		$subject = '';
+		if ( isset( $_POST['subject'] ) && $_POST['subject'] ) {
+			$subject = $_POST['subject'];
+		} elseif ( isset( $_COOKIE['bp_messages_subject'] ) && $_COOKIE['bp_messages_subject'] ) {
+			$subject = $_COOKIE['bp_messages_subject'];
+		}
 
 		/**
 		 * Filters the default value for the subject field.
@@ -1034,9 +1037,12 @@ function bp_messages_content_value() {
 	function bp_get_messages_content_value() {
 
 		// Sanitized in bp-messages-filters.php.
-		$content = ! empty( $_POST['content'] )
-			? $_POST['content']
-			: '';
+		$content = '';
+		if ( isset( $_POST['content'] ) && $_POST['content'] ) {
+			$content = $_POST['content'];
+		} elseif ( isset( $_COOKIE['bp_messages_content'] ) && $_COOKIE['bp_messages_content'] ) {
+			$content = $_COOKIE['bp_messages_content'];
+		}
 
 		/**
 		 * Filters the default value for the content field.
@@ -1679,9 +1685,12 @@ function bp_message_get_recipient_usernames() {
 	function bp_get_message_get_recipient_usernames() {
 
 		// Sanitized in bp-messages-filters.php.
-		$recipients = isset( $_GET['r'] )
-			? $_GET['r']
-			: '';
+		$recipients = '';
+		if ( isset( $_GET['r'] ) && $_GET['r'] ) {
+			$recipients = $_GET['r'];
+		} elseif ( isset( $_COOKIE['bp_messages_send_to'] ) && $_COOKIE['bp_messages_send_to'] ) {
+			$recipients = $_COOKIE['bp_messages_send_to'];
+		}
 
 		/**
 		 * Filters the recipients usernames for prefilling the 'To' field on the Compose screen.

--- a/src/bp-templates/bp-legacy/buddypress/members/single/messages/compose.php
+++ b/src/bp-templates/bp-legacy/buddypress/members/single/messages/compose.php
@@ -10,7 +10,7 @@
 ?>
 <h2 class="bp-screen-reader-text"><?php
 	/* translators: accessibility text */
-	_e( 'Compose Message', 'buddypress' );
+	esc_html_e( 'Compose Message', 'buddypress' );
 ?></h2>
 
 <form action="<?php bp_messages_form_action(); ?>" method="post" id="send_message_form" class="standard-form" enctype="multipart/form-data">
@@ -24,7 +24,7 @@
 	 */
 	do_action( 'bp_before_messages_compose_content' ); ?>
 
-	<label for="send-to-input"><?php _e("Send To (Username or Friend's Name)", 'buddypress' ); ?></label>
+	<label for="send-to-input"><?php esc_html_e( 'Send To (Username or Friend\'s Name)', 'buddypress' ); ?></label>
 	<ul class="first acfb-holder">
 		<li>
 			<?php bp_message_get_recipient_tabs(); ?>
@@ -33,13 +33,13 @@
 	</ul>
 
 	<?php if ( bp_current_user_can( 'bp_moderate' ) ) : ?>
-		<p><label for="send-notice"><input type="checkbox" id="send-notice" name="send-notice" value="1" /> <?php _e( "This is a notice to all users.", 'buddypress' ); ?></label></p>
+		<p><label for="send-notice"><input type="checkbox" id="send-notice" name="send-notice" value="1" /> <?php esc_html_e( "This is a notice to all users.", 'buddypress' ); ?></label></p>
 	<?php endif; ?>
 
-	<label for="subject"><?php _e( 'Subject', 'buddypress' ); ?></label>
+	<label for="subject"><?php esc_html_e( 'Subject', 'buddypress' ); ?></label>
 	<input type="text" name="subject" id="subject" value="<?php bp_messages_subject_value(); ?>" />
 
-	<label for="message_content"><?php _e( 'Message', 'buddypress' ); ?></label>
+	<label for="message_content"><?php esc_html_e( 'Message', 'buddypress' ); ?></label>
 	<textarea name="content" id="message_content" rows="15" cols="40"><?php bp_messages_content_value(); ?></textarea>
 
 	<input type="hidden" name="send_to_usernames" id="send-to-usernames" value="<?php bp_message_get_recipient_usernames(); ?>" class="<?php bp_message_get_recipient_usernames(); ?>" />


### PR DESCRIPTION
- Use a redirect to be sure to clear notice errors when a required field is missing.
- Preserve submitted texts and contacts in case of missing required fields.
- Improve the feedback message so that it informs about all missing required fields.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8578

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
