### PR TITLE
Wait for 'bp-rewrites-ui' JS to be registered before enqueuing it

### DIFF
--- a/src/bp-core/admin/bp-core-admin-rewrites.php
+++ b/src/bp-core/admin/bp-core-admin-rewrites.php
@@ -28,8 +28,6 @@ function bp_core_admin_rewrites_load() {
 		.site-health-issues-wrapper .health-check-accordion:last-of-type { border-bottom: 1px solid #c3c4c7; }'
 	);
 
-	wp_enqueue_script( 'bp-rewrites-ui' );
-
 	// Handle slugs customization.
 	if ( isset( $_POST['bp-admin-rewrites-submit'] ) ) {
 		check_admin_referer( 'bp-admin-rewrites-setup' );
@@ -112,6 +110,8 @@ function bp_core_admin_rewrites_settings() {
 	$bp              = buddypress();
 	$bp_pages        = $bp->pages;
 	$reordered_pages = array();
+
+	wp_enqueue_script( 'bp-rewrites-ui' );
 
 	if ( isset( $bp_pages->register ) ) {
 		$reordered_pages['register'] = $bp_pages->register;


### PR DESCRIPTION
Wait for 'bp-rewrites-ui' JS to be registered before enqueuing it.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9003

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
