### PR TITLE
Patch/9104

### DIFF
--- a/src/bp-core/bp-core-adminbar.php
+++ b/src/bp-core/bp-core-adminbar.php
@@ -23,8 +23,9 @@ function bp_admin_bar_my_account_root() {
 	global $wp_admin_bar;
 
 	// Bail if this is an ajax request.
-	if ( !bp_use_wp_admin_bar() || defined( 'DOING_AJAX' ) )
+	if ( wp_doing_ajax() ) {
 		return;
+	}
 
 	// Only add menu for logged in user.
 	if ( is_user_logged_in() ) {
@@ -53,12 +54,6 @@ function bp_core_load_admin_bar() {
 	if ( ! is_user_logged_in() && (int) bp_get_option( 'hide-loggedout-adminbar' ) != 1 ) {
 		show_admin_bar( true );
 	}
-
-	// Hide the WordPress Toolbar.
-	if ( ! bp_use_wp_admin_bar() ) {
-		// Keep the WP Toolbar from loading.
-		show_admin_bar( false );
-	}
 }
 add_action( 'init', 'bp_core_load_admin_bar', 9 );
 
@@ -86,9 +81,8 @@ function bp_core_load_admin_bar_css() {
  */
 function bp_core_enqueue_admin_bar_css() {
 
-	// Bail if not using WordPress's admin bar or it's not showing on this
-	// page request.
-	if ( ! bp_use_wp_admin_bar() || ! is_admin_bar_showing() ) {
+	// Bail if WordPress's admin bar is not showing on this page request.
+	if ( ! is_admin_bar_showing() ) {
 		return;
 	}
 

--- a/src/bp-core/bp-core-dependency.php
+++ b/src/bp-core/bp-core-dependency.php
@@ -190,17 +190,12 @@ function bp_setup_nav() {
  * @since 1.5.0
  */
 function bp_setup_admin_bar() {
-	if ( bp_use_wp_admin_bar() ) {
-
-		/**
-		 * Fires inside the 'bp_setup_admin_bar' function, where plugins should add items to the WP admin bar.
-		 *
-		 * This hook will only fire if bp_use_wp_admin_bar() returns true.
-		 *
-		 * @since 1.5.0
-		 */
-		do_action( 'bp_setup_admin_bar', array() );
-	}
+	/**
+	 * Fires inside the 'bp_setup_admin_bar' function, where plugins should add items to the WP admin bar.
+	 *
+	 * @since 1.5.0
+	 */
+	do_action( 'bp_setup_admin_bar', array() );
 }
 
 /**

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -499,36 +499,6 @@ function bp_is_username_compatibility_mode() {
 	return apply_filters( 'bp_is_username_compatibility_mode', defined( 'BP_ENABLE_USERNAME_COMPATIBILITY_MODE' ) && BP_ENABLE_USERNAME_COMPATIBILITY_MODE );
 }
 
-/**
- * Should we use the WP Toolbar?
- *
- * The WP Toolbar, introduced in WP 3.1, is fully supported in BuddyPress as
- * of BP 1.5. For BP 1.6, the WP Toolbar is the default.
- *
- * @since 1.5.0
- *
- * @return bool Default: true. False when WP Toolbar support is disabled.
- */
-function bp_use_wp_admin_bar() {
-
-	// Default to true.
-	$use_admin_bar = true;
-
-	// Has the WP Toolbar constant been explicitly opted into?
-	if ( defined( 'BP_USE_WP_ADMIN_BAR' ) ) {
-		$use_admin_bar = (bool) BP_USE_WP_ADMIN_BAR;
-	}
-
-	/**
-	 * Filters whether or not to use the admin bar.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param bool $use_admin_bar Whether or not to use the admin bar.
-	 */
-	return (bool) apply_filters( 'bp_use_wp_admin_bar', $use_admin_bar );
-}
-
 
 /**
  * Return the parent forum ID for the Legacy Forums abstraction layer.

--- a/src/bp-core/classes/class-bp-component.php
+++ b/src/bp-core/classes/class-bp-component.php
@@ -807,12 +807,7 @@ class BP_Component {
 		global $wp_admin_bar;
 
 		// Bail if this is an ajax request.
-		if ( defined( 'DOING_AJAX' ) ) {
-			return;
-		}
-
-		// Do not proceed if BP_USE_WP_ADMIN_BAR constant is not set or is false.
-		if ( ! bp_use_wp_admin_bar() ) {
+		if ( wp_doing_ajax() ) {
 			return;
 		}
 

--- a/src/bp-core/deprecated/14.0.php
+++ b/src/bp-core/deprecated/14.0.php
@@ -31,3 +31,35 @@ function bp_block_init_editor_settings_filter() {
 function bp_block_init_category_filter() {
 	_deprecated_function( __FUNCTION__, '14.0.0' );
 }
+
+/**
+ * Should we use the WP Toolbar?
+ *
+ * The WP Toolbar, introduced in WP 3.1, is fully supported in BuddyPress as
+ * of BP 1.5. For BP 1.6, the WP Toolbar is the default.
+ *
+ * @since 1.5.0
+ * @deprecated 14.0.0
+ *
+ * @return bool Default: true. False when WP Toolbar support is disabled.
+ */
+function bp_use_wp_admin_bar() {
+	_deprecated_function( __FUNCTION__, '14.0.0' );
+
+	// Default to true.
+	$use_admin_bar = true;
+
+	if ( defined( 'BP_USE_WP_ADMIN_BAR' ) ) {
+		_doing_it_wrong( 'BP_USE_WP_ADMIN_BAR', esc_html__( 'The BP_USE_WP_ADMIN_BAR constant is deprecated.', 'buddypress' ), 'BuddyPress 14.0.0' );
+	}
+
+	/**
+	 * Filters whether or not to use the admin bar.
+	 *
+	 * @since 1.5.0
+	 * @deprecated 14.0.0
+	 *
+	 * @param bool $use_admin_bar Whether or not to use the admin bar.
+	 */
+	return apply_filters_deprecated( 'bp_use_wp_admin_bar', array( $use_admin_bar ), '14.0.0' );
+}


### PR DESCRIPTION
Deprecate `bp_use_wp_admin_bar()` & `BP_USE_WP_ADMIN_BAR`

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9104

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
