### PR TITLE
Add a documentation page for BP URI globals functions

### DIFF
--- a/docs/developer/functions/README.md
+++ b/docs/developer/functions/README.md
@@ -1,4 +1,4 @@
 # BuddyPress Functions
 
 - [BP URL functions](./rewrites.md)
-- BP URI globals functions
+- [BP URI globals functions](uri-globals.md)

--- a/docs/developer/functions/uri-globals.md
+++ b/docs/developer/functions/uri-globals.md
@@ -1,0 +1,31 @@
+# BuddyPress URI Globals Functions
+
+These functions are informing about the BuddyPress object being displayed on front-end. Thanks to them, you can programmatically know whether a component's directory or a component's single item or a specific sub-page of both is being loaded. These are set inside the `parse_query()` method of [Components main classes](./../component/build-component.md#parsing-requests-about-your-custom-add-on-directory) when a BuddyPress page loads according to the requested URL.
+
+**NB**: it's important to note that since version 12.0.0 of BuddyPress, URI globals returned by the following functions are only fully set once the `bp_parse_query` hook has been fired. 
+
+## URL schemas
+
+To make sure to use the BP URI globals the right way, you need to know about the specificities of BP URL schemas.
+
+| Contexts | Schemas |
+|---|---|
+| Directories | site.url/`bp_current_component()`/ |
+| Members single item | site.url/members-slug/`bp_current_item()`/`bp_current_component()`/`bp_current_action()`/`bp_action_variables()`/ |
+| Groups single item | site.url/groups-slug/`bp_current_item()`/`bp_current_action()`/`bp_action_variables()`/ |
+
+## `bp_current_item()`
+
+This function was introduced in verion 1.0.0 & returns the slug of the single item being viewed. For instance, in `site.url/members/buddypress/` or `site.url/groups/buddypress/`, `bp_current_item()` is `buddypress`. 
+
+## `bp_current_component()`
+
+This function was introduced in verion 1.0.0 & returns the slug of the components being viewed. For instance, in `site.url/members/buddypress/activity/` or `site.url/activity/`, `bp_current_component()` is `activity`.
+
+## `bp_current_action()`
+
+This function was introduced in verion 1.0.0 & returns the slug of the single item action being viewed. For instance, in `site.url/members/buddypress/activity/mentions` or `site.url/groups/members`, `bp_current_component()` is respectively `mentions` & `members`.
+
+## `bp_action_variables()`
+
+This function was introduced in verion 1.0.0 & returns a list (`array`) of all what's after the single item action slug of the requested URL. For instance, in `site.url/members/buddypress/profile/edit/group/1/`, `bp_action_variables()` are `array( 'group', 1 )`.

--- a/docs/developer/functions/uri-globals.md
+++ b/docs/developer/functions/uri-globals.md
@@ -1,14 +1,14 @@
 # BuddyPress URI Globals Functions
 
-These functions are informing about the BuddyPress object being displayed on front-end. Thanks to them, you can programmatically know whether a component's directory or a component's single item or a specific sub-page of both is being loaded. These are set inside the `parse_query()` method of [Components main classes](./../component/build-component.md#parsing-requests-about-your-custom-add-on-directory) when a BuddyPress page loads according to the requested URL.
+These functions provide information about the BuddyPress object being displayed on the front end. Thanks to them, you can programmatically know whether a component's directory, a component's single item, or a specific sub-page is being loaded. These globals are set inside the `parse_query()` method of the [main class](./../component/build-component.md#parsing-requests-about-your-custom-add-on-directory) of each component when a BuddyPress page loads.
 
-**NB**: it's important to note that since version 12.0.0 of BuddyPress, URI globals returned by the following functions are only fully set once the `bp_parse_query` hook has been fired. 
+**NB**: It's important to note that as of version 12.0.0 of BuddyPress, URI globals  are only fully set once the `bp_parse_query` hook has been fired. 
 
 ## URL schemas
 
-To make sure to use the BP URI globals the right way, you need to know about the specificities of BP URL schemas.
+To use the BP URI globals the right way, you need to know about the specificities of the BP URL schemas.
 
-| Contexts | Schemas |
+| Context | Schema |
 |---|---|
 | Directories | site.url/`bp_current_component()`/ |
 | Members single item | site.url/members-slug/`bp_current_item()`/`bp_current_component()`/`bp_current_action()`/`bp_action_variables()`/ |
@@ -16,16 +16,16 @@ To make sure to use the BP URI globals the right way, you need to know about the
 
 ## `bp_current_item()`
 
-This function was introduced in verion 1.0.0 & returns the slug of the single item being viewed. For instance, in `site.url/members/buddypress/` or `site.url/groups/buddypress/`, `bp_current_item()` is `buddypress`. 
+This function was introduced in version 1.0.0. It returns the slug of the single item being viewed. For instance, in `site.url/members/alpha/` or `site.url/groups/alpha/`, `bp_current_item()` returns `alpha`. 
 
 ## `bp_current_component()`
 
-This function was introduced in verion 1.0.0 & returns the slug of the components being viewed. For instance, in `site.url/members/buddypress/activity/` or `site.url/activity/`, `bp_current_component()` is `activity`.
+This function was introduced in version 1.0.0. It returns the slug of the component being viewed. For instance, in `site.url/members/marie/activity/` or `site.url/activity/`, `bp_current_component()` returns `activity`.
 
 ## `bp_current_action()`
 
-This function was introduced in verion 1.0.0 & returns the slug of the single item action being viewed. For instance, in `site.url/members/buddypress/activity/mentions` or `site.url/groups/members`, `bp_current_component()` is respectively `mentions` & `members`.
+This function was introduced in version 1.0.0. It returns the slug of the single item action being viewed. For instance, in `site.url/members/marie/activity/mentions`, `bp_current_action()` returns `mentions`; in `site.url/groups/members`, `bp_current_action()` returns `members`.
 
 ## `bp_action_variables()`
 
-This function was introduced in verion 1.0.0 & returns a list (`array`) of all what's after the single item action slug of the requested URL. For instance, in `site.url/members/buddypress/profile/edit/group/1/`, `bp_action_variables()` are `array( 'group', 1 )`.
+This function was introduced in version 1.0.0. It returns a list (`array`) of the modifiers that follow the single item action slug in the requested URL. For instance, in `site.url/members/marie/profile/edit/group/1/`, `bp_action_variables()` returns `array( 'group', 1 )`.

--- a/docs/developer/manifest.json
+++ b/docs/developer/manifest.json
@@ -58,5 +58,11 @@
 		"slug": "rewrites",
 		"markdown_source": "../developer/functions/rewrites.md",
 		"parent": null
+	},
+	{
+		"title": "BuddyPress URI Globals Functions",
+		"slug": "uri-globals",
+		"markdown_source": "../developer/functions/uri-globals.md",
+		"parent": null
 	}
 ]


### PR DESCRIPTION
I think it's also important we explain that URI globals are only set once `bp_parse_query` hook has been fired.  My suggestion is to explain it documenting functions like `bp_current_component()`. 

@dcavins could you have a look about it? Thanks in advance.

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
