### PR TITLE
Only add the `no-js` body class when in community area

### DIFF
--- a/src/bp-templates/bp-legacy/buddypress-functions.php
+++ b/src/bp-templates/bp-legacy/buddypress-functions.php
@@ -84,9 +84,11 @@ class BP_Legacy extends BP_Theme_Compat {
 		add_action( 'bp_enqueue_community_scripts', array( $this, 'enqueue_scripts'  ) ); // Enqueue theme JS
 		add_action( 'bp_enqueue_community_scripts', array( $this, 'localize_scripts' ) ); // Enqueue theme script localization
 
-		/** Body no-js Class **************************************************/
-
-		add_filter( 'body_class', array( $this, 'add_nojs_body_class' ), 20, 1 );
+		/** This filter is documented in bp-core/bp-core-dependency.php */
+		if ( is_buddypress() || ! apply_filters( 'bp_enqueue_assets_in_bp_pages_only', true ) ) {
+			// Body no-js class.
+			add_filter( 'body_class', array( $this, 'add_nojs_body_class' ), 20, 1 );
+		}
 
 		/** Buttons ***********************************************************/
 

--- a/src/bp-templates/bp-nouveau/buddypress-functions.php
+++ b/src/bp-templates/bp-nouveau/buddypress-functions.php
@@ -220,8 +220,11 @@ class BP_Nouveau extends BP_Theme_Compat {
 		add_action( 'bp_enqueue_community_scripts', array( $this, 'localize_scripts' ) );
 		remove_action( 'bp_enqueue_community_scripts', 'bp_core_confirmation_js' );
 
-		// Body no-js class.
-		add_filter( 'body_class', array( $this, 'add_nojs_body_class' ), 20, 1 );
+		/** This filter is documented in bp-core/bp-core-dependency.php */
+		if ( is_buddypress() || ! apply_filters( 'bp_enqueue_assets_in_bp_pages_only', true ) ) {
+			// Body no-js class.
+			add_filter( 'body_class', array( $this, 'add_nojs_body_class' ), 20, 1 );
+		}
 
 		// Ajax querystring.
 		add_filter( 'bp_ajax_querystring', 'bp_nouveau_ajax_querystring', 10, 2 );


### PR DESCRIPTION
[r13418](https://buddypress.trac.wordpress.org/changeset/13418/) introduced a regression leaving the `no-js` body class when not in the community area as we do not load community assets everywhere on the site anymore and some themes are using this class to be informed whether JavaScript is enabled or not (eg: TwentyFifteen).

We forgot we also needed to avoid adding this `no-js` body class when not in a community area (See #8679).

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9033

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
