### PR TITLE
Create a specific CSS file for BP Tooltips

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,6 +35,7 @@ module.exports = function( grunt ) {
 			'!bp-templates/bp-nouveau/css/twenty*.css',
 			'!bp-templates/bp-nouveau/css/primary-nav.css',
 			'!bp-templates/bp-nouveau/sass/priority-nav.scss',
+			'!bp-templates/bp-nouveau/sass/bp-tooltips.scss',
 			'!bp-core/admin/css/hello.css',
 			'!src/js/**',
 			'!**/blocks/*/index.css'
@@ -119,8 +120,17 @@ module.exports = function( grunt ) {
 				expand: true,
 				ext: '.css',
 				flatten: true,
-				src: ['bp-templates/bp-nouveau/sass/buddypress.scss', 'bp-templates/bp-nouveau/sass/twenty*.scss', 'bp-templates/bp-nouveau/sass/primary-nav.scss', 'bp-templates/bp-nouveau/sass/priority-nav.scss'],
+				src: ['bp-templates/bp-nouveau/sass/buddypress.scss', 'bp-templates/bp-nouveau/sass/twenty*.scss', 'bp-templates/bp-nouveau/sass/primary-nav.scss', 'bp-templates/bp-nouveau/sass/priority-nav.scss', 'bp-templates/bp-nouveau/sass/bp-tooltips.scss'],
 				dest: SOURCE_DIR + 'bp-templates/bp-nouveau/css/'
+			},
+			core: {
+				cwd: SOURCE_DIR,
+				extDot: 'last',
+				expand: true,
+				ext: '.css',
+				flatten: true,
+				src: ['bp-core/sass/*.scss'],
+				dest: SOURCE_DIR + 'bp-core/css/'
 			},
 			admin: {
 				cwd: SOURCE_DIR,

--- a/src/bp-activity/bp-activity-blocks.php
+++ b/src/bp-activity/bp-activity-blocks.php
@@ -156,6 +156,9 @@ function bp_activity_render_latest_activities_block( $attributes = array() ) {
 	// Reset the global template loop.
 	$GLOBALS['activities_template'] = $reset_activities_template;
 
+	// Enqueue BP Tooltips.
+	wp_enqueue_style( 'bp-tooltips' );
+
 	// Only add a block wrapper if not loaded into a Widgets sidebar.
 	if ( ! did_action( 'dynamic_sidebar_before' ) ) {
 		return sprintf(

--- a/src/bp-core/admin/css/common-rtl.css
+++ b/src/bp-core/admin/css/common-rtl.css
@@ -348,42 +348,6 @@ body.tools_page_bp-optouts .nav-tab-wrapper {
 /*
  * 2.5 Tooltips
  */
-.bp-tooltip {
-	position: relative;
-}
-
-.bp-tooltip:after {
-	background: #fff;
-	border: 1px solid #aaa;
-	border-collapse: separate;
-	border-radius: 1px;
-	box-shadow: -1px 1px 0 1px rgba(132, 132, 132, 0.3);
-	color: #000;
-	content: attr(data-bp-tooltip);
-	display: none;
-	font-family: sans-serif;
-	font-size: 11px;
-	font-weight: 400;
-	letter-spacing: normal;
-	line-height: 1.5;
-	margin-top: 10px;
-	max-width: 240px;
-	opacity: 0;
-	padding: 3px 6px;
-	position: absolute;
-	left: 50%;
-	text-align: center;
-	text-decoration: none;
-	text-shadow: none;
-	text-transform: none;
-	top: 100%;
-	transform: translateX(-50%);
-	transition: opacity 2s ease-out;
-	white-space: pre;
-	word-wrap: break-word;
-	z-index: 998;
-}
-
 .bp-hello-close .bp-tooltip:after {
 	left: 0;
 	text-align: left;
@@ -396,16 +360,6 @@ body.tools_page_bp-optouts .nav-tab-wrapper {
 	margin-top: 0;
 	top: auto;
 	transform: translateX(-15%);
-}
-
-.bp-tooltip:hover:after,
-.bp-tooltip:active:after,
-.bp-tooltip:focus:after {
-	display: inline-block;
-	opacity: 1;
-	overflow: visible;
-	text-decoration: none;
-	z-index: 999;
 }
 
 /*------------------------------------------------------------------------------

--- a/src/bp-core/admin/css/common.css
+++ b/src/bp-core/admin/css/common.css
@@ -348,42 +348,6 @@ body.tools_page_bp-optouts .nav-tab-wrapper {
 /*
  * 2.5 Tooltips
  */
-.bp-tooltip {
-	position: relative;
-}
-
-.bp-tooltip:after {
-	background: #fff;
-	border: 1px solid #aaa;
-	border-collapse: separate;
-	border-radius: 1px;
-	box-shadow: 1px 1px 0 1px rgba(132, 132, 132, 0.3);
-	color: #000;
-	content: attr(data-bp-tooltip);
-	display: none;
-	font-family: sans-serif;
-	font-size: 11px;
-	font-weight: 400;
-	letter-spacing: normal;
-	line-height: 1.5;
-	margin-top: 10px;
-	max-width: 240px;
-	opacity: 0;
-	padding: 3px 6px;
-	position: absolute;
-	right: 50%;
-	text-align: center;
-	text-decoration: none;
-	text-shadow: none;
-	text-transform: none;
-	top: 100%;
-	transform: translateX(50%);
-	transition: opacity 2s ease-out;
-	white-space: pre;
-	word-wrap: break-word;
-	z-index: 998;
-}
-
 .bp-hello-close .bp-tooltip:after {
 	right: 0;
 	text-align: right;
@@ -396,16 +360,6 @@ body.tools_page_bp-optouts .nav-tab-wrapper {
 	margin-top: 0;
 	top: auto;
 	transform: translateX(15%);
-}
-
-.bp-tooltip:hover:after,
-.bp-tooltip:active:after,
-.bp-tooltip:focus:after {
-	display: inline-block;
-	opacity: 1;
-	overflow: visible;
-	text-decoration: none;
-	z-index: 999;
 }
 
 /*------------------------------------------------------------------------------

--- a/src/bp-core/bp-core-cssjs.php
+++ b/src/bp-core/bp-core-cssjs.php
@@ -104,6 +104,14 @@ function bp_core_register_common_styles() {
 	 */
 	$admin_bar_file = apply_filters( 'bp_core_admin_bar_css', "{$url}admin-bar{$min}.css" );
 
+	// Set default BP Tooltips styles.
+	$tooltips_uri      = "{$url}bp-tooltips{$min}.css";
+	$template_tooltips = bp_locate_template_asset( "css/bp-tooltips{$min}.css" );
+
+	if ( isset( $template_tooltips['uri'] ) && $template_tooltips['uri'] ) {
+		$tooltips_uri = $template_tooltips['uri'];
+	}
+
 	/**
 	 * Filters the BuddyPress Core stylesheet files to register.
 	 *
@@ -119,6 +127,10 @@ function bp_core_register_common_styles() {
 		'bp-avatar' => array(
 			'file'         => "{$url}avatar{$min}.css",
 			'dependencies' => array( 'jcrop' )
+		),
+		'bp-tooltips' => array(
+			'file'         => $tooltips_uri,
+			'dependencies' => array()
 		),
 	) );
 

--- a/src/bp-core/classes/class-bp-admin.php
+++ b/src/bp-core/classes/class-bp-admin.php
@@ -1370,7 +1370,7 @@ class BP_Admin {
 			// Legacy.
 			'bp-admin-common-css' => array(
 				'file'         => $common_css,
-				'dependencies' => array(),
+				'dependencies' => array( 'bp-tooltips' ),
 			),
 
 			// 2.5

--- a/src/bp-core/css/bp-tooltips-rtl.css
+++ b/src/bp-core/css/bp-tooltips-rtl.css
@@ -1,0 +1,52 @@
+/*--------------------------------------------------------------
+BP Tooltips
+--------------------------------------------------------------*/
+[data-bp-tooltip] {
+	position: relative;
+}
+
+[data-bp-tooltip]:after {
+	background: #fff;
+	border: 1px solid #aaa;
+	border-collapse: separate;
+	border-radius: 1px;
+	box-shadow: -1px 1px 0 1px rgba(132, 132, 132, 0.3);
+	color: #000;
+	content: attr(data-bp-tooltip);
+	display: none;
+	font-family: sans-serif;
+	font-size: 11px;
+	font-weight: 400;
+	letter-spacing: normal;
+	line-height: 1.5;
+	margin-top: 10px;
+	max-width: 240px;
+	opacity: 0;
+	padding: 3px 6px;
+	position: absolute;
+	left: 50%;
+	text-align: center;
+	text-decoration: none;
+	text-shadow: none;
+	text-transform: none;
+	top: 100%;
+	transform: translateX(-50%);
+	transition: opacity 2s ease-out;
+	white-space: pre;
+	word-wrap: break-word;
+	z-index: 998;
+}
+
+[data-bp-tooltip]:hover:after, [data-bp-tooltip]:active:after, [data-bp-tooltip]:focus:after {
+	display: inline-block;
+	opacity: 1;
+	overflow: visible;
+	text-decoration: none;
+	z-index: 999;
+}
+
+[data-bp-tooltip=""] {
+	display: none;
+	opacity: 0;
+	visibility: hidden;
+}

--- a/src/bp-core/css/bp-tooltips.css
+++ b/src/bp-core/css/bp-tooltips.css
@@ -1,0 +1,52 @@
+/*--------------------------------------------------------------
+BP Tooltips
+--------------------------------------------------------------*/
+[data-bp-tooltip] {
+	position: relative;
+}
+
+[data-bp-tooltip]:after {
+	background: #fff;
+	border: 1px solid #aaa;
+	border-collapse: separate;
+	border-radius: 1px;
+	box-shadow: 1px 1px 0 1px rgba(132, 132, 132, 0.3);
+	color: #000;
+	content: attr(data-bp-tooltip);
+	display: none;
+	font-family: sans-serif;
+	font-size: 11px;
+	font-weight: 400;
+	letter-spacing: normal;
+	line-height: 1.5;
+	margin-top: 10px;
+	max-width: 240px;
+	opacity: 0;
+	padding: 3px 6px;
+	position: absolute;
+	right: 50%;
+	text-align: center;
+	text-decoration: none;
+	text-shadow: none;
+	text-transform: none;
+	top: 100%;
+	transform: translateX(50%);
+	transition: opacity 2s ease-out;
+	white-space: pre;
+	word-wrap: break-word;
+	z-index: 998;
+}
+
+[data-bp-tooltip]:hover:after, [data-bp-tooltip]:active:after, [data-bp-tooltip]:focus:after {
+	display: inline-block;
+	opacity: 1;
+	overflow: visible;
+	text-decoration: none;
+	z-index: 999;
+}
+
+[data-bp-tooltip=""] {
+	display: none;
+	opacity: 0;
+	visibility: hidden;
+}

--- a/src/bp-core/sass/bp-tooltips.scss
+++ b/src/bp-core/sass/bp-tooltips.scss
@@ -1,0 +1,59 @@
+/*--------------------------------------------------------------
+BP Tooltips
+--------------------------------------------------------------*/
+
+[data-bp-tooltip] {
+	position: relative;
+
+	&:after {
+		background: #fff;
+		border: 1px solid #aaa;
+		border-collapse: separate;
+		border-radius: 1px;
+		box-shadow: 1px 1px 0 1px rgba(132, 132, 132, 0.3);
+		color: #000;
+		content: attr(data-bp-tooltip);
+		display: none;
+		font-family: sans-serif;
+		font-size: 11px;
+		font-weight: 400;
+		letter-spacing: normal;
+		line-height: 1.5;
+		margin-top: 10px;
+		max-width: 240px;
+		opacity: 0;
+		padding: 3px 6px;
+		position: absolute;
+		right: 50%;
+		text-align: center;
+		text-decoration: none;
+		text-shadow: none;
+		text-transform: none;
+		top: 100%;
+		transform: translateX(50%);
+		transition: opacity 2s ease-out;
+		white-space: pre;
+		word-wrap: break-word;
+		z-index: 998;
+	}
+
+	&:hover,
+	&:active,
+	&:focus {
+
+		&:after {
+
+			display: inline-block;
+			opacity: 1;
+			overflow: visible;
+			text-decoration: none;
+			z-index: 999;
+		}
+	}
+}
+
+[data-bp-tooltip=""] {
+	display: none;
+	opacity: 0;
+	visibility: hidden;
+}

--- a/src/bp-members/bp-members-blocks.php
+++ b/src/bp-members/bp-members-blocks.php
@@ -662,6 +662,9 @@ function bp_members_render_members_avatars_block( $block_args = array() ) {
 			</div>',
 			implode( "\n", $member_avatars )
 		);
+
+		// Only enqueue BP Tooltips if there is some content to style.
+		wp_enqueue_style( 'bp-tooltips' );
 	} else {
 		$widget_content .= sprintf(
 			'<div class="widget-error">

--- a/src/bp-messages/bp-messages-blocks.php
+++ b/src/bp-messages/bp-messages-blocks.php
@@ -118,6 +118,9 @@ function bp_messages_render_sitewide_notices_block( $attributes = array() ) {
 
 	$widget_content .= '</div>';
 
+	// Enqueue BP Tooltips.
+	wp_enqueue_style( 'bp-tooltips' );
+
 	if ( ! did_action( 'dynamic_sidebar_before' ) ) {
 		return sprintf(
 			'<div %1$s>%2$s</div>',

--- a/src/bp-templates/bp-legacy/css/buddypress-rtl.css
+++ b/src/bp-templates/bp-legacy/css/buddypress-rtl.css
@@ -2004,53 +2004,6 @@ body.register #buddypress div.page ul {
 /*--------------------------------------------------------------
 3.11 - Tooltips
 --------------------------------------------------------------*/
-
-.buddypress .bp-tooltip {
-	position: relative;
-}
-
-.bp-tooltip:after {
-	background: #fff;
-	border: 1px solid #aaa;
-	border-collapse: separate;
-	border-radius: 1px;
-	box-shadow: -1px 1px 0 1px rgba(132, 132, 132, 0.3);
-	color: #000;
-	content: attr(data-bp-tooltip);
-	display: none;
-	font-family: sans-serif;
-	font-size: 11px;
-	font-weight: 400;
-	letter-spacing: normal;
-	line-height: 1.5;
-	margin-top: 10px;
-	max-width: 240px;
-	opacity: 0;
-	padding: 3px 6px;
-	position: absolute;
-	left: 50%;
-	text-align: center;
-	text-decoration: none;
-	text-shadow: none;
-	text-transform: none;
-	top: 100%;
-	transform: translateX(-50%);
-	transition: opacity 2s ease-out;
-	white-space: pre;
-	word-wrap: break-word;
-	z-index: 998;
-}
-
-.bp-tooltip:hover:after,
-.bp-tooltip:active:after,
-.bp-tooltip:focus:after {
-	display: inline-block;
-	opacity: 1;
-	overflow: visible;
-	text-decoration: none;
-	z-index: 999;
-}
-
 #group-admins .bp-tooltip:after,
 #group-mods .bp-tooltip:after,
 .message-metadata .bp-tooltip:after {

--- a/src/bp-templates/bp-legacy/css/buddypress.css
+++ b/src/bp-templates/bp-legacy/css/buddypress.css
@@ -2004,53 +2004,6 @@ body.register #buddypress div.page ul {
 /*--------------------------------------------------------------
 3.11 - Tooltips
 --------------------------------------------------------------*/
-
-.buddypress .bp-tooltip {
-	position: relative;
-}
-
-.bp-tooltip:after {
-	background: #fff;
-	border: 1px solid #aaa;
-	border-collapse: separate;
-	border-radius: 1px;
-	box-shadow: 1px 1px 0 1px rgba(132, 132, 132, 0.3);
-	color: #000;
-	content: attr(data-bp-tooltip);
-	display: none;
-	font-family: sans-serif;
-	font-size: 11px;
-	font-weight: 400;
-	letter-spacing: normal;
-	line-height: 1.5;
-	margin-top: 10px;
-	max-width: 240px;
-	opacity: 0;
-	padding: 3px 6px;
-	position: absolute;
-	right: 50%;
-	text-align: center;
-	text-decoration: none;
-	text-shadow: none;
-	text-transform: none;
-	top: 100%;
-	transform: translateX(50%);
-	transition: opacity 2s ease-out;
-	white-space: pre;
-	word-wrap: break-word;
-	z-index: 998;
-}
-
-.bp-tooltip:hover:after,
-.bp-tooltip:active:after,
-.bp-tooltip:focus:after {
-	display: inline-block;
-	opacity: 1;
-	overflow: visible;
-	text-decoration: none;
-	z-index: 999;
-}
-
 #group-admins .bp-tooltip:after,
 #group-mods .bp-tooltip:after,
 .message-metadata .bp-tooltip:after {

--- a/src/bp-templates/bp-nouveau/buddypress-functions.php
+++ b/src/bp-templates/bp-nouveau/buddypress-functions.php
@@ -270,7 +270,7 @@ class BP_Nouveau extends BP_Theme_Compat {
 		 *
 		 * @param array $value Array of style dependencies. Default Dashicons.
 		 */
-		$css_dependencies = apply_filters( 'bp_nouveau_css_dependencies', array( 'dashicons' ) );
+		$css_dependencies = apply_filters( 'bp_nouveau_css_dependencies', array( 'dashicons', 'bp-tooltips' ) );
 
 		/**
 		 * Filters the styles to enqueue for BuddyPress Nouveau.

--- a/src/bp-templates/bp-nouveau/common-styles/_bp_activity_entries.scss
+++ b/src/bp-templates/bp-nouveau/common-styles/_bp_activity_entries.scss
@@ -4,6 +4,11 @@
 
 .activity-list {
 
+	.bp-tooltip {
+
+		@include bp-tooltip-bottom-left;
+	}
+
 	padding: $pad-sml;
 
 	.activity-item:before,

--- a/src/bp-templates/bp-nouveau/common-styles/_bp_buttons.scss
+++ b/src/bp-templates/bp-nouveau/common-styles/_bp_buttons.scss
@@ -156,6 +156,20 @@
 				}
 
 			}
+
+			.bp-tooltip {
+
+				@include bp-tooltip-bottom-right;
+			}
+
+			#send-invites-editor .bp-tooltip {
+
+				// override .bp-invites-content .bp-tooltip
+				&:after {
+					left: 0;
+					right: auto;
+				}
+			}
 		}
 
 		#item-buttons:empty {

--- a/src/bp-templates/bp-nouveau/common-styles/_bp_group_header.scss
+++ b/src/bp-templates/bp-nouveau/common-styles/_bp_group_header.scss
@@ -56,6 +56,17 @@
 				margin-left: 4px;
 				padding: 4px;
 			}
+
+			// Bottom Left Tooltip for mobile and Bottom Right Tooltip for tablet/desktop
+			.bp-tooltip {
+
+				@include bp-tooltip-bottom-left;
+
+				@include medium-up() {
+
+					@include bp-tooltip-bottom-right;
+				}
+			}
 		}
 
 		img.avatar {

--- a/src/bp-templates/bp-nouveau/common-styles/_bp_messages.scss
+++ b/src/bp-templates/bp-nouveau/common-styles/_bp_messages.scss
@@ -69,6 +69,11 @@
 	.message-metadata {
 		overflow: hidden;
 		position: relative;
+
+		.actions .bp-tooltip {
+
+			@include bp-tooltip-bottom-right;
+		}
 	}
 
 	.message-content {
@@ -127,4 +132,9 @@ a.message-action-star:hover {
 .message-action-unstar span.icon:before {
 	color: #fcdd77;
 	content: "\f155";
+}
+
+.participants-list .bp-tooltip {
+
+	@include bp-tooltip-bottom-left;
 }

--- a/src/bp-templates/bp-nouveau/common-styles/_bp_tables.scss
+++ b/src/bp-templates/bp-nouveau/common-styles/_bp_tables.scss
@@ -110,6 +110,11 @@
 		.actions,
 		.notification-actions {
 			width: 15%;
+
+			.bp-tooltip {
+
+				@include bp-tooltip-bottom-left;
+			}
 		}
 	}
 

--- a/src/bp-templates/bp-nouveau/css/bp-tooltips-rtl.css
+++ b/src/bp-templates/bp-nouveau/css/bp-tooltips-rtl.css
@@ -1,0 +1,59 @@
+[data-bp-tooltip] {
+	position: relative;
+}
+
+[data-bp-tooltip]:after {
+	background-color: #fff;
+	display: none;
+	opacity: 0;
+	position: absolute;
+	transform: translate3d(0, 0, 0);
+	visibility: hidden;
+}
+
+[data-bp-tooltip]:after {
+	border: 1px solid #737373;
+	border-radius: 1px;
+	box-shadow: -4px 4px 8px rgba(0, 0, 0, 0.2);
+	color: #333;
+	content: attr(data-bp-tooltip);
+	font-family: "Helvetica Neue", helvetica, arial, san-serif;
+	font-size: 12px;
+	font-weight: 400;
+	letter-spacing: normal;
+	line-height: 1.25;
+	max-width: 200px;
+	padding: 5px 8px;
+	pointer-events: none;
+	text-shadow: none;
+	text-transform: none;
+	transition: all 1.5s ease;
+	white-space: nowrap;
+	word-wrap: break-word;
+	z-index: 100000;
+}
+
+[data-bp-tooltip]:hover:after, [data-bp-tooltip]:active:after, [data-bp-tooltip]:focus:after {
+	display: block;
+	opacity: 1;
+	overflow: visible;
+	visibility: visible;
+}
+
+[data-bp-tooltip=""] {
+	display: none;
+	opacity: 0;
+	visibility: hidden;
+}
+
+.bp-tooltip:after {
+	right: 50%;
+	margin-top: 7px;
+	top: 110%;
+	transform: translate(50%, 0);
+}
+
+.avatar-block .item-avatar .bp-tooltip:after {
+	right: 0;
+	transform: translate(0, 0);
+}

--- a/src/bp-templates/bp-nouveau/css/bp-tooltips.css
+++ b/src/bp-templates/bp-nouveau/css/bp-tooltips.css
@@ -1,0 +1,59 @@
+[data-bp-tooltip] {
+	position: relative;
+}
+
+[data-bp-tooltip]:after {
+	background-color: #fff;
+	display: none;
+	opacity: 0;
+	position: absolute;
+	transform: translate3d(0, 0, 0);
+	visibility: hidden;
+}
+
+[data-bp-tooltip]:after {
+	border: 1px solid #737373;
+	border-radius: 1px;
+	box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.2);
+	color: #333;
+	content: attr(data-bp-tooltip);
+	font-family: "Helvetica Neue", helvetica, arial, san-serif;
+	font-size: 12px;
+	font-weight: 400;
+	letter-spacing: normal;
+	line-height: 1.25;
+	max-width: 200px;
+	padding: 5px 8px;
+	pointer-events: none;
+	text-shadow: none;
+	text-transform: none;
+	transition: all 1.5s ease;
+	white-space: nowrap;
+	word-wrap: break-word;
+	z-index: 100000;
+}
+
+[data-bp-tooltip]:hover:after, [data-bp-tooltip]:active:after, [data-bp-tooltip]:focus:after {
+	display: block;
+	opacity: 1;
+	overflow: visible;
+	visibility: visible;
+}
+
+[data-bp-tooltip=""] {
+	display: none;
+	opacity: 0;
+	visibility: hidden;
+}
+
+.bp-tooltip:after {
+	left: 50%;
+	margin-top: 7px;
+	top: 110%;
+	transform: translate(-50%, 0);
+}
+
+.avatar-block .item-avatar .bp-tooltip:after {
+	left: 0;
+	transform: translate(0, 0);
+}

--- a/src/bp-templates/bp-nouveau/css/buddypress-rtl.css
+++ b/src/bp-templates/bp-nouveau/css/buddypress-rtl.css
@@ -1245,6 +1245,11 @@ body.buddypress article.page > .entry-header:not(.alignwide):not(.alignfull) .en
 	padding: 0.5em;
 }
 
+.activity-list .bp-tooltip:after {
+	right: 0;
+	transform: translate(0, 0);
+}
+
 .activity-list .activity-item:before,
 .activity-list .activity-item:after {
 	content: " ";
@@ -2466,6 +2471,19 @@ body.no-js .single-item-header .js-self-profile-button {
 	padding: 4px;
 }
 
+.groups-header .moderators-lists .user-list .bp-tooltip:after {
+	right: 0;
+	transform: translate(0, 0);
+}
+
+@media screen and (min-width: 46.8em) {
+	.groups-header .moderators-lists .user-list .bp-tooltip:after {
+		right: auto;
+		left: 0;
+		transform: translate(0, 0);
+	}
+}
+
 .groups-header .moderators-lists img.avatar {
 	box-shadow: none;
 	float: none;
@@ -3390,6 +3408,13 @@ body.register .buddypress-wrap .page ul {
 	display: table;
 }
 
+.bp-messages-content .preview-pane-header .actions .bp-tooltip:after,
+.bp-messages-content .single-message-thread-header .actions .bp-tooltip:after {
+	right: auto;
+	left: 0;
+	transform: translate(0, 0);
+}
+
 .bp-messages-content .preview-thread-title,
 .bp-messages-content .single-thread-title {
 	font-size: 16px;
@@ -4081,6 +4106,12 @@ body.no-js .buddypress #messages-bulk-management #select-all-messages {
 	width: 15%;
 }
 
+.buddypress-wrap table.notifications .actions .bp-tooltip:after,
+.buddypress-wrap table.notifications .notification-actions .bp-tooltip:after {
+	right: 0;
+	transform: translate(0, 0);
+}
+
 .buddypress-wrap table.notification-settings th.title,
 .buddypress-wrap table.profile-settings th.title {
 	width: 80%;
@@ -4318,6 +4349,17 @@ body.no-js .buddypress #messages-bulk-management #select-all-messages {
 .buddypress .buddypress-wrap .bp-invites-content ul.bp-list li a.invite-button:hover,
 .buddypress .buddypress-wrap .bp-invites-content ul.bp-list li a.group-remove-invite-button:hover {
 	color: #a00;
+}
+
+.buddypress .buddypress-wrap .bp-invites-content .bp-tooltip:after {
+	right: auto;
+	left: 0;
+	transform: translate(0, 0);
+}
+
+.buddypress .buddypress-wrap .bp-invites-content #send-invites-editor .bp-tooltip:after {
+	right: 0;
+	left: auto;
 }
 
 .buddypress .buddypress-wrap #item-buttons:empty {
@@ -4781,96 +4823,6 @@ body.create-blog #buddypress .success {
 .buddypress-wrap a.loading:hover,
 .buddypress-wrap input.loading:hover {
 	color: #777;
-}
-
-[data-bp-tooltip] {
-	position: relative;
-}
-
-[data-bp-tooltip]:after {
-	background-color: #fff;
-	display: none;
-	opacity: 0;
-	position: absolute;
-	transform: translate3d(0, 0, 0);
-	visibility: hidden;
-}
-
-[data-bp-tooltip]:after {
-	border: 1px solid #737373;
-	border-radius: 1px;
-	box-shadow: -4px 4px 8px rgba(0, 0, 0, 0.2);
-	color: #333;
-	content: attr(data-bp-tooltip);
-	font-family: "Helvetica Neue", helvetica, arial, san-serif;
-	font-size: 12px;
-	font-weight: 400;
-	letter-spacing: normal;
-	line-height: 1.25;
-	max-width: 200px;
-	padding: 5px 8px;
-	pointer-events: none;
-	text-shadow: none;
-	text-transform: none;
-	transition: all 1.5s ease;
-	white-space: nowrap;
-	word-wrap: break-word;
-	z-index: 100000;
-}
-
-[data-bp-tooltip]:hover:after, [data-bp-tooltip]:active:after, [data-bp-tooltip]:focus:after {
-	display: block;
-	opacity: 1;
-	overflow: visible;
-	visibility: visible;
-}
-
-[data-bp-tooltip=""] {
-	display: none;
-	opacity: 0;
-	visibility: hidden;
-}
-
-.bp-tooltip:after {
-	right: 50%;
-	margin-top: 7px;
-	top: 110%;
-	transform: translate(50%, 0);
-}
-
-.user-list .bp-tooltip:after {
-	right: 0;
-	transform: translate(0, 0);
-}
-
-@media screen and (min-width: 46.8em) {
-	.user-list .bp-tooltip:after {
-		right: auto;
-		left: 0;
-		transform: translate(0, 0);
-	}
-}
-
-.activity-list .bp-tooltip:after,
-.activity-meta-action .bp-tooltip:after,
-.avatar-block .item-avatar .bp-tooltip:after,
-.notification-actions .bp-tooltip:after,
-.participants-list .bp-tooltip:after {
-	right: 0;
-	transform: translate(0, 0);
-}
-
-.bp-invites-content .bp-tooltip:after,
-.message-metadata .actions .bp-tooltip:after,
-.single-message-thread-header .actions .bp-tooltip:after {
-	right: auto;
-	left: 0;
-	transform: translate(0, 0);
-}
-
-.bp-invites-content #send-invites-editor .bp-tooltip:after {
-	right: 0;
-	left: auto;
 }
 
 /**

--- a/src/bp-templates/bp-nouveau/css/buddypress.css
+++ b/src/bp-templates/bp-nouveau/css/buddypress.css
@@ -1245,6 +1245,11 @@ body.buddypress article.page > .entry-header:not(.alignwide):not(.alignfull) .en
 	padding: 0.5em;
 }
 
+.activity-list .bp-tooltip:after {
+	left: 0;
+	transform: translate(0, 0);
+}
+
 .activity-list .activity-item:before,
 .activity-list .activity-item:after {
 	content: " ";
@@ -2466,6 +2471,19 @@ body.no-js .single-item-header .js-self-profile-button {
 	padding: 4px;
 }
 
+.groups-header .moderators-lists .user-list .bp-tooltip:after {
+	left: 0;
+	transform: translate(0, 0);
+}
+
+@media screen and (min-width: 46.8em) {
+	.groups-header .moderators-lists .user-list .bp-tooltip:after {
+		left: auto;
+		right: 0;
+		transform: translate(0, 0);
+	}
+}
+
 .groups-header .moderators-lists img.avatar {
 	box-shadow: none;
 	float: none;
@@ -3390,6 +3408,13 @@ body.register .buddypress-wrap .page ul {
 	display: table;
 }
 
+.bp-messages-content .preview-pane-header .actions .bp-tooltip:after,
+.bp-messages-content .single-message-thread-header .actions .bp-tooltip:after {
+	left: auto;
+	right: 0;
+	transform: translate(0, 0);
+}
+
 .bp-messages-content .preview-thread-title,
 .bp-messages-content .single-thread-title {
 	font-size: 16px;
@@ -4081,6 +4106,12 @@ body.no-js .buddypress #messages-bulk-management #select-all-messages {
 	width: 15%;
 }
 
+.buddypress-wrap table.notifications .actions .bp-tooltip:after,
+.buddypress-wrap table.notifications .notification-actions .bp-tooltip:after {
+	left: 0;
+	transform: translate(0, 0);
+}
+
 .buddypress-wrap table.notification-settings th.title,
 .buddypress-wrap table.profile-settings th.title {
 	width: 80%;
@@ -4318,6 +4349,17 @@ body.no-js .buddypress #messages-bulk-management #select-all-messages {
 .buddypress .buddypress-wrap .bp-invites-content ul.bp-list li a.invite-button:hover,
 .buddypress .buddypress-wrap .bp-invites-content ul.bp-list li a.group-remove-invite-button:hover {
 	color: #a00;
+}
+
+.buddypress .buddypress-wrap .bp-invites-content .bp-tooltip:after {
+	left: auto;
+	right: 0;
+	transform: translate(0, 0);
+}
+
+.buddypress .buddypress-wrap .bp-invites-content #send-invites-editor .bp-tooltip:after {
+	left: 0;
+	right: auto;
 }
 
 .buddypress .buddypress-wrap #item-buttons:empty {
@@ -4781,96 +4823,6 @@ body.create-blog #buddypress .success {
 .buddypress-wrap a.loading:hover,
 .buddypress-wrap input.loading:hover {
 	color: #777;
-}
-
-[data-bp-tooltip] {
-	position: relative;
-}
-
-[data-bp-tooltip]:after {
-	background-color: #fff;
-	display: none;
-	opacity: 0;
-	position: absolute;
-	transform: translate3d(0, 0, 0);
-	visibility: hidden;
-}
-
-[data-bp-tooltip]:after {
-	border: 1px solid #737373;
-	border-radius: 1px;
-	box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.2);
-	color: #333;
-	content: attr(data-bp-tooltip);
-	font-family: "Helvetica Neue", helvetica, arial, san-serif;
-	font-size: 12px;
-	font-weight: 400;
-	letter-spacing: normal;
-	line-height: 1.25;
-	max-width: 200px;
-	padding: 5px 8px;
-	pointer-events: none;
-	text-shadow: none;
-	text-transform: none;
-	transition: all 1.5s ease;
-	white-space: nowrap;
-	word-wrap: break-word;
-	z-index: 100000;
-}
-
-[data-bp-tooltip]:hover:after, [data-bp-tooltip]:active:after, [data-bp-tooltip]:focus:after {
-	display: block;
-	opacity: 1;
-	overflow: visible;
-	visibility: visible;
-}
-
-[data-bp-tooltip=""] {
-	display: none;
-	opacity: 0;
-	visibility: hidden;
-}
-
-.bp-tooltip:after {
-	left: 50%;
-	margin-top: 7px;
-	top: 110%;
-	transform: translate(-50%, 0);
-}
-
-.user-list .bp-tooltip:after {
-	left: 0;
-	transform: translate(0, 0);
-}
-
-@media screen and (min-width: 46.8em) {
-	.user-list .bp-tooltip:after {
-		left: auto;
-		right: 0;
-		transform: translate(0, 0);
-	}
-}
-
-.activity-list .bp-tooltip:after,
-.activity-meta-action .bp-tooltip:after,
-.avatar-block .item-avatar .bp-tooltip:after,
-.notification-actions .bp-tooltip:after,
-.participants-list .bp-tooltip:after {
-	left: 0;
-	transform: translate(0, 0);
-}
-
-.bp-invites-content .bp-tooltip:after,
-.message-metadata .actions .bp-tooltip:after,
-.single-message-thread-header .actions .bp-tooltip:after {
-	left: auto;
-	right: 0;
-	transform: translate(0, 0);
-}
-
-.bp-invites-content #send-invites-editor .bp-tooltip:after {
-	left: 0;
-	right: auto;
 }
 
 /**

--- a/src/bp-templates/bp-nouveau/sass/_nouveau_messages.scss
+++ b/src/bp-templates/bp-nouveau/sass/_nouveau_messages.scss
@@ -321,6 +321,11 @@
 			content: "";
 			display: table;
 		}
+
+		.actions .bp-tooltip {
+
+			@include bp-tooltip-bottom-right;
+		}
 	}
 
 	.preview-thread-title,

--- a/src/bp-templates/bp-nouveau/sass/bp-tooltips.scss
+++ b/src/bp-templates/bp-nouveau/sass/bp-tooltips.scss
@@ -1,5 +1,10 @@
 // BuddyPress Tooltips
-// @version 4.0.0
+// @version 12.2.0
+
+// Import our partials mixins & variables files
+
+@import "../common-styles/_bp-variables";
+@import "../common-styles/_bp-mixins";
 
 [data-bp-tooltip] {
 	position: relative;
@@ -71,43 +76,8 @@
 	@include bp-tooltip-default;
 }
 
-// Bottom Left Tooltip for mobile and Bottom Right Tooltip for tablet/desktop
-
-.user-list .bp-tooltip {
-
-	@include bp-tooltip-bottom-left;
-
-	@include medium-up() {
-
-		@include bp-tooltip-bottom-right;
-	}
-}
-
 // Bottom Left Tooltip
-
-.activity-list .bp-tooltip,
-.activity-meta-action .bp-tooltip,
-.avatar-block .item-avatar .bp-tooltip,
-.notification-actions .bp-tooltip,
-.participants-list .bp-tooltip {
+.avatar-block .item-avatar .bp-tooltip {
 
 	@include bp-tooltip-bottom-left;
-}
-
-// Bottom Right Tooltip
-
-.bp-invites-content .bp-tooltip,
-.message-metadata .actions .bp-tooltip,
-.single-message-thread-header .actions .bp-tooltip {
-
-	@include bp-tooltip-bottom-right;
-}
-
-.bp-invites-content #send-invites-editor .bp-tooltip {
-
-	// override .bp-invites-content .bp-tooltip
-	&:after {
-		left: 0;
-		right: auto;
-	}
 }

--- a/src/bp-templates/bp-nouveau/sass/buddypress.scss
+++ b/src/bp-templates/bp-nouveau/sass/buddypress.scss
@@ -426,10 +426,6 @@ Hello, this is the BuddyPress Nouveau stylesheet.
 
 @import "../common-styles/_bp_animations";
 
-// Import BP Tooltips
-
-@import "../common-styles/_bp_tooltips";
-
 /**
 *-------------------------------------------------------------------------------
 * @section 9.0 - Layout classes


### PR DESCRIPTION
1. Move BP Tooltips default CSS  rules into a Core file usable with or without Template pack assets.
2. Use this core file as a dependency for Admin's common CSS.
3. Enqueue BP Tooltips CSS rules when Block widgets are rendered.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9070

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
