### PR TITLE
Make sure the Activity Load More button do not skip entries

### DIFF
--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -425,10 +425,16 @@ function bp_activity_load_more_link() {
 			$activities_template->pag_arg => $activities_template->pag_page + 1,
 		);
 
-		// Try to include the offset arg.
-		$last_displayed_activity = reset( $activities_template->activities );
-		if ( isset( $last_displayed_activity->id ) && $last_displayed_activity->id ) {
-			$load_more_args['offset_lower'] = (int) $last_displayed_activity->id;
+		// Use the first posted offset arg to transport it for each following page links.
+		if ( isset( $_POST['offset_lower'] ) && $_POST['offset_lower'] ) {
+			$load_more_args['offset_lower'] = (int) wp_unslash( $_POST['offset_lower'] );
+
+			// Try to include the offset arg to the second page link.
+		} elseif ( 1 === $activities_template->pag_page ) {
+			$last_displayed_activity = reset( $activities_template->activities );
+			if ( isset( $last_displayed_activity->id ) && $last_displayed_activity->id ) {
+				$load_more_args['offset_lower'] = (int) $last_displayed_activity->id;
+			}
 		}
 
 		$link = add_query_arg( $load_more_args, $url );

--- a/src/bp-activity/classes/class-bp-activity-activity.php
+++ b/src/bp-activity/classes/class-bp-activity-activity.php
@@ -1978,7 +1978,7 @@ class BP_Activity_Activity {
 
 		if ( ! empty( $filter_array['offset_lower'] ) ) {
 			$sid_sql = absint( $filter_array['offset_lower'] );
-			$filter_sql[] = "a.id < {$sid_sql}";
+			$filter_sql[] = "a.id <= {$sid_sql}";
 		}
 
 		if ( ! empty( $filter_array['since'] ) ) {


### PR DESCRIPTION
The offset lower value needs to remain the higher activity ID of the first displayed page.

Include two unit tests about `offset_lower` filter usage.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9094

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
