### PR TITLE
Use a common class to widgets and posts to style avatars Block Widgets

### DIFF
--- a/src/bp-members/blocks/active-members/index.asset.php
+++ b/src/bp-members/blocks/active-members/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-i18n', 'wp-server-side-render'), 'version' => '2cf313e342f1db29f272');
+<?php return array('dependencies' => array('react', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-i18n', 'wp-server-side-render'), 'version' => 'ebcabdc452d850bc2b31');

--- a/src/bp-members/blocks/active-members/index.css
+++ b/src/bp-members/blocks/active-members/index.css
@@ -1,1 +1,1 @@
-.wp-block-bp-active-members .avatar-block,[data-type="bp/active-members"] .avatar-block{display:flex;flex-flow:row wrap}.wp-block-bp-active-members .avatar-block img,[data-type="bp/active-members"] .avatar-block img{margin:.5em}
+.widget_bp_core_recently_active_widget .avatar-block,[data-type="bp/active-members"] .avatar-block{display:flex;flex-flow:row wrap}.widget_bp_core_recently_active_widget .avatar-block img,[data-type="bp/active-members"] .avatar-block img{margin:.5em}

--- a/src/bp-members/blocks/online-members/index.asset.php
+++ b/src/bp-members/blocks/online-members/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-i18n', 'wp-server-side-render'), 'version' => 'a682169cdddb9445585b');
+<?php return array('dependencies' => array('react', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-i18n', 'wp-server-side-render'), 'version' => '9d7011c1c325cb35815b');

--- a/src/bp-members/blocks/online-members/index.css
+++ b/src/bp-members/blocks/online-members/index.css
@@ -1,1 +1,1 @@
-.wp-block-bp-online-members .avatar-block,[data-type="bp/online-members"] .avatar-block{display:flex;flex-flow:row wrap}.wp-block-bp-online-members .avatar-block img,[data-type="bp/online-members"] .avatar-block img{margin:.5em}
+.widget_bp_core_whos_online_widget .avatar-block,[data-type="bp/online-members"] .avatar-block{display:flex;flex-flow:row wrap}.widget_bp_core_whos_online_widget .avatar-block img,[data-type="bp/online-members"] .avatar-block img{margin:.5em}

--- a/src/js/blocks/bp-members/active-members/active-members.scss
+++ b/src/js/blocks/bp-members/active-members/active-members.scss
@@ -1,6 +1,6 @@
 // BP Active members widget
 [data-type="bp/active-members"],
-.wp-block-bp-active-members {
+.widget_bp_core_recently_active_widget {
 
 	.avatar-block {
 		display: flex;

--- a/src/js/blocks/bp-members/online-members/online-members.scss
+++ b/src/js/blocks/bp-members/online-members/online-members.scss
@@ -1,6 +1,6 @@
 // BP Who's online widget
 [data-type="bp/online-members"],
-.wp-block-bp-online-members {
+.widget_bp_core_whos_online_widget {
 
 	.avatar-block {
 		display: flex;


### PR DESCRIPTION
Style online/active members the same way whether it's in a post or in a sidebar widgets.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9037

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
