### PR TITLE
Make sure to set the user ID used inside `BP_Core_Nav`

### DIFF
--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -230,20 +230,23 @@ class BP_Members_Component extends BP_Component {
 		$this->register_permastruct = bp_get_signup_slug() . '/%' . $this->rewrite_ids['member_register'] . '%';
 		$this->activate_permastruct = bp_get_activate_slug() . '/%' . $this->rewrite_ids['member_activate'] . '%';
 
+		// Init the User's ID to use to build the Nav for.
+		$user_id = bp_loggedin_user_id();
+
 		/** Logged in user ***************************************************
 		 */
 
 		// The core userdata of the user who is currently logged in.
-		$bp->loggedin_user->userdata = bp_core_get_core_userdata( bp_loggedin_user_id() );
+		$bp->loggedin_user->userdata = bp_core_get_core_userdata( $user_id );
 
 		// Fetch the full name for the logged in user.
 		$bp->loggedin_user->fullname = isset( $bp->loggedin_user->userdata->display_name ) ? $bp->loggedin_user->userdata->display_name : '';
 
 		// Hits the DB on single WP installs so get this separately.
-		$bp->loggedin_user->is_super_admin = $bp->loggedin_user->is_site_admin = is_super_admin( bp_loggedin_user_id() );
+		$bp->loggedin_user->is_super_admin = $bp->loggedin_user->is_site_admin = is_super_admin( $user_id );
 
 		// The domain for the user currently logged in. eg: http://example.com/members/andy.
-		$bp->loggedin_user->domain = bp_members_get_user_url( bp_loggedin_user_id() );
+		$bp->loggedin_user->domain = bp_members_get_user_url( $user_id );
 
 		/**
 		 * Set the Displayed user for the classic BuddyPress. This should only be the case when the
@@ -251,14 +254,17 @@ class BP_Members_Component extends BP_Component {
 		 * `BP_Members_Component::parse_query()`.
 		 */
 		if ( bp_displayed_user_id() ) {
+			// We're viewing a speciific user, switch the ID to use for the Nav to this one.
+			$user_id = bp_displayed_user_id();
+
 			// The core userdata of the user who is currently being displayed.
-			$bp->displayed_user->userdata = bp_core_get_core_userdata( bp_displayed_user_id() );
+			$bp->displayed_user->userdata = bp_core_get_core_userdata( $user_id );
 
 			// Fetch the full name displayed user.
 			$bp->displayed_user->fullname = isset( $bp->displayed_user->userdata->display_name ) ? $bp->displayed_user->userdata->display_name : '';
 
 			// The domain for the user currently being displayed.
-			$bp->displayed_user->domain = bp_members_get_user_url( bp_displayed_user_id() );
+			$bp->displayed_user->domain = bp_members_get_user_url( $user_id );
 
 			// If A user is displayed, check if there is a front template
 			if ( bp_get_displayed_user() ) {
@@ -269,7 +275,7 @@ class BP_Members_Component extends BP_Component {
 		/** Initialize the nav for the members component *********************
 		 */
 
-		$this->nav = new BP_Core_Nav();
+		$this->nav = new BP_Core_Nav( $user_id );
 
 		/** Signup ***********************************************************
 		 */


### PR DESCRIPTION
Initialize the BP_Core_Nav object with a user ID, by default the logged in one. Use the displayed user ID if available.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9009

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
