### PR TITLE
Make sure the default selected field type is the 'textbox' one

### DIFF
--- a/src/bp-xprofile/bp-xprofile-admin.php
+++ b/src/bp-xprofile/bp-xprofile-admin.php
@@ -1201,7 +1201,7 @@ function bp_xprofile_admin_get_signup_field( $signup_field, $field_group = null,
 function bp_xprofile_admin_form_field_types( $select_field_type ) {
 	$categories = array();
 
-	if ( is_null( $select_field_type ) ) {
+	if ( empty( $select_field_type ) ) {
 		$select_field_type = 'textbox';
 	}
 


### PR DESCRIPTION
In [r13414](https://buddypress.trac.wordpress.org/changeset/13414/) the `BP_XProfile_Field::$type` variable default value was set to `''` to prevent deprecation notices. This move generated a side effect on the selected default field of the select box used to define a new xProfile field type. The `is_null()` check performed inside `bp_xprofile_admin_form_field_types()` needs to be replaced by a check for an empty string.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9035

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
