### PR TITLE
Make sure Register and Acticate Rewrite rules are strict enough

### DIFF
--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -722,7 +722,7 @@ class BP_Members_Component extends BP_Component {
 				'query' => 'index.php?' . $this->rewrite_ids['directory'] . '=1&' . $this->rewrite_ids['directory_type'] . '=$matches[1]',
 			),
 			'member_activate'     => array(
-				'regex' => bp_get_activate_slug(),
+				'regex' => bp_get_activate_slug() . '/?$',
 				'order' => 40,
 				'query' => 'index.php?' . $this->rewrite_ids['member_activate'] . '=1',
 			),
@@ -732,7 +732,7 @@ class BP_Members_Component extends BP_Component {
 				'query' => 'index.php?' . $this->rewrite_ids['member_activate'] . '=1&' . $this->rewrite_ids['member_activate_key'] . '=$matches[1]',
 			),
 			'member_register'     => array(
-				'regex' => bp_get_signup_slug(),
+				'regex' => bp_get_signup_slug() . '/?$',
 				'order' => 20,
 				'query' => 'index.php?' . $this->rewrite_ids['member_register'] . '=1',
 			),


### PR DESCRIPTION
Adds a trailing `'/?$'` to Activate and Register rewrite rules so that we only match URL strictly containing the corresponding slugs.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9077

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
