### PR TITLE
Update `@wordpress/env` to 9.4.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11,7 +11,7 @@
 			"devDependencies": {
 				"@wordpress/babel-preset-default": "^7.32.0",
 				"@wordpress/browserslist-config": "^5.31.0",
-				"@wordpress/env": "^9.0.0",
+				"@wordpress/env": "^9.4.0",
 				"@wordpress/scripts": "^26.19.0",
 				"@wordpress/stylelint-config": "~19.1.0",
 				"autoprefixer": "^9.8.8",
@@ -5030,9 +5030,9 @@
 			}
 		},
 		"node_modules/@wordpress/env": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-9.0.0.tgz",
-			"integrity": "sha512-Fyec0k5N7kaXVIpTnJ2zO/n3CIiq8cPDsUaFoLVKI+yv2cVuq1dSQyc1lLXB9Gu+SNvmfbq7nNVVmNfKgpAkrw==",
+			"version": "9.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-9.4.0.tgz",
+			"integrity": "sha512-flF+WLAuf8j97OjFkJU7/l9bzvI7GEUm1MXYdo16kSqxBvOTwVkk2yf5s9nxREJ3gPYahgNYf8cA7uT9Rj2eDQ==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"@wordpress/babel-preset-default": "^7.32.0",
 		"@wordpress/browserslist-config": "^5.31.0",
 		"@wordpress/scripts": "^26.19.0",
-		"@wordpress/env": "^9.0.0",
+		"@wordpress/env": "^9.4.0",
 		"@wordpress/stylelint-config": "~19.1.0",
 		"autoprefixer": "^9.8.8",
 		"grunt": "^1.6.1",


### PR DESCRIPTION
Goal of this update is to fix failing PHPUnit tests.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9105

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
