### PR TITLE
Raise WordPress required version to 6.1

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
           - php: '7.4'
             wp_version: '6.4'
           - php: '7.4'
-            wp_version: '5.8'
+            wp_version: '6.1'
     env:
       WP_ENV_PHP_VERSION: ${{ matrix.php }}
       WP_VERSION: ${{ matrix.wp_version }}
@@ -64,12 +64,6 @@ jobs:
         uses: ramsey/composer-install@v2
         with:
           composer-options: "--ignore-platform-reqs"
-
-      - name: Adapt WP PHPUnit version for WP < 6.1
-        run: |
-          if [ ${{ env.WP_VERSION }} == '5.8' ]; then
-            composer require wp-phpunit/wp-phpunit:6.0 --dev --ignore-platform-reqs
-          fi
 
       - name: Cache node modules
         uses: actions/cache@v2

--- a/bp-loader.php
+++ b/bp-loader.php
@@ -20,7 +20,7 @@
  * Text Domain:       buddypress
  * Domain Path:       /bp-languages/
  * Requires PHP:      5.6
- * Requires at least: 5.8
+ * Requires at least: 6.1
  * Version:           14.0.0-alpha
  */
 

--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -1549,23 +1549,7 @@ function bp_block_category( $categories = array(), $editor_name_or_post = null )
 		)
 	);
 }
-
-/**
- * Select the right `block_categories` filter according to WP version.
- *
- * @since 8.0.0
- * @since 12.0.0 This category is left for third party plugin but not used anymmore.
- *
- * @todo deprecate.
- */
-function bp_block_init_category_filter() {
-	if ( function_exists( 'get_default_block_categories' ) ) {
-		add_filter( 'block_categories_all', 'bp_block_category', 1, 2 );
-	} else {
-		add_filter( 'block_categories', 'bp_block_category', 1, 2 );
-	}
-}
-add_action( 'bp_init', 'bp_block_init_category_filter' );
+add_filter( 'block_categories_all', 'bp_block_category', 1, 2 );
 
 /**
  * Outputs an Admin Notification.

--- a/src/bp-core/bp-core-blocks.php
+++ b/src/bp-core/bp-core-blocks.php
@@ -155,20 +155,7 @@ function bp_blocks_editor_settings( $editor_settings = array() ) {
 
 	return $editor_settings;
 }
-
-/**
- * Select the right `block_editor_settings` filter according to WP version.
- *
- * @since 8.0.0
- */
-function bp_block_init_editor_settings_filter() {
-	if ( function_exists( 'get_block_editor_settings' ) ) {
-		add_filter( 'block_editor_settings_all', 'bp_blocks_editor_settings' );
-	} else {
-		add_filter( 'block_editor_settings', 'bp_blocks_editor_settings' );
-	}
-}
-add_action( 'bp_init', 'bp_block_init_editor_settings_filter' );
+add_filter( 'block_editor_settings_all', 'bp_blocks_editor_settings' );
 
 /**
  * Preload the Active BuddyPress Components.

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -4699,7 +4699,7 @@ function bp_strip_script_and_style_tags( $string ) {
  */
 function bp_is_large_install() {
 	// Use the Multisite function if available.
-	if ( function_exists( 'wp_is_large_network' ) ) {
+	if ( is_multisite() ) {
 		$is_large = wp_is_large_network( 'users' );
 	} else {
 		$is_large = bp_core_get_total_member_count() > 10000;
@@ -4870,6 +4870,7 @@ function bp_get_deprecated_functions_versions() {
 		10.0,
 		11.0,
 		12.0,
+		14.0,
 	);
 
 	/*

--- a/src/bp-core/bp-core-template-loader.php
+++ b/src/bp-core/bp-core-template-loader.php
@@ -464,7 +464,7 @@ function bp_get_query_template( $type, $templates = array() ) {
 	 * The current theme is using the WordPress Full Site Editing feature.
 	 * BuddyPress then needs to use the WordPress template canvas to retrieve the community content.
 	 */
-	if ( bp_is_running_wp( '5.9.0', '>=' ) && wp_is_block_theme() ) {
+	if ( wp_is_block_theme() ) {
 		$template = ABSPATH . WPINC . '/template-canvas.php';
 	}
 
@@ -833,7 +833,7 @@ function bp_get_theme_compat_templates() {
  * @since 14.0.0
  */
 function bp_set_block_theme_compat() {
-	if ( bp_is_running_wp( '5.9.0', '>=' ) && wp_is_block_theme() && current_theme_supports( 'buddypress' ) ) {
+	if ( wp_is_block_theme() && current_theme_supports( 'buddypress' ) ) {
 		bp_deregister_template_stack( 'get_stylesheet_directory', 10 );
 		bp_deregister_template_stack( 'get_template_directory', 12 );
 

--- a/src/bp-core/classes/class-bp-attachment.php
+++ b/src/bp-core/classes/class-bp-attachment.php
@@ -643,10 +643,7 @@ abstract class BP_Attachment {
 			'height' => $height,
 		);
 
-		/**
-		 * Make sure the wp_read_image_metadata function is reachable for the old Avatar UI
-		 * or if WordPress < 3.9 (New Avatar UI is not available in this case)
-		 */
+		// Make sure the wp_read_image_metadata function is reachable.
 		if ( ! function_exists( 'wp_read_image_metadata' ) ) {
 			require_once( ABSPATH . 'wp-admin/includes/image.php' );
 		}

--- a/src/bp-core/deprecated/14.0.php
+++ b/src/bp-core/deprecated/14.0.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Deprecated functions.
+ *
+ * @package BuddyPress
+ * @deprecated 14.0.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Select the right `block_editor_settings` filter according to WP version.
+ *
+ * @since 8.0.0
+ * @deprecated 14.0.0
+ */
+function bp_block_init_editor_settings_filter() {
+	_deprecated_function( __FUNCTION__, '14.0.0' );
+}
+
+/**
+ * Select the right `block_categories` filter according to WP version.
+ *
+ * @since 8.0.0
+ * @since 12.0.0 This category is left for third party plugin but not used anymmore.
+ * @deprecated 14.0.0
+ */
+function bp_block_init_category_filter() {
+	_deprecated_function( __FUNCTION__, '14.0.0' );
+}

--- a/src/bp-loader.php
+++ b/src/bp-loader.php
@@ -20,7 +20,7 @@
  * Text Domain:       buddypress
  * Domain Path:       /bp-languages/
  * Requires PHP:      5.6
- * Requires at least: 5.8
+ * Requires at least: 6.1
  * Version:           14.0.0-alpha
  */
 

--- a/src/bp-templates/bp-nouveau/buddypress-functions.php
+++ b/src/bp-templates/bp-nouveau/buddypress-functions.php
@@ -83,10 +83,7 @@ class BP_Nouveau extends BP_Theme_Compat {
 		$this->includes_dir   = trailingslashit( $this->dir ) . 'includes/';
 		$this->directory_nav  = new BP_Core_Nav( bp_get_root_blog_id() );
 		$this->is_block_theme = false;
-
-		if ( bp_is_running_wp( '5.9.0', '>=' ) ) {
-			$this->is_block_theme = wp_is_block_theme();
-		}
+		$this->is_block_theme = wp_is_block_theme();
 	}
 
 	/**

--- a/src/bp-templates/bp-nouveau/includes/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/functions.php
@@ -1662,8 +1662,8 @@ function bp_nouveau_get_theme_layout_widths() {
 		);
 	}
 
-	// `wp_get_global_settings()` has been introduced in WordPress 5.9
-	if ( function_exists( 'wp_get_global_settings' ) ) {
+	// Use Block Theme global settings for Block Themes.
+	if ( wp_is_block_theme() ) {
 		$theme_layouts = wp_get_global_settings( array( 'layout' ) );
 
 		if ( isset( $theme_layouts['wideSize'] ) && $theme_layouts['wideSize'] ) {

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -5,7 +5,7 @@ Tags:              profiles, groups, activity, direct messaging, notifications, 
 License:           GNU General Public License v2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Requires PHP:      5.6
-Requires at least: 5.8
+Requires at least: 6.1
 Tested up to:      6.4
 Stable tag:        12.2.0
 


### PR DESCRIPTION
- 6.1 required WP version bumps
- Remove checks for WP versions < 6.1
- deprecate 2 BP Block functions

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9051

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
