### PR TITLE
Improve BP Directory/page panels in URLs settings tab

### DIFF
--- a/src/bp-core/admin/bp-core-admin-rewrites.php
+++ b/src/bp-core/admin/bp-core-admin-rewrites.php
@@ -183,6 +183,37 @@ function bp_core_admin_rewrites_settings() {
 											<input type="text" class="code" name="<?php printf( 'components[%d][post_name]', absint( $directory_data->id ) ); ?>" id="<?php echo esc_attr( sprintf( '%s-directory-slug', sanitize_key( $component_id ) ) ); ?>" value="<?php echo esc_attr( $directory_data->slug ); ?>">
 										</td>
 									</tr>
+									<tr>
+										<th scope="row">
+											<label for="<?php echo esc_attr( sprintf( '%s-directory-url', sanitize_key( $component_id ) ) ); ?>">
+												<?php ( 'activate' === $component_id || 'register' === $component_id ) ? esc_html_e( 'Page permalink', 'buddypress' ) : esc_html_e( 'Directory permalink', 'buddypress' ); ?>
+											</label>
+										</th>
+										<td>
+											<?php
+											$url_args = array(
+												'component_id' => $component_id,
+											);
+
+											if ( 'activate' === $component_id || 'register' === $component_id ) {
+												$url_args = array(
+													'component_id'                        => 'members',
+													sprintf( 'member_%s', $component_id ) => 1,
+												);
+											}
+
+											$permalink = bp_rewrites_get_url( $url_args );
+											?>
+											<input type="text" class="code bp-directory-url" id="<?php echo esc_attr( sprintf( '%s-directory-url', sanitize_key( $component_id ) ) ); ?>" value="<?php echo esc_url( $permalink ); ?>" disabled="disabled">
+
+											<?php if ( 'activate' !== $component_id && 'register' !== $component_id ) : ?>
+												<a href="<?php echo esc_url( $permalink ); ?>" class="button-secondary bp-open-permalink" target="_bp">
+													<?php esc_html_e( 'View', 'buddypress' ); ?> <span class="dashicons dashicons-external" aria-hidden="true"></span>
+													<span class="screen-reader-text"><?php esc_html_e( '(opens in a new tab)', 'buddypress' ); ?></span>
+												</a>
+											<?php endif; ?>
+										</td>
+									</tr>
 								</table>
 							</div>
 						</div>

--- a/src/bp-core/admin/css/common-rtl.css
+++ b/src/bp-core/admin/css/common-rtl.css
@@ -15,8 +15,9 @@ TABLE OF CONTENTS:
 2.0 Dashicons
 	2.1 Top level menus
 	2.2 Settings - Components
-	2.3 Tools
-	2.4 Tooltips
+	2.3 Settings - URls
+	2.4 Tools
+	2.5 Tooltips
 3.0 Users
 	3.1 Users List
 	3.2 Site Notices
@@ -307,7 +308,22 @@ TABLE OF CONTENTS:
 }
 
 /*
- * 2.3 Tools
+ * 2.3 Settings - URLs
+ */
+.settings_page_bp-rewrites .bp-directory-url {
+	width: 80%;
+	box-shadow: 0 0 0 transparent;
+	border: 1px solid #8c8f94;
+	background-color: #fff;
+	color: #2c3338;
+}
+
+.settings_page_bp-rewrites .bp-open-permalink .dashicons {
+	vertical-align: sub;
+}
+
+/*
+ * 2.4 Tools
  */
 #adminmenu .toplevel_page_network-tools div.wp-menu-image:before {
 	content: "";
@@ -330,7 +346,7 @@ body.tools_page_bp-optouts .nav-tab-wrapper {
 }
 
 /*
- * 2.4 Tooltips
+ * 2.5 Tooltips
  */
 .bp-tooltip {
 	position: relative;

--- a/src/bp-core/admin/css/common.css
+++ b/src/bp-core/admin/css/common.css
@@ -15,8 +15,9 @@ TABLE OF CONTENTS:
 2.0 Dashicons
 	2.1 Top level menus
 	2.2 Settings - Components
-	2.3 Tools
-	2.4 Tooltips
+	2.3 Settings - URls
+	2.4 Tools
+	2.5 Tooltips
 3.0 Users
 	3.1 Users List
 	3.2 Site Notices
@@ -307,7 +308,22 @@ TABLE OF CONTENTS:
 }
 
 /*
- * 2.3 Tools
+ * 2.3 Settings - URLs
+ */
+.settings_page_bp-rewrites .bp-directory-url {
+	width: 80%;
+	box-shadow: 0 0 0 transparent;
+	border: 1px solid #8c8f94;
+	background-color: #fff;
+	color: #2c3338;
+}
+
+.settings_page_bp-rewrites .bp-open-permalink .dashicons {
+	vertical-align: sub;
+}
+
+/*
+ * 2.4 Tools
  */
 #adminmenu .toplevel_page_network-tools div.wp-menu-image:before {
 	content: "";
@@ -330,7 +346,7 @@ body.tools_page_bp-optouts .nav-tab-wrapper {
 }
 
 /*
- * 2.4 Tooltips
+ * 2.5 Tooltips
  */
 .bp-tooltip {
 	position: relative;

--- a/src/bp-core/admin/js/rewrites-ui.js
+++ b/src/bp-core/admin/js/rewrites-ui.js
@@ -4,9 +4,9 @@
 
 		accordions.forEach( function( accordion ) {
 			accordion.addEventListener( 'click', function( e ) {
-				e.preventDefault();
-
 				if ( e.target && e.target.matches( 'button.health-check-accordion-trigger' ) ) {
+					e.preventDefault();
+
 					var isExpanded = ( 'true' === e.target.getAttribute( 'aria-expanded' ) ),
 					    panel = document.querySelector( '#' + e.target.getAttribute( 'aria-controls' ) );
 


### PR DESCRIPTION
- Adds a Disabled input to inform about the directory/page permalink
- Adds a button to open the corresponding page into a new window.

<img width="880" alt="bp-rewrites-admin-panel" src="https://github.com/buddypress/buddypress/assets/1834524/57b0ea4a-7eb7-414d-9aa5-a1ffd679ef60">

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9039

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
