### PR TITLE
Avoid a PHP warning in `bp_core_current_user_ip()`

### DIFF
--- a/src/bp-core/bp-core-moderation.php
+++ b/src/bp-core/bp-core-moderation.php
@@ -330,7 +330,10 @@ function bp_core_check_for_disallowed_keys( $user_id = 0, $title = '', $content 
  * @return string IP address.
  */
 function bp_core_current_user_ip() {
-	$retval = preg_replace( '/[^0-9a-fA-F:., ]/', '', $_SERVER['REMOTE_ADDR'] );
+	$retval = '';
+	if ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
+		$retval = preg_replace( '/[^0-9a-fA-F:., ]/', '', wp_unslash( $_SERVER['REMOTE_ADDR'] ) );
+	}
 
 	/**
 	 * Filters the current user's IP address.


### PR DESCRIPTION
Avoid a PHP warning in `bp_core_current_user_ip()`

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9028

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
