### PR TITLE
Add phpunit-watcher for more convenient testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,10 +45,15 @@
 	"require-dev": {
 		"buddypress/bp-coding-standards": "dev-trunk",
 		"wp-phpunit/wp-phpunit": "^6.3",
-		"yoast/phpunit-polyfills": "^1.0.1"
+		"yoast/phpunit-polyfills": "^1.0.1",
+		"spatie/phpunit-watcher": "^1.23"
 	},
 	"scripts": {
 		"test": "@php ./vendor/phpunit/phpunit/phpunit",
+		"test:watch": [
+			"Composer\\Config::disableProcessTimeout",
+			"phpunit-watcher watch"
+		],
 		"phpcs" : "@php ./vendor/bin/phpcs"
 	}
 }

--- a/phpunit-watcher.yml.dist
+++ b/phpunit-watcher.yml.dist
@@ -1,0 +1,12 @@
+watch:
+  directories:
+    - ./src
+    - ./tests
+  fileMask: '*.php'
+  ignoreDotFiles: true
+  ignoreVCS: true
+  ignoreVCSIgnored: true
+
+notifications:
+  passingTests: false
+  failingTests: false


### PR DESCRIPTION
This is an alternative approach for a test watcher to the Grunt approach in [6382.6.patch](https://buddypress.trac.wordpress.org/attachment/ticket/6382/6382.6.patch). phpunit-watcher is used in Gutenberg, wordcamp.org, and several other wporg repos.

Pest may be a better alternative long term, but that might require a more substantial migration. There isn't any watcher right now, which makes testing less convenient (and therefore less likely). The ticket has been dormant for a long time, and this only took a few minutes to set up, so it seems like a good short/medium-term solution to me, even if folks eventually want to switch to Pest or something else. IMO it'd also be fine as a long-term solution.

To test, run `composer update`, then something like `composer run test:watch -- --group=groups,cache`. It should re-run the selected tests automatically when any PHP files in `src` or `tests` change.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/6382
