### PR TITLE
Improve BP debug info

### DIFF
--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -822,6 +822,10 @@ function bp_core_add_contextual_help_content( $tab = '' ) {
 			$retval = __( 'Your users will distinguish themselves through their profile page. Create relevant profile fields that will show on each users profile.', 'buddypress' ) . '<br /><br />' . __( 'Note: Drag fields from other groups and drop them on the "Signup Fields" tab to include them into your registration form.', 'buddypress' );
 			break;
 
+		case 'bp-debug-settings':
+			$retval = __( 'Find all the details about your BuddyPress configuration opening the BuddyPress panel of your Site Health info accordion panels. If you need to ask for support, this information will help the BuddyPress community in giving you the right reply to your issue.', 'buddypress' );
+			break;
+
 		case 'bp-rewrites-overview':
 			$retval = __( 'Customize the page titles and URL slugs for the BuddyPress screens on your site.', 'buddypress' ) . '<br /><br />' . __( 'The <strong>title</strong> is the page title displayed above the BuddyPress content. For example, the page title "Members" is shown above the members directory.', 'buddypress' ) . '<br /><br />' . __( 'A <strong>slug</strong> is a portion of the URL itself. For instance, "members" is the members directory slug in the following example URL: <code>https://mysite.org/members</code>. Slugs should only include lowercase letters, numbers, and hyphens.', 'buddypress' );
 			break;

--- a/src/bp-core/admin/bp-core-admin-tools.php
+++ b/src/bp-core/admin/bp-core-admin-tools.php
@@ -757,6 +757,10 @@ add_action( 'network_admin_notices', 'bp_core_admin_notice_repopulate_blogs_resu
 function bp_core_admin_debug_information( $debug_info = array() ) {
 	global $wp_settings_fields;
 
+	if ( ! bp_is_root_blog() ) {
+		return $debug_info;
+	}
+
 	$active_components = wp_list_pluck( bp_core_get_active_components( array(), 'objects' ), 'name', 'id' );
 	$bp_settings       = array();
 	$skipped_settings  = array( '_bp_theme_package_id', '_bp_community_visibility' );

--- a/src/bp-core/admin/bp-core-admin-tools.php
+++ b/src/bp-core/admin/bp-core-admin-tools.php
@@ -756,9 +756,10 @@ add_action( 'network_admin_notices', 'bp_core_admin_notice_repopulate_blogs_resu
  */
 function bp_core_admin_debug_information( $debug_info = array() ) {
 	global $wp_settings_fields;
-	$active_components = array_intersect_key( bp_core_get_components(), buddypress()->active_components );
-	$bp_settings       = array();
-	$bp_url_parsers    = array(
+	$active_components    = array_intersect_key( bp_core_get_components(), buddypress()->active_components );
+	$bp_settings          = array();
+	$non_numeric_settings = array( '_bp_theme_package_id', '_bp_community_visibility' );
+	$bp_url_parsers       = array(
 		'rewrites' => __( 'BP Rewrites API', 'buddypress' ),
 		'legacy'   => __( 'Legacy Parser', 'buddypress' ),
 	);
@@ -770,7 +771,6 @@ function bp_core_admin_debug_information( $debug_info = array() ) {
 	} else {
 		$bp_url_parser = __( 'Custom', 'buddypress' );
 	}
-
 
 	foreach ( $wp_settings_fields['buddypress'] as $section => $settings ) {
 		$prefix       = '';
@@ -787,13 +787,13 @@ function bp_core_admin_debug_information( $debug_info = array() ) {
 				strpos( $bp_setting['id'], 'disable' ) !== false
 			);
 
-			if ( ! isset( $bp_setting['id'] ) || '_bp_theme_package_id' === $bp_setting['id'] ) {
+			if ( ! isset( $bp_setting['id'] ) || in_array( $bp_setting['id'], $non_numeric_settings, true ) ) {
 				continue;
 			}
 
-			$bp_setting_value = bp_get_option( $bp_setting['id'] );
-			if ( '0' === $bp_setting_value || '1' === $bp_setting_value ) {
-				if ( ( $reverse && '0' === $bp_setting_value ) || ( ! $reverse && '1' === $bp_setting_value ) ) {
+			$bp_setting_value = (int) bp_get_option( $bp_setting['id'], 0 );
+			if ( 0 === $bp_setting_value || 1 === $bp_setting_value ) {
+				if ( ( $reverse && 0 === $bp_setting_value ) || ( ! $reverse && 1 === $bp_setting_value ) ) {
 					$bp_setting_value = __( 'Yes', 'buddypress' );
 				} else {
 					$bp_setting_value = __( 'No', 'buddypress' );
@@ -817,21 +817,25 @@ function bp_core_admin_debug_information( $debug_info = array() ) {
 		'label'  => __( 'BuddyPress', 'buddypress' ),
 		'fields' => array_merge(
 			array(
-				'version' => array(
+				'version'                     => array(
 					'label' => __( 'Version', 'buddypress' ),
 					'value' => bp_get_version(),
 				),
-				'active_components' => array(
+				'active_components'           => array(
 					'label' => __( 'Active components', 'buddypress' ),
 					'value' => implode( ', ', wp_list_pluck( $active_components, 'title' ) ),
 				),
-				'template_pack' => array(
+				'template_pack'               => array(
 					'label' => __( 'Active template pack', 'buddypress' ),
 					'value' => bp_get_theme_compat_name() . ' ' . bp_get_theme_compat_version(),
 				),
-				'url_parser'    => array(
+				'url_parser'                  => array(
 					'label' => __( 'URL Parser', 'buddypress' ),
 					'value' => $bp_url_parser,
+				),
+				'global_community_visibility' => array(
+					'label' => __( 'Community visibility', 'buddypress' ),
+					'value' => bp_get_community_visibility( 'global' ),
 				),
 			),
 			$bp_settings


### PR DESCRIPTION
Use JavaScript to make sure the BP help tab link is only added when the BuddyPress help tab is active.

<img width="1280" alt="bp-debug-info" src="https://github.com/buddypress/buddypress/assets/1834524/88ddff29-227d-422d-b565-fd585a77be31">

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9093

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
