### PR TITLE
BP Nouveau: use the right total member count for the dynamic directory tab

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/members/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/members/functions.php
@@ -526,8 +526,8 @@ function bp_nouveau_members_loop_additional_info( $additional_info = array(), $a
 
 	$members_template = $GLOBALS['members_template'];
 
-	if ( isset( $members_template->member_count ) && 'all' === $args['scope'] ) {
-		$additional_info['totalItems'] = bp_core_number_format( $members_template->member_count );
+	if ( isset( $members_template->total_member_count ) && 'all' === $args['scope'] ) {
+		$additional_info['totalItems'] = bp_core_number_format( $members_template->total_member_count );
 		$additional_info['navLabel']   = esc_html__( 'All Members', 'buddypress' );
 
 		$nav_labels = array(


### PR DESCRIPTION
In [[13136]](https://buddypress.trac.wordpress.org/changeset/13136) I haven't used the right property to get the total member count. The `member_count` property in informing about the number of displayed members, the `total_member_count` is the right property to use.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9001

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
