### PR TITLE
Make sure slugs are customizable for BP Network activated with subsite root

### DIFF
--- a/src/bp-core/admin/bp-core-admin-rewrites.php
+++ b/src/bp-core/admin/bp-core-admin-rewrites.php
@@ -38,6 +38,14 @@ function bp_core_admin_rewrites_load() {
 			wp_safe_redirect( add_query_arg( 'error', 'true', $base_url ) );
 		}
 
+		$switched_to_root_blog = false;
+
+		// Make sure the current blog is set to the root blog.
+		if ( ! bp_is_root_blog() ) {
+			switch_to_blog( bp_get_root_blog_id() );
+			$switched_to_root_blog = true;
+		}
+
 		$directory_pages     = (array) bp_core_get_directory_pages();
 		$current_page_slugs  = wp_list_pluck( $directory_pages, 'slug', 'id' );
 		$current_page_titles = wp_list_pluck( $directory_pages, 'title', 'id' );
@@ -95,6 +103,10 @@ function bp_core_admin_rewrites_load() {
 		// Make sure the WP rewrites will be regenarated at next page load.
 		if ( $reset_rewrites ) {
 			bp_delete_rewrite_rules();
+		}
+
+		if ( $switched_to_root_blog ) {
+			restore_current_blog();
 		}
 
 		wp_safe_redirect( add_query_arg( 'updated', 'true', $base_url ) );

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -775,7 +775,14 @@ function bp_core_get_directory_pages() {
 	if ( false === $pages ) {
 
 		// Set pages as standard class.
-		$pages = new stdClass;
+		$pages                 = new stdClass;
+		$switched_to_root_blog = false;
+
+		// Make sure the current blog is set to the root blog.
+		if ( ! bp_is_root_blog() && ! bp_is_multiblog_mode() ) {
+			switch_to_blog( bp_get_root_blog_id() );
+			$switched_to_root_blog = true;
+		}
 
 		// Get pages and IDs.
 		$page_ids = bp_core_get_directory_page_ids();
@@ -815,6 +822,10 @@ function bp_core_get_directory_pages() {
 					unset( $slug );
 				}
 			}
+		}
+
+		if ( $switched_to_root_blog ) {
+			restore_current_blog();
 		}
 
 		wp_cache_set( 'directory_pages', $pages, 'bp_pages' );

--- a/src/bp-core/bp-core-rewrites.php
+++ b/src/bp-core/bp-core-rewrites.php
@@ -51,7 +51,7 @@ function bp_rewrites_get_default_url_chunks() {
  * @since 12.0.0
  */
 function bp_delete_rewrite_rules() {
-	delete_option( 'rewrite_rules' );
+	bp_delete_option( 'rewrite_rules' );
 }
 
 /**


### PR DESCRIPTION
- [x] Fixes the customization issue,
- [x] Checked the tool to reset slugs
- [x] Simulated another upgrade having pages named like directories on the main site and no slug conflicts were found (no $suffix were added to `buddypress` post types slugs.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9048

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
