### PR TITLE
Include WP 6.4 in Unit tests matrix

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,9 +20,9 @@ jobs:
         wp_version: ['master']
         include:
           - php: '8.0'
-            wp_version: '6.3'
+            wp_version: '6.4'
           - php: '7.4'
-            wp_version: '6.3'
+            wp_version: '6.4'
           - php: '7.4'
             wp_version: '5.8'
     env:

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 	},
 	"require-dev": {
 		"buddypress/bp-coding-standards": "dev-trunk",
-		"wp-phpunit/wp-phpunit": "^6.4",
+		"wp-phpunit/wp-phpunit": "^6.3",
 		"yoast/phpunit-polyfills": "^1.0.1"
 	},
 	"scripts": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 	},
 	"require-dev": {
 		"buddypress/bp-coding-standards": "dev-trunk",
-		"wp-phpunit/wp-phpunit": "^6.3",
+		"wp-phpunit/wp-phpunit": "^6.4",
 		"yoast/phpunit-polyfills": "^1.0.1"
 	},
 	"scripts": {


### PR DESCRIPTION
Update GH PHPunit tests action so that WP matrix includes WP 6.4

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9029

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
