### PR TITLE
Make sure sure a BP directory used as home does not 404 in the customizer

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -481,7 +481,7 @@ class BP_Activity_Component extends BP_Component {
 			return parent::parse_query( $query );
 		}
 
-		if ( home_url( '/' ) === bp_get_requested_url() && bp_is_directory_homepage( $this->id ) ) {
+		if ( bp_is_site_home() && bp_is_directory_homepage( $this->id ) ) {
 			$query->set( $this->rewrite_ids['directory'], 1 );
 		}
 

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -1926,6 +1926,25 @@ function bp_is_blog_page() {
 }
 
 /**
+ * Checks whether the requested URL is site home's one.
+ *
+ * @since 12.1.0
+ *
+ * @return boolean True if the requested URL is site home's one. False otherwise.
+ */
+function bp_is_site_home() {
+	$requested_url = bp_get_requested_url();
+	$home_url      = home_url( '/' );
+
+	if ( is_customize_preview() ) {
+		$requested_url = wp_parse_url( $requested_url, PHP_URL_PATH );
+		$home_url      = wp_parse_url( $home_url, PHP_URL_PATH );
+	}
+
+	return $home_url === $requested_url;
+}
+
+/**
  * Is this a BuddyPress component?
  *
  * You can tell if a page is displaying BP content by whether the

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -1064,7 +1064,7 @@ class BP_Groups_Component extends BP_Component {
 			return parent::parse_query( $query );
 		}
 
-		if ( home_url( '/' ) === bp_get_requested_url() && bp_is_directory_homepage( $this->id ) ) {
+		if ( bp_is_site_home() && bp_is_directory_homepage( $this->id ) ) {
 			$query->set( $this->rewrite_ids['directory'], 1 );
 		}
 

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -796,7 +796,7 @@ class BP_Members_Component extends BP_Component {
 			add_action( 'bp_screens', 'bp_members_screen_display_profile', 3 );
 		}
 
-		if ( home_url( '/' ) === bp_get_requested_url() && bp_is_directory_homepage( $this->id ) ) {
+		if ( bp_is_site_home() && bp_is_directory_homepage( $this->id ) ) {
 			$query->set( $this->rewrite_ids['directory'], 1 );
 		}
 


### PR DESCRIPTION
Introduce `bp_is_site_home()` to check requested URL is site home even into the customizer.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9056

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
