### PR TITLE
Force permalinks to be refreshed after a fresh install

### DIFF
--- a/src/bp-core/bp-core-update.php
+++ b/src/bp-core/bp-core-update.php
@@ -222,6 +222,9 @@ function bp_version_updater() {
 		bp_core_add_page_mappings( $default_components, 'delete' );
 		bp_core_install_emails();
 
+		// Force permalinks to be refreshed at next page load.
+		bp_delete_rewrite_rules();
+
 	// Upgrades.
 	} else {
 


### PR DESCRIPTION
Force permalinks to be refreshed after a fresh install

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9018

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
