### PR TITLE
Avoid a fatal error when blog comments are synced with activity comments

### DIFF
--- a/src/bp-blogs/bp-blogs-activity.php
+++ b/src/bp-blogs/bp-blogs-activity.php
@@ -1029,8 +1029,8 @@ function bp_blogs_new_blog_comment_query_backpat( $args ) {
 	global $wpdb;
 	$bp = buddypress();
 
-	// If activity comments are disabled for blog posts, stop now!
-	if ( bp_disable_blogforum_comments() ) {
+	// If activity comments are disabled for blog posts or if the action is not a string, stop now!
+	if ( bp_disable_blogforum_comments() || ! is_string( $args['action'] ) ) {
 		return $args;
 	}
 


### PR DESCRIPTION
Make sure the `bp_blogs_new_blog_comment_query_backpat()` doesn't generate an error when an array of activity actions is requested by the activity loop.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9010

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
