### PR TITLE
Make sure to reset Primary item link when a member is displayed

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -2791,7 +2791,22 @@ function bp_nav_menu_get_loggedin_pages() {
 	$bp_menu_items = array();
 
 	if ( 'rewrites' !== bp_core_get_query_parser() ) {
-		$bp_menu_items = $bp->members->nav->get_primary();
+		$primary_items = $bp->members->nav->get_primary();
+
+		foreach( $primary_items as $primary_item ) {
+			$current_user_link = $primary_item['link'];
+
+			// When displaying a user, reset the primary item link.
+			if ( bp_is_user() ) {
+				$current_user_link = bp_loggedin_user_url( bp_members_get_path_chunks( array( $primary_item['slug'] ) ) );
+			}
+
+			$bp_menu_items[] = array(
+				'name' => $primary_item['name'],
+				'slug' => $primary_item['slug'],
+				'link' => $current_user_link,
+			);
+		}
 	} else {
 		$members_navigation = bp_get_component_navigations();
 


### PR DESCRIPTION
**The BP Core Nav has always stored items using the displayed user ID.**

Before 12.0.0, the `bp_core_create_nav_link()` was forcing the [link attribute](https://github.com/buddypress/buddypress/blob/13e73bc821f8dc2fc9ff30d8166d3991268063ab/src/bp-core/bp-core-buddybar.php#L163) of items to be a logged in user link and a replacement was performed during displayed member navigation generation so that this link became the displayed user link.

Starting in 12.0.0, this `link` attribute is no more used by default when creating these nav links, instead, we are [generating this link attribute](https://github.com/buddypress/buddypress/blob/master/src/bp-core/classes/class-bp-core-nav.php#L217) using a function to check whether primary slug items has been customized or not.

Links for the `bp_nav_menu_get_loggedin_pages()` are built using the `bp_get_component_navigations()` when the BP URL parser is set to `rewrites` while it keeps on using the BP Core Nav items when it is set to `legacy`. This is necessary because plugins not ready yet for BuddyPress 12.0 are not registering their nav items but just setting them. For this particular case: we need to reset the primary item link to the logged in user one when viewing a member (as nav items are now using the displayed user link by default).

This will fix the issue for users that are forced to use BP Classic by plugins not updating their code for the Modern BuddyPress 😫.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9108

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
