### PR TITLE
fix: incorrect function arguments passed to bp_rewrites_get_url filte…

### DIFF
--- a/src/bp-core/bp-core-rewrites.php
+++ b/src/bp-core/bp-core-rewrites.php
@@ -175,7 +175,7 @@ function bp_rewrites_get_url( $args = array() ) {
 	$bp  = buddypress();
 	$url = get_home_url( bp_get_root_blog_id() );
 
-	$args = bp_parse_args(
+	$r = bp_parse_args(
 		$args,
 		array(
 			'component_id'                 => '',

--- a/src/bp-core/bp-core-rewrites.php
+++ b/src/bp-core/bp-core-rewrites.php
@@ -282,7 +282,7 @@ function bp_rewrites_get_url( $args = array() ) {
 	 * @since 12.0.0
 	 *
 	 * @param string $url The BuddyPress URL.
-	 * @param array  $args {
+	 * @param array  $path_chunks {
 	 *      Optional. An array of arguments.
 	 *
 	 *      @type string $component_id                The BuddyPress component ID. Defaults ''.

--- a/src/bp-core/bp-core-rewrites.php
+++ b/src/bp-core/bp-core-rewrites.php
@@ -187,7 +187,8 @@ function bp_rewrites_get_url( $args = array() ) {
 		)
 	);
 
-	$r = $args;
+	// Define the path chunks out of parsed arguments to make them available & unchanged for the 'bp_rewrites_get_url' filter.
+	$path_chunks = $r;
 
 	if ( $r['component_id'] && isset( $bp->{$r['component_id']}->rewrite_ids ) ) {
 		$component = $bp->{$r['component_id']};

--- a/src/bp-core/bp-core-rewrites.php
+++ b/src/bp-core/bp-core-rewrites.php
@@ -297,7 +297,7 @@ function bp_rewrites_get_url( $args = array() ) {
 	 *      @type array $single_item_action_variables The list of BuddyPress single item's action variable URL chunks. Defaults [].
 	 * }
 	 */
-	return apply_filters( 'bp_rewrites_get_url', $url, $args );
+	return apply_filters( 'bp_rewrites_get_url', $url, $path_chunks, $args );
 }
 
 /**

--- a/src/bp-core/bp-core-rewrites.php
+++ b/src/bp-core/bp-core-rewrites.php
@@ -296,6 +296,7 @@ function bp_rewrites_get_url( $args = array() ) {
 	 *                                                Eg: the member's Activity mentions page.
 	 *      @type array $single_item_action_variables The list of BuddyPress single item's action variable URL chunks. Defaults [].
 	 * }
+	 * @param array  $args Original arguments used with the function.
 	 */
 	return apply_filters( 'bp_rewrites_get_url', $url, $path_chunks, $args );
 }

--- a/src/bp-core/bp-core-rewrites.php
+++ b/src/bp-core/bp-core-rewrites.php
@@ -175,7 +175,7 @@ function bp_rewrites_get_url( $args = array() ) {
 	$bp  = buddypress();
 	$url = get_home_url( bp_get_root_blog_id() );
 
-	$r = bp_parse_args(
+	$args = bp_parse_args(
 		$args,
 		array(
 			'component_id'                 => '',
@@ -186,6 +186,8 @@ function bp_rewrites_get_url( $args = array() ) {
 			'single_item_action_variables' => array(),
 		)
 	);
+
+	$r = $args;
 
 	if ( $r['component_id'] && isset( $bp->{$r['component_id']}->rewrite_ids ) ) {
 		$component = $bp->{$r['component_id']};
@@ -274,12 +276,12 @@ function bp_rewrites_get_url( $args = array() ) {
 	}
 
 	/**
-	 * Filter here to edit any BudyPress URL.
+	 * Filter here to edit any BuddyPress URL.
 	 *
 	 * @since 12.0.0
 	 *
-	 * @param string $url The BudyPress URL.
-	 * @param array  $r {
+	 * @param string $url The BuddyPress URL.
+	 * @param array  $args {
 	 *      Optional. An array of arguments.
 	 *
 	 *      @type string $component_id                The BuddyPress component ID. Defaults ''.
@@ -294,7 +296,7 @@ function bp_rewrites_get_url( $args = array() ) {
 	 *      @type array $single_item_action_variables The list of BuddyPress single item's action variable URL chunks. Defaults [].
 	 * }
 	 */
-	return apply_filters( 'bp_rewrites_get_url', $url, $r );
+	return apply_filters( 'bp_rewrites_get_url', $url, $args );
 }
 
 /**


### PR DESCRIPTION
…r (fixes #9060)

The bp_rewrites_get_url() function passes function arguments after they have been modified by the function. This fix ensures the original function arguments are passed to the filter so critical fields remain intact.

<!-- Insert a description of your changes here -->

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9060#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
