### PR TITLE
Improve cover member header’s action buttons consistency

### DIFF
--- a/src/bp-templates/bp-nouveau/buddypress/members/single/cover-image-header.php
+++ b/src/bp-templates/bp-nouveau/buddypress/members/single/cover-image-header.php
@@ -3,7 +3,7 @@
  * BuddyPress - Users Cover Image Header
  *
  * @since 3.0.0
- * @version 7.0.0
+ * @version 12.0.0
  */
 ?>
 
@@ -25,15 +25,7 @@
 				<h2 class="user-nicename">@<?php bp_displayed_user_mentionname(); ?></h2>
 			<?php endif; ?>
 
-			<?php
-			bp_nouveau_member_header_buttons(
-				array(
-					'container'         => 'ul',
-					'button_element'    => 'button',
-					'container_classes' => array( 'member-header-actions' ),
-				)
-			);
-			?>
+			<?php bp_nouveau_member_header_buttons( array( 'container_classes' => array( 'member-header-actions' ) ) ); ?>
 
 			<?php bp_nouveau_member_hook( 'before', 'header_meta' ); ?>
 


### PR DESCRIPTION
Wrap the cover member header's action buttons into a `<div>`.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9023

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
