### PR TITLE
Fix 9067

### DIFF
--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -193,7 +193,10 @@ function bp_core_load_template( $templates ) {
 			$wp_query->is_404      = false;
 
 			// Check if a BuddyPress component's direcory is set as homepage.
-			$wp_query->is_home = bp_is_directory_homepage( bp_current_component() );
+			if ( bp_is_directory_homepage( bp_current_component() ) ) {
+				$wp_query->home          = true;
+				$wp_query->is_front_page = true;
+			}
 		}
 
 		/**


### PR DESCRIPTION
Make sure Block Themes are using the right template to display a BP Directory when it is set as the site's front page.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9067

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
