### PR TITLE
Improve Post Comments settings UI

### DIFF
--- a/src/bp-core/admin/bp-core-admin-settings.php
+++ b/src/bp-core/admin/bp-core-admin-settings.php
@@ -148,10 +148,14 @@ function bp_admin_setting_callback_activity_akismet() {
  * @since 1.6.0
  */
 function bp_admin_setting_callback_blogforum_comments() {
+	$support = post_type_supports( 'post', 'buddypress-activity' );
 ?>
 
-	<input id="bp-disable-blogforum-comments" name="bp-disable-blogforum-comments" type="checkbox" value="1" <?php checked( !bp_disable_blogforum_comments( false ) ); ?> />
-	<label for="bp-disable-blogforum-comments"><?php _e( 'Allow activity stream commenting on posts and comments', 'buddypress' ); ?></label>
+	<input id="bp-disable-blogforum-comments" name="bp-disable-blogforum-comments" type="checkbox" value="1" <?php checked( ! bp_disable_blogforum_comments( false ) ); ?> <?php disabled( ! $support ); ?> />
+	<label for="bp-disable-blogforum-comments"><?php esc_html_e( 'Allow activity stream commenting on posts and comments', 'buddypress' ); ?></label>
+	<?php if ( ! $support ) : ?>
+		<p class="description"><?php esc_html_e( 'WordPress Post\'s support for BuddyPress activities is not active, this option will have no effects. An easy way to add this support is to activate the Site Tracking component.', 'buddypress' ); ?></p>
+	<?php endif; ?>
 
 <?php
 }


### PR DESCRIPTION
Uses a Post type's support check about BP Activities to disable the "Post Comments" option and include a description about why it's disabled and how to have it enabled.

<img width="838" alt="post-comments-settings" src="https://github.com/buddypress/buddypress/assets/1834524/85bfe091-76b2-461b-ad0e-baf1ee0422f2">


Trac ticket: https://buddypress.trac.wordpress.org/ticket/9016

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
