### PR TITLE
Patch/9095

### DIFF
--- a/src/bp-templates/bp-nouveau/includes/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/functions.php
@@ -752,7 +752,10 @@ function bp_nouveau_customizer_grid_choices( $type = 'option' ) {
  * @return array An array of nav items slugs.
  */
 function bp_nouveau_sanitize_nav_order( $option = '' ) {
-	$option = explode( ',', $option );
+	if ( ! is_array( $option ) ) {
+		$option = explode( ',', $option );
+	}
+
 	return array_map( 'sanitize_key', $option );
 }
 

--- a/src/bp-templates/bp-nouveau/includes/members/functions.php
+++ b/src/bp-templates/bp-nouveau/includes/members/functions.php
@@ -493,10 +493,21 @@ function bp_nouveau_get_wp_profile_fields( $user = null ) {
  * @return array The Members single item primary nav ordered.
  */
 function bp_nouveau_member_customizer_nav() {
+	$nav = buddypress()->members->nav;
+
+	if ( ! $nav->get_primary() ) {
+		$nav_items = bp_get_component_navigations();
+
+		// Forces navigation generation.
+		foreach ( $nav_items as $nav_item ) {
+			$nav->add_nav( $nav_item['main_nav'] );
+		}
+	}
+
 	add_filter( '_bp_nouveau_member_reset_front_template', 'bp_nouveau_member_restrict_user_front_templates', 10, 1 );
 
 	if ( bp_displayed_user_get_front_template( buddypress()->loggedin_user ) ) {
-		buddypress()->members->nav->add_nav(
+		$nav->add_nav(
 			array(
 				'name'     => _x( 'Home', 'Member Home page', 'buddypress' ),
 				'slug'     => 'front',
@@ -506,8 +517,6 @@ function bp_nouveau_member_customizer_nav() {
 	}
 
 	remove_filter( '_bp_nouveau_member_reset_front_template', 'bp_nouveau_member_restrict_user_front_templates', 10, 1 );
-
-	$nav = buddypress()->members->nav;
 
 	// Eventually reset the order.
 	bp_nouveau_set_nav_item_order( $nav, bp_nouveau_get_appearance_settings( 'user_nav_order' ) );


### PR DESCRIPTION
Fixes a notice error about the Group's customizer panel to customize nav item orders
Brings back the nav items to the Member's customizer panel to allow the admin to customize the order for these.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9095

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
