### PR TITLE
Option to Disable Private Message Notication

### DIFF
--- a/src/bp-core/admin/bp-core-admin-settings.php
+++ b/src/bp-core/admin/bp-core-admin-settings.php
@@ -201,6 +201,29 @@ function bp_admin_sanitize_callback_blogforum_comments( $value = false ) {
 	return $value ? 0 : 1;
 }
 
+/** Notification Section *******************************************************************/
+
+/**
+ * Notification settings section description for the settings page.
+ *
+ * @since 12.0.0
+ */
+function bp_admin_setting_callback_notifications_section() { }
+
+/**
+ * Allow Private Message Notification
+ *
+ * @since 12.0.0
+ */
+function bp_admin_setting_callback_private_message_notifications() {
+	?>
+
+	<input id="bp-enable-pm-notifications" name="bp-enable-pm-notifications" type="checkbox" value="1" <?php checked( bp_is_private_message_notification_active( true ) ); ?> />
+	<label for="bp-enable-pm-notifications"><?php _e( 'Allow notifications for new incoming private messages', 'buddypress' ); ?></label>
+
+<?php
+}
+
 /** Members *******************************************************************/
 
 /**

--- a/src/bp-core/bp-core-options.php
+++ b/src/bp-core/bp-core-options.php
@@ -697,6 +697,27 @@ function bp_is_activity_heartbeat_active( $default = true ) {
 }
 
 /**
+ * Check whether Private Message Notifications are enabled.
+ *
+ * @since 12.0.0
+ *
+ * @param bool $default Optional. Fallback value if not found in the database.
+ *                      Default: true.
+ * @return bool True if Private Message Notifications are enabled, otherwise false.
+ */
+function bp_is_private_message_notification_active( $default = true ) {
+
+	/**
+	 * Filters whether or not Private Message Notificatios are enabled.
+	 *
+	 * @since 12.0.0
+	 *
+	 * @param bool $value Whether or not Private Message Notificatios are enabled.
+	 */
+	return (bool) apply_filters( 'bp_is_private_message_notifications_active', (bool) bp_get_option( 'bp-enable-pm-notifications', $default ) );
+}
+
+/**
  * Get the current theme package ID.
  *
  * @since 1.7.0

--- a/src/bp-core/classes/class-bp-admin.php
+++ b/src/bp-core/classes/class-bp-admin.php
@@ -568,6 +568,18 @@ class BP_Admin {
 				register_setting( 'buddypress', '_bp_enable_akismet', 'intval' );
 			}
 		}
+
+		/* Notification Section **************************************************/
+
+		if ( bp_is_active( 'notifications' ) ) {
+
+			// Add the main section.
+			add_settings_section( 'bp_notifications', __( 'Notifications Settings', 'buddypress' ), 'bp_admin_setting_callback_notifications_section', 'buddypress' );
+
+			// Enable Private Message Notification
+			add_settings_field( 'bp-enable-pm-notifications', __( 'Private Message', 'buddypress' ), 'bp_admin_setting_callback_private_message_notifications', 'buddypress', 'bp_notifications' );
+			register_setting( 'buddypress', 'bp-enable-pm-notifications', 'intval' );
+		}
 	}
 
 	/**

--- a/src/bp-messages/bp-messages-notifications.php
+++ b/src/bp-messages/bp-messages-notifications.php
@@ -194,6 +194,17 @@ function messages_format_notifications( $action, $item_id, $secondary_item_id, $
  * @param BP_Messages_Message $message Message object.
  */
 function bp_messages_message_sent_add_notification( $message ) {
+
+	/**
+	 * Enable/Disables Notification for New Private Messages
+	 *
+	 * @since 12.0.0
+	 *
+	 */
+	if( ! bp_is_private_message_notification_active() ) {
+		return;
+	}
+
 	if ( ! empty( $message->recipients ) ) {
 		foreach ( (array) $message->recipients as $recipient ) {
 			bp_notifications_add_notification( array(


### PR DESCRIPTION
Currently, when a member sends a private message to another member, the receiver sees a notification beside the new message indicator.
I have added a new Notification Section and an option on the [BuddyPress](https://buddypress.trac.wordpress.org/wiki/BuddyPress) Settings Page to enable/disable the notification for new private messages.

I suggest the attached patch for the new feature. I am also adding the Screenshot of Settings:
https://www.awesomescreenshot.com/image/43208437?key=dc742fe4717afe153f121a55f5590264

**Trac ticket**: [https://buddypress.trac.wordpress.org/ticket/8997](url)

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**