### PR TITLE
Make sure to check for deprecated function files according to the current major release

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -4846,30 +4846,30 @@ function bp_get_deprecated_functions_versions() {
 
 	// List of versions containing deprecated functions.
 	$deprecated_functions_versions = array(
-		'1.2',
-		'1.5',
-		'1.6',
-		'1.7',
-		'1.9',
-		'2.0',
-		'2.1',
-		'2.2',
-		'2.3',
-		'2.4',
-		'2.5',
-		'2.6',
-		'2.7',
-		'2.8',
-		'2.9',
-		'3.0',
-		'4.0',
-		'6.0',
-		'7.0',
-		'8.0',
-		'9.0',
-		'10.0',
-		'11.0',
-		'12.0',
+		1.2,
+		1.5,
+		1.6,
+		1.7,
+		1.9,
+		2.0,
+		2.1,
+		2.2,
+		2.3,
+		2.4,
+		2.5,
+		2.6,
+		2.7,
+		2.8,
+		2.9,
+		3.0,
+		4.0,
+		6.0,
+		7.0,
+		8.0,
+		9.0,
+		10.0,
+		11.0,
+		12.0,
 	);
 
 	/*
@@ -4893,8 +4893,8 @@ function bp_get_deprecated_functions_versions() {
 	 * 2 last versions deprecated functions will be loaded for upgraded installs.
 	 */
 	$initial_version        = (float) bp_get_initial_version();
-	$current_version        = (float) bp_get_version();
-	$load_latest_deprecated = $initial_version < bp_get_major_version( $current_version );
+	$current_major_version  = (float) bp_get_major_version( bp_get_version() );
+	$load_latest_deprecated = $initial_version < $current_major_version;
 
 	// New installs.
 	if ( ! $load_latest_deprecated ) {
@@ -4904,7 +4904,7 @@ function bp_get_deprecated_functions_versions() {
 				array_map(
 					function( $file ) {
 						if ( false !== strpos( $file, '.php' ) ) {
-							return str_replace( '.php', '', $file );
+							return (float) str_replace( '.php', '', $file );
 						};
 					},
 					scandir( buddypress()->plugin_dir . 'bp-core/deprecated' )
@@ -4917,7 +4917,7 @@ function bp_get_deprecated_functions_versions() {
 		}
 
 		// Only load 12.0 deprecated functions.
-		return array( '12.0' );
+		return array( 12.0 );
 	}
 
 	$index_first_major = array_search( $initial_version, $deprecated_functions_versions, true );

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -4894,7 +4894,7 @@ function bp_get_deprecated_functions_versions() {
 	 */
 	$initial_version        = (float) bp_get_initial_version();
 	$current_version        = (float) bp_get_version();
-	$load_latest_deprecated = $initial_version < $current_version;
+	$load_latest_deprecated = $initial_version < bp_get_major_version( $current_version );
 
 	// New installs.
 	if ( ! $load_latest_deprecated ) {
@@ -4920,13 +4920,7 @@ function bp_get_deprecated_functions_versions() {
 		return array( '12.0' );
 	}
 
-	// Try to get the first major version that was in used when BuddyPress was fist installed.
-	$first_major = '';
-	if ( $initial_version ) {
-		$first_major = bp_get_major_version( $initial_version );
-	}
-
-	$index_first_major = array_search( $first_major, $deprecated_functions_versions, true );
+	$index_first_major = array_search( $initial_version, $deprecated_functions_versions, true );
 	if ( false === $index_first_major ) {
 		return array_splice( $deprecated_functions_versions, -2 );
 	}
@@ -4937,7 +4931,7 @@ function bp_get_deprecated_functions_versions() {
 		$latest_deprecated_functions_versions = array_splice( $latest_deprecated_functions_versions, -2 );
 	}
 
-	$index_initial_version = array_search( $first_major, $latest_deprecated_functions_versions, true );
+	$index_initial_version = array_search( $initial_version, $latest_deprecated_functions_versions, true );
 	if ( false !== $index_initial_version ) {
 		unset( $latest_deprecated_functions_versions[ $index_initial_version ] );
 	}

--- a/src/class-buddypress.php
+++ b/src/class-buddypress.php
@@ -654,7 +654,7 @@ class BuddyPress {
 
 			foreach ( $deprecated_functions_versions as $deprecated_functions_version ) {
 				// Load all or last 2 deprecated versions.
-				require $this->plugin_dir . sprintf( 'bp-core/deprecated/%s.php', $deprecated_functions_version );
+				require $this->plugin_dir . sprintf( 'bp-core/deprecated/%s.php', number_format( $deprecated_functions_version, 1 ) );
 			}
   		}
 

--- a/tests/phpunit/testcases/core/functions.php
+++ b/tests/phpunit/testcases/core/functions.php
@@ -877,7 +877,7 @@ class BP_Tests_Core_Functions extends BP_UnitTestCase {
 		$bp              = buddypress();
 
 		// When current major version is the initial version, we should only load 12.0 deprecated functions file.
-		$this->assertSame( $versions, array( '12.0' ), 'Please check the list of `$deprecated_functions_versions` in `bp_get_deprecated_functions_versions()`. There should be one for each file of the `/src/bp-core/deprecated` directory.' );
+		$this->assertSame( $versions, array( 12.0 ), 'Please check the list of `$deprecated_functions_versions` in `bp_get_deprecated_functions_versions()`. There should be one for each file of the `/src/bp-core/deprecated` directory.' );
 
 		$bp->version = '12.1.1';
 
@@ -888,13 +888,13 @@ class BP_Tests_Core_Functions extends BP_UnitTestCase {
 
 		$versions = bp_get_deprecated_functions_versions();
 
-		$this->assertContains( '12.0', $versions, '12.0 deprecated functions should be loaded when 12.1.1 was the first installed version.' );
+		$this->assertContains( 12.0, $versions, '12.0 deprecated functions should be loaded when 12.1.1 was the first installed version.' );
 
 		$this->bp_initial_version = '9.0';
 
 		$versions = bp_get_deprecated_functions_versions();
 
-		$this->assertContains( '12.0', $versions, '12.0 deprecated functions should be loaded when 12.0 was updated for a minor release' );
+		$this->assertContains( 12.0, $versions, '12.0 deprecated functions should be loaded when 12.0 was updated for a minor release' );
 
 		remove_filter( 'pre_option__bp_initial_major_version', array( $this, 'override_initial_version' ), 10, 0 );
 

--- a/tests/phpunit/testcases/core/functions.php
+++ b/tests/phpunit/testcases/core/functions.php
@@ -869,13 +869,36 @@ class BP_Tests_Core_Functions extends BP_UnitTestCase {
 
 	/**
 	 * @ticket BP8687
+	 * @ticket BP9075
 	 */
 	public function test_bp_get_deprecated_functions_versions() {
-		$current_version = (float) bp_get_version();
+		$current_version = bp_get_version();
 		$versions        = bp_get_deprecated_functions_versions();
+		$bp              = buddypress();
 
-		// When current version is the initial version, we should only load 12.0 deprecated functions file.
+		// When current major version is the initial version, we should only load 12.0 deprecated functions file.
 		$this->assertSame( $versions, array( '12.0' ), 'Please check the list of `$deprecated_functions_versions` in `bp_get_deprecated_functions_versions()`. There should be one for each file of the `/src/bp-core/deprecated` directory.' );
+
+		$bp->version = '12.1.1';
+
+		// We should load the 2 lasts deprecated functions files.
+		$this->bp_initial_version = '12.0';
+
+		add_filter( 'pre_option__bp_initial_major_version', array( $this, 'override_initial_version' ), 10, 0 );
+
+		$versions = bp_get_deprecated_functions_versions();
+
+		$this->assertContains( '12.0', $versions, '12.0 deprecated functions should be loaded when 12.1.1 was the first installed version.' );
+
+		$this->bp_initial_version = '9.0';
+
+		$versions = bp_get_deprecated_functions_versions();
+
+		$this->assertContains( '12.0', $versions, '12.0 deprecated functions should be loaded when 12.0 was updated for a minor release' );
+
+		remove_filter( 'pre_option__bp_initial_major_version', array( $this, 'override_initial_version' ), 10, 0 );
+
+		$bp->version = $current_version;
 
 		// We should load the 2 lasts deprecated functions files.
 		$this->bp_initial_version = '8.0';


### PR DESCRIPTION
- On install, the initial version is always set to the closest major one, so there's no need to get it again as the `$first_major` variable.
- Instead of comparing initial major version with the current version, we need to use the current **major** version so that minor releases also includes the right deprecated function files.
- Improve the unit test to include a check with a current minor version.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9075

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
