### PR TITLE
Include 12.0 deprecated functions for new installs

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -5135,7 +5135,7 @@ function bp_core_get_admin_notifications() {
 			'text'    => __( 'Get The BP Classic Add-on', 'buddypress' ),
 			'title'   => __( 'Thank you for installing BuddyPress 12.0!', 'buddypress' ),
 			'content' => __( 'This major version is very specific as it introduces several large changes that could be incompatible with some third party BuddyPress plugins or BuddyPress standalone themes that have not been updated in the last few months.', 'buddypress' ) . '<br><br>' .
-				'<strong>' . __( 'If you plan to install and activate such plugins or themes, to prevent problems, we strongly advise you to install and activate the BP Classic Add-on.', 'buddypress' ) . '</strong>',
+				'<strong>' . __( 'If you plan to install and activate such plugins or themes, to prevent problems, we strongly advise you to install and activate the BP Classic Add-on first.', 'buddypress' ) . '</strong>',
 				'version' => 12.0,
 		),
 	);

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -4885,7 +4885,7 @@ function bp_get_deprecated_functions_versions() {
 	$current_version        = (float) bp_get_version();
 	$load_latest_deprecated = $initial_version < $current_version;
 
-	// We don't load deprecated functions for new installs.
+	// New installs.
 	if ( ! $load_latest_deprecated ) {
 		// Run some additional checks if PHPUnit is running.
 		if ( defined( 'BP_TESTS_DIR' ) ) {
@@ -4904,7 +4904,9 @@ function bp_get_deprecated_functions_versions() {
 				return false;
 			}
 		}
-		return array();
+
+		// Only load 12.0 deprecated functions.
+		return array( '12.0' );
 	}
 
 	// Try to get the first major version that was in used when BuddyPress was fist installed.
@@ -5119,7 +5121,23 @@ function bp_core_get_admin_notifications() {
 				'<strong>' . __( 'You still use a BP Legacy Widget.', 'buddypress' ) . '</strong><br><br>' .
 				__( 'If any of the above items are true, we strongly advise you to install and activate the Classic Add-on before updating to BuddyPress 12.0.0.', 'buddypress' ),
 				'version' => 11.4,
-		)
+		),
+		'bp120-new-installs-warning' => (object) array(
+			'id'      => 'bp120-new-installs-warning',
+			'href'    => add_query_arg(
+				array(
+					'tab'  => 'bp-add-ons',
+					'show' => 'bp-classic',
+					'n'    => 'bp120-new-installs-warning'
+				),
+				bp_get_admin_url( 'plugin-install.php' )
+			),
+			'text'    => __( 'Get The BP Classic Add-on', 'buddypress' ),
+			'title'   => __( 'Thank you for installing BuddyPress 12.0!', 'buddypress' ),
+			'content' => __( 'This major version is very specific as it introduces several large changes that could be incompatible with some third party BuddyPress plugins or BuddyPress standalone themes that have not been updated in the last few months.', 'buddypress' ) . '<br><br>' .
+				'<strong>' . __( 'If you plan to install and activate such plugins or themes, to prevent problems, we strongly advise you to install and activate the BP Classic Add-on.', 'buddypress' ) . '</strong>',
+				'version' => 12.0,
+		),
 	);
 
 	// Only keep unread notifications.

--- a/src/bp-core/bp-core-update.php
+++ b/src/bp-core/bp-core-update.php
@@ -203,12 +203,20 @@ function bp_version_updater() {
 		$switched_to_root_blog = true;
 	}
 
-	// Install BP schema and activate only Activity and XProfile.
+	// Install BP schema and activate default components.
 	if ( bp_is_install() ) {
 		// Set the first BP major version the plugin was installed.
 		bp_update_option( '_bp_initial_major_version', bp_get_major_version() );
 
-		// Apply schema and set Activity and XProfile components as active.
+		// Add an unread Admin notification.
+		if ( 13422 === bp_get_db_version() ) {
+			$unread   = bp_core_get_unread_admin_notifications();
+			$unread[] = 'bp120-new-installs-warning';
+
+			bp_update_option( 'bp_unread_admin_notifications', $unread );
+		}
+
+		// Apply schema and set default components as active.
 		bp_core_install( $default_components );
 		bp_update_option( 'bp-active-components', $default_components );
 		bp_core_add_page_mappings( $default_components, 'delete' );

--- a/tests/phpunit/testcases/core/functions.php
+++ b/tests/phpunit/testcases/core/functions.php
@@ -874,8 +874,8 @@ class BP_Tests_Core_Functions extends BP_UnitTestCase {
 		$current_version = (float) bp_get_version();
 		$versions        = bp_get_deprecated_functions_versions();
 
-		// When current version is the initial version, we shouldn't load deprecated functions files.
-		$this->assertTrue( is_array( $versions ) && ! $versions, 'Please check the list of `$deprecated_functions_versions` in `bp_get_deprecated_functions_versions()`. There should be one for each file of the `/src/bp-core/deprecated` directory.' );
+		// When current version is the initial version, we should only load 12.0 deprecated functions file.
+		$this->assertSame( $versions, array( '12.0' ), 'Please check the list of `$deprecated_functions_versions` in `bp_get_deprecated_functions_versions()`. There should be one for each file of the `/src/bp-core/deprecated` directory.' );
 
 		// We should load the 2 lasts deprecated functions files.
 		$this->bp_initial_version = '8.0';


### PR DESCRIPTION
- Include 12.0 deprecated functions for new installs.
- Add an Admin Notification about 12.0 for new installs.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9015

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
