### PR TITLE
Do truncate group descriptions inside groups loop

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/groups/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/template-tags.php
@@ -1404,15 +1404,21 @@ function bp_nouveau_get_group_description_excerpt( $group = null, $length = null
 		}
 	}
 
+	if ( $length ) {
+		$excerpt = bp_create_excerpt( $group->description, $length );
+	} else {
+		$excerpt = bp_create_excerpt( $group->description );
+	}
+
 	/**
 	 * Filters the excerpt of a group description.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $value Excerpt of a group description.
-	 * @param object $group Object for group whose description is made into an excerpt.
+	 * @param string $excerpt Excerpt of a group description.
+	 * @param object $group   Object for group whose description is made into an excerpt.
 	 */
-	return apply_filters( 'bp_nouveau_get_group_description_excerpt', bp_create_excerpt( $group->description, $length ), $group );
+	return apply_filters( 'bp_nouveau_get_group_description_excerpt', $excerpt, $group );
 }
 
 /**


### PR DESCRIPTION
Avoid simply removing the last 11 characters of the group description only sending a valid `$length` parameter to `bp_create_excerpt()`.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9024

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
