### PR TITLE
Patch/9072

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -328,7 +328,7 @@ module.exports = function( grunt ) {
 		},
 		exec: {
 			cli: {
-				command: 'svn export --force https://github.com/buddypress/wp-cli-buddypress.git/tags/2.0.2 cli',
+				command: 'npm run download:cli',
 				cwd: BUILD_DIR,
 				stdout: false
 			},
@@ -337,7 +337,7 @@ module.exports = function( grunt ) {
 				stdout: true
 			},
 			rest_api: {
-				command: 'svn export --force https://github.com/buddypress/BP-REST.git/trunk bp-rest',
+				command: 'npm run download:rest',
 				cwd: BUILD_DIR,
 				stdout: false
 			},

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
 		"test-php": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/buddypress/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/buddypress/tests/phpunit/env.xml'",
 		"test-php:group": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/buddypress/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/buddypress/tests/phpunit/env.xml --group $npm_confi_g'",
 		"test-php-multisite": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/buddypress/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/buddypress/tests/phpunit/env.multisite.xml'",
-		"test-php-multisite:group": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/buddypress/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/buddypress/tests/phpunit/env.multisite.xml --group $npm_confi_g'"
+		"test-php-multisite:group": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/buddypress/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/buddypress/tests/phpunit/env.multisite.xml --group $npm_confi_g'",
+		"download:cli": "curl -L -o 'cli-archive.zip' https://github.com/buddypress/wp-cli-buddypress/archive/2.0.2.zip && unzip -qq cli-archive.zip && mv wp-cli-buddypress-2.0.2 cli && rm cli-archive.zip",
+		"download:rest": "curl -L -o 'rest-archive.zip' https://github.com/buddypress/BP-REST/archive/master.zip && unzip -qq rest-archive.zip && mv BP-REST-master bp-rest && rm rest-archive.zip"
 	},
 	"keywords": [
 		"activity",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
 		"test-php:group": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/buddypress/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/buddypress/tests/phpunit/env.xml --group $npm_confi_g'",
 		"test-php-multisite": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/buddypress/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/buddypress/tests/phpunit/env.multisite.xml'",
 		"test-php-multisite:group": "npm run wp-env run phpunit 'php /var/www/html/wp-content/plugins/buddypress/vendor/phpunit/phpunit/phpunit -c /var/www/html/wp-content/plugins/buddypress/tests/phpunit/env.multisite.xml --group $npm_confi_g'",
-		"download:cli": "curl -L -o 'cli-archive.zip' https://github.com/buddypress/wp-cli-buddypress/archive/2.0.2.zip && unzip -qq cli-archive.zip && mv wp-cli-buddypress-2.0.2 cli && rm cli-archive.zip",
-		"download:rest": "curl -L -o 'rest-archive.zip' https://github.com/buddypress/BP-REST/archive/master.zip && unzip -qq rest-archive.zip && mv BP-REST-master bp-rest && rm rest-archive.zip"
+		"download:cli": "curl -L -o 'cli-archive.zip' https://github.com/buddypress/wp-cli-buddypress/archive/2.0.2.zip && unzip -qq cli-archive.zip && mv wp-cli-buddypress-2.0.2 build/cli && rm cli-archive.zip",
+		"download:rest": "curl -L -o 'rest-archive.zip' https://github.com/buddypress/BP-REST/archive/master.zip && unzip -qq rest-archive.zip && mv BP-REST-master build/bp-rest && rm rest-archive.zip"
 	},
 	"keywords": [
 		"activity",


### PR DESCRIPTION
Now GH is no more supporting SVN we need to replace `svn export` usage in Grunt tasks.

- Add the `download:cli` npm script
- Add the `download:rest` npm script

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9072

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
