### PR TITLE
Introduce `bp_nouveau_activity_comment_data_attribute_id()`

### DIFF
--- a/src/bp-templates/bp-nouveau/buddypress/activity/comment.php
+++ b/src/bp-templates/bp-nouveau/buddypress/activity/comment.php
@@ -11,7 +11,7 @@
 
 bp_nouveau_activity_hook( 'before', 'comment' ); ?>
 
-<li id="acomment-<?php bp_activity_comment_id(); ?>" class="comment-item" <?php bp_nouveau_activity_data_attribute_id(); ?>>
+<li id="acomment-<?php bp_activity_comment_id(); ?>" class="comment-item" <?php bp_nouveau_activity_comment_data_attribute_id(); ?>>
 	<div class="acomment-avatar item-avatar">
 		<a href="<?php bp_activity_comment_user_link(); ?>">
 			<?php

--- a/src/bp-templates/bp-nouveau/includes/activity/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/template-tags.php
@@ -159,27 +159,21 @@ function bp_nouveau_activity_hook( $when = '', $suffix = '' ) {
 }
 
 /**
- * Output the `data-bp-activity-id` or `data-bp-activity-comment-id` attribute
- * according to the activity type.
+ * Output the `data-bp-activity-id` attribute.
  *
  * @since 10.0.0
  */
 function bp_nouveau_activity_data_attribute_id() {
-	$attribute  = 'data-bp-%1$s-id="%2$s"';
-	$type       = 'activity';
-	$id         = (int) bp_get_activity_id();
-	$comment_id = (int) bp_get_activity_comment_id();
+	printf( 'data-bp-activity-id="%d"', (int) bp_get_activity_id() );
+}
 
-	if ( 'activity_comment' === bp_get_activity_type() || $comment_id ) {
-		$type = 'activity-comment';
-
-
-		if ( $comment_id ) {
-			$id = $comment_id;
-		}
-	}
-
-	printf( $attribute, $type, $id );
+/**
+ * Output the `data-bp-activity-comment-id` attribute.
+ *
+ * @since 12.0.0
+ */
+function bp_nouveau_activity_comment_data_attribute_id() {
+	printf( 'data-bp-activity-comment-id="%d"', (int) bp_get_activity_comment_id() );
 }
 
 /**
@@ -276,7 +270,7 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 	 *
 	 * @todo This function is too large and needs refactoring and reviewing.
 	 * @since 3.0.0
-	 * 
+	 *
 	 * @global BP_Activity_Template $activities_template The Activity template loop.
 	 *
 	 * @param array $args See bp_nouveau_wrapper() for the description of parameters.
@@ -777,7 +771,7 @@ function bp_nouveau_activity_comment_buttons( $args = array() ) {
 	 * Get the action buttons for the activity comments
 	 *
 	 * @since 3.0.0
-	 * 
+	 *
 	 * @global BP_Activity_Template $activities_template The Activity template loop.
 	 *
 	 * @param array $args Optional. See bp_nouveau_wrapper() for the description of parameters.


### PR DESCRIPTION
This function is outputting the `data-bp-activity-comment-id` attribute. It was created as a replacement of `bp_nouveau_activity_data_attribute_id()` for the `activity/comment.php` template to avoid messing with activity types when not set (instead a requerying for the parent activity).

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9014

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
