### PR TITLE
Make sure using a BP Directory as front page do not conflict with BP email preview

### DIFF
--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -1936,7 +1936,7 @@ function bp_is_site_home() {
 	$requested_url = bp_get_requested_url();
 	$home_url      = home_url( '/' );
 
-	if ( is_customize_preview() ) {
+	if ( is_customize_preview() && ! bp_is_email_customizer() ) {
 		$requested_url = wp_parse_url( $requested_url, PHP_URL_PATH );
 		$home_url      = wp_parse_url( $home_url, PHP_URL_PATH );
 	}

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -3781,6 +3781,20 @@ function bp_email_the_salutation( $settings = array() ) {
 	}
 
 /**
+ * Outputs the BP Email's template footer.
+ *
+ * @since 12.1.0
+ */
+function bp_email_footer() {
+	// `the_block_template_skip_link()` was deprecated in WP 6.4.0.
+	if ( bp_is_running_wp( '6.4.0', '>=' ) && has_action( 'wp_footer', 'the_block_template_skip_link' ) ) {
+		remove_action( 'wp_footer', 'the_block_template_skip_link' );
+	}
+
+	wp_footer();
+}
+
+/**
  * Checks if a Widget/Block is active.
  *
  * @since 9.0.0

--- a/src/bp-templates/bp-legacy/buddypress/assets/emails/single-bp-email.php
+++ b/src/bp-templates/bp-legacy/buddypress/assets/emails/single-bp-email.php
@@ -240,6 +240,6 @@ $settings = bp_email_get_appearance_settings();
 		</div>
 	</center>
 </td></tr></table>
-<?php if ( function_exists( 'is_customize_preview' ) && is_customize_preview() ) wp_footer(); ?>
+<?php if ( function_exists( 'is_customize_preview' ) && is_customize_preview() ) bp_email_footer(); ?>
 </body>
 </html>

--- a/src/bp-templates/bp-nouveau/buddypress/assets/emails/single-bp-email.php
+++ b/src/bp-templates/bp-nouveau/buddypress/assets/emails/single-bp-email.php
@@ -242,7 +242,7 @@ $settings = bp_email_get_appearance_settings();
 </td></tr></table>
 <?php
 if ( function_exists( 'is_customize_preview' ) && is_customize_preview() ) {
-	wp_footer();
+	bp_email_footer();
 }
 ?>
 </body>


### PR DESCRIPTION
[r13689](https://buddypress.trac.wordpress.org/changeset/13689) introduced a side effect with the BP Email customization feature. Instead of showing a random Email it was showing the site’s home page when a BP Directory was set as the home page. The PR is making sure to avoid overriding the WP Request when a BP Email is being previewed into the customizer.

Many thanks to @emaralive for reporting this issue.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9056

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
