### PR TITLE
Add a documentation page to explain Ajax Action registration

### DIFF
--- a/docs/developer/execution-contexts/README.md
+++ b/docs/developer/execution-contexts/README.md
@@ -1,0 +1,8 @@
+# BuddyPress execution contexts
+
+## Table of content
+
+1. Theme/front-end
+2. [Ajax](./ajax.md)
+3. REST API
+3. Administration

--- a/docs/developer/execution-contexts/ajax.md
+++ b/docs/developer/execution-contexts/ajax.md
@@ -1,0 +1,17 @@
+# Using Ajax requests in BuddyPress
+
+Starting in BuddyPress 12.0.0, if your Ajax callback needs to get values about BP URI globals such as the displayed user, the current component, the current action or current action variables, you'll need to register your Ajax action so that BuddyPress is informed you're expecting these globals' values.
+
+To avoid running the `WP()` request analysis at each Ajax request, BuddyPress is only doing so for the registered Ajax actions.
+
+To register your Ajax action, you simply need to use the `bp_ajax_register_action()` once the `bp_init` action hook has been fired.
+
+```php
+/**
+ * Register a BP Ajax action.
+ */
+function register_your_ajax_action() {
+	bp_ajax_register_action( 'your_ajax_action' );
+}
+add_action( 'bp_init', 'register_your_ajax_action' );
+```

--- a/docs/developer/manifest.json
+++ b/docs/developer/manifest.json
@@ -34,5 +34,17 @@
 		"slug": "bp-theme-compat",
 		"markdown_source": "../developer/theme-compat/README.md",
 		"parent": null
+	},
+	{
+		"title": "BuddyPress execution contexts",
+		"slug": "bp-execution-contexts",
+		"markdown_source": "../developer/execution-contexts/README.md",
+		"parent": null
+	},
+	{
+		"title": "Using Ajax requests in BuddyPress",
+		"slug": "bp-ajax-context",
+		"markdown_source": "../developer/execution-contexts/ajax.md",
+		"parent": null
 	}
 ]


### PR DESCRIPTION
In 12.0.0, using `bp_ajax_register_action()` is required to get BP URI globals values.

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
