### PR TITLE
Inform Admins/Site owners about current URL parser in use

### DIFF
--- a/src/bp-core/admin/bp-core-admin-tools.php
+++ b/src/bp-core/admin/bp-core-admin-tools.php
@@ -696,6 +696,19 @@ function bp_core_admin_debug_information( $debug_info = array() ) {
 	global $wp_settings_fields;
 	$active_components = array_intersect_key( bp_core_get_components(), buddypress()->active_components );
 	$bp_settings       = array();
+	$bp_url_parsers    = array(
+		'rewrites' => __( 'BP Rewrites API', 'buddypress' ),
+		'legacy'   => __( 'Legacy Parser', 'buddypress' ),
+	);
+
+	// Get the current URL parser.
+	$current_parser = bp_core_get_query_parser();
+	if ( isset( $bp_url_parsers[ $current_parser ] ) ) {
+		$bp_url_parser = $bp_url_parsers[ $current_parser ];
+	} else {
+		$bp_url_parser = __( 'Custom', 'buddypress' );
+	}
+
 
 	foreach ( $wp_settings_fields['buddypress'] as $section => $settings ) {
 		$prefix       = '';
@@ -753,6 +766,10 @@ function bp_core_admin_debug_information( $debug_info = array() ) {
 				'template_pack' => array(
 					'label' => __( 'Active template pack', 'buddypress' ),
 					'value' => bp_get_theme_compat_name() . ' ' . bp_get_theme_compat_version(),
+				),
+				'url_parser'    => array(
+					'label' => __( 'URL Parser', 'buddypress' ),
+					'value' => $bp_url_parser,
 				),
 			),
 			$bp_settings

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -142,7 +142,7 @@ function bp_is_running_wp( $version, $compare = '>=' ) {
 /** Functions *****************************************************************/
 
 /**
- * Get the BuddyPress parser in use.
+ * Get the BuddyPress URL Parser in use.
  *
  * @since 12.0.0
  *


### PR DESCRIPTION
Adds a new row to the BuddyPress panel of the WP Site Health's debug information screen to inform about the URL Parser currently in use (Legacy or BP Rewrites).

![site-health](https://github.com/buddypress/buddypress/assets/1834524/1acd56ba-c83f-4290-9466-7d8ba442ea55)


This should help us to reply to future support topics.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9027

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
