### PR TITLE
Avoid wrong usage of `$wpdb->prepare()`

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-query.php
+++ b/src/bp-activity/classes/class-bp-activity-query.php
@@ -162,7 +162,7 @@ class BP_Activity_Query extends BP_Recursive_Query {
 			}
 
 			// Tinyint.
-			if ( ! empty( $column ) && true === in_array( $column, array( 'hide_sitewide', 'is_spam' ) ) ) {
+			if ( ! empty( $column ) && true === in_array( $column, array( 'hide_sitewide', 'is_spam' ) ) && is_int( $value ) ) {
 				$sql_chunks['where'][] = $wpdb->prepare( "{$alias}{$column} = %d", $value );
 
 			} else {


### PR DESCRIPTION
Avoid wrong usage of `$wpdb->prepare()` in `BP_Activity_Query::get_sql_for_clause()` 

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9017

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
