### PR TITLE
Introduce the Activity Type API and replace favorites with likes!

### DIFF
--- a/src/bp-activity/actions/dislike.php
+++ b/src/bp-activity/actions/dislike.php
@@ -17,11 +17,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 14.0.0
  *
- * @return bool False on failure.
+ * @return void
  */
 function bp_activity_dislike_action() {
 	if ( ! is_user_logged_in() || ! bp_is_activity_component() || ! bp_is_current_action( 'dislike' ) ) {
-		return false;
+		return;
 	}
 
 	// Check the nonce.

--- a/src/bp-activity/actions/dislike.php
+++ b/src/bp-activity/actions/dislike.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Activity: Dislike action
+ *
+ * @package BuddyPress
+ * @subpackage ActivityActions
+ * @since 14.0.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Dislike an activity.
+ *
+ * @since 14.0.0
+ *
+ * @return bool False on failure.
+ */
+function bp_activity_dislike_action() {
+	if ( ! is_user_logged_in() || ! bp_is_activity_component() || ! bp_is_current_action( 'dislike' ) ) {
+		return false;
+	}
+
+	// Check the nonce.
+	check_admin_referer( 'bp_activity_like' );
+
+	$feedback        = __( 'Ouch something went wrong when trying to dislike this activity.', 'buddypress' );
+	$feedback_type   = 'error';
+	$activities      = bp_activity_get_specific(
+		array(
+			'activity_ids'     => bp_action_variable( 0 ),
+			'display_comments' => 'threaded',
+		)
+	);
+	$parent_activity = reset( $activities['activities'] );
+
+	if ( empty( $parent_activity->id ) ) {
+		$feedback = __( 'The activity you want to dislike does not exist.', 'buddypress' );
+
+	} else {
+		$user_like = array();
+		if ( isset( $parent_activity->reactions ) ) {
+			$user_like = wp_filter_object_list( $parent_activity->reactions, array( 'type' => 'activity_like', 'user_id' => bp_loggedin_user_id() ), 'AND', 'id' );
+		}
+
+		// The user didn't like it!
+		if ( empty( $user_like ) || 1 !== count( $user_like ) ) {
+			$feedback = __( 'Ouch! Are you sure you liked this activity? Looks like it’s not the case.', 'buddypress' );
+
+		} else {
+			$reaction_id = reset( $user_like );
+			$disliked    = bp_activity_remove_reaction( $reaction_id );
+
+			if ( is_wp_error( $disliked ) ) {
+				$feedback = $disliked->get_error_message();
+			} else {
+				$feedback      = __( 'You successfully disliked it!', 'buddypress' );
+				$feedback_type = 'success';
+			}
+		}
+	}
+
+	bp_core_add_message( $feedback, $feedback_type );
+	bp_core_redirect( wp_get_referer() );
+}
+add_action( 'bp_actions', 'bp_activity_dislike_action' );

--- a/src/bp-activity/actions/like.php
+++ b/src/bp-activity/actions/like.php
@@ -56,7 +56,8 @@ function bp_activity_like_action() {
 		} else {
 			$like_id = bp_activity_add_reaction(
 				array(
-					'activity_id' => $parent_activity->id,
+					'activity'     => $parent_activity,
+					'primary_link' => bp_activity_get_permalink( $parent_activity->id, $parent_activity ),
 				)
 			);
 

--- a/src/bp-activity/actions/like.php
+++ b/src/bp-activity/actions/like.php
@@ -17,11 +17,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 14.0.0
  *
- * @return bool False on failure.
+ * @return void
  */
 function bp_activity_like_action() {
 	if ( ! is_user_logged_in() || ! bp_is_activity_component() || ! bp_is_current_action( 'like' ) ) {
-		return false;
+		return;
 	}
 
 	// Check the nonce.

--- a/src/bp-activity/actions/like.php
+++ b/src/bp-activity/actions/like.php
@@ -38,7 +38,7 @@ function bp_activity_like_action() {
 	$parent_activity = reset( $activities['activities'] );
 
 	if ( empty( $parent_activity->id ) ) {
-		$feedback = __( 'The activity you want to like does not exist', 'buddypress' );
+		$feedback = __( 'The activity you want to like does not exist.', 'buddypress' );
 
 	} elseif ( ! bp_activity_user_can_read( $parent_activity, bp_loggedin_user_id() ) ) {
 		$feedback = __( 'You are not allowed to like this activity.', 'buddypress' );

--- a/src/bp-activity/bp-activity-cache.php
+++ b/src/bp-activity/bp-activity-cache.php
@@ -48,9 +48,13 @@ function bp_activity_clear_cache_for_activity( $activity ) {
 	wp_cache_delete( $activity->id, 'bp_activity' );
 	wp_cache_delete( 'bp_activity_sitewide_front', 'bp' );
 
-	// Clear the comments cache for the parent activity ID.
-	if ( 'activity_comment' === $activity->type && ! empty( $activity->item_id ) ) {
-		wp_cache_delete( $activity->item_id, 'bp_activity_comments' );
+	// Clear the reactions cache for the parent activity ID.
+	if ( ! empty( $activity->item_id ) ) {
+		if ( 'activity_comment' === $activity->type ) {
+			wp_cache_delete( $activity->item_id, 'bp_activity_comments' );
+		} elseif ( in_array( $activity->type, bp_get_activity_types_for_role( 'reaction' ), true ) ) {
+			wp_cache_delete( $activity->item_id, 'bp_activity_reactions' );
+		}
 	}
 }
 add_action( 'bp_activity_after_save', 'bp_activity_clear_cache_for_activity' );

--- a/src/bp-activity/bp-activity-filters.php
+++ b/src/bp-activity/bp-activity-filters.php
@@ -719,7 +719,7 @@ add_filter( 'bp_activity_set_just-me_scope_args', 'bp_activity_filter_just_me_sc
  *
  * @param array $retval Empty array by default.
  * @param array $filter Current activity arguments.
- * @return array $retval
+ * @return array
  */
 function bp_activity_filter_likes_scope( $retval = array(), $filter = array() ) {
 

--- a/src/bp-activity/bp-activity-filters.php
+++ b/src/bp-activity/bp-activity-filters.php
@@ -713,6 +713,62 @@ function bp_activity_filter_just_me_scope( $retval = array(), $filter = array() 
 add_filter( 'bp_activity_set_just-me_scope_args', 'bp_activity_filter_just_me_scope', 10, 2 );
 
 /**
+ * Set up activity arguments for use with the 'likes' scope.
+ *
+ * @since 14.0.0
+ *
+ * @param array $retval Empty array by default.
+ * @param array $filter Current activity arguments.
+ * @return array $retval
+ */
+function bp_activity_filter_likes_scope( $retval = array(), $filter = array() ) {
+
+	// Determine the user_id.
+	if ( ! empty( $filter['user_id'] ) ) {
+		$user_id = $filter['user_id'];
+	} else {
+		$user_id = bp_displayed_user_id()
+			? bp_displayed_user_id()
+			: bp_loggedin_user_id();
+	}
+
+	// Get user likes.
+	$likes = bp_activity_get_user_reactions( $user_id );
+	if ( empty( $likes ) ) {
+		$likes = array( 0 );
+	}
+
+	// Should we show all items regardless of sitewide visibility?
+	$show_hidden = array();
+	if ( ! empty( $user_id ) && ( $user_id !== bp_loggedin_user_id() ) ) {
+		$show_hidden = array(
+			'column' => 'hide_sitewide',
+			'value'  => 0
+		);
+	}
+
+	$retval = array(
+		'relation' => 'AND',
+		array(
+			'column'  => 'id',
+			'compare' => 'IN',
+			'value'   => (array) $likes,
+		),
+		$show_hidden,
+
+		// Overrides.
+		'override' => array(
+			'display_comments' => true,
+			'filter'           => array( 'user_id' => 0 ),
+			'show_hidden'      => true
+		),
+	);
+
+	return $retval;
+}
+add_filter( 'bp_activity_set_likes_scope_args', 'bp_activity_filter_likes_scope', 10, 2 );
+
+/**
  * Set up activity arguments for use with the 'favorites' scope.
  *
  * @since 2.2.0

--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -1217,11 +1217,6 @@ function bp_activity_add_reaction( $args = '' ) {
 		)
 	);
 
-	// Bail on failure.
-	if ( is_wp_error( $reaction_id ) ) {
-		return $reaction_id;
-	}
-
 	return $reaction_id;
 }
 

--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -1143,7 +1143,7 @@ function bp_activity_get_actions_for_context( $context = '' ) {
  *     @type bool       $skip_notification Optional. false to send a reaction notification, true otherwise.
  *                                         Defaults to true.
  * }
- * @return WP_Error|int The ID of the reaction on success, otherwise false.
+ * @return WP_Error|integer The ID of the reaction on success, otherwise false.
  */
 function bp_activity_add_reaction( $args = '' ) {
 	$r = bp_parse_args(

--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -387,12 +387,12 @@ function bp_unregister_activity_type( $type ) {
 }
 
 /**
- * Retrieves the list of Activity types having a specific role.
+ * Retrieves the Activity type object for a specific type.
  *
  * @since 14.0.0
  *
  * @param string $type The name key of the activity type.
- * @return WP_Error|BP_Activity_Type The list of Activity type name keys having the requested role.
+ * @return WP_Error|BP_Activity_Type The Activity type object.
  */
 function bp_get_activity_type_object( $type ) {
 	$activity_types = buddypress()->activity->types;
@@ -809,7 +809,6 @@ function bp_activity_type_supports( $activity_type = '', $feature = '' ) {
 
 	switch ( $feature ) {
 		case 'comments' :
-		case 'favorites' :
 		case 'likes' :
 			$retval = isset( $bp->activity->types[ $activity_type ]->supports->{$feature} ) && true === $bp->activity->types[ $activity_type ]->supports->{$feature};
 			break;
@@ -1276,7 +1275,7 @@ function bp_activity_remove_reaction( $reaction_id, $reaction_type = 'activity_l
 
 	// Validate the reaction.
 	$reaction = new BP_Activity_Activity( $reaction_id );
-	if ( empty( $reaction->id ) ) {
+	if ( empty( $reaction->id ) || $reaction_type !== $reaction->type ) {
 		return new WP_Error(
 			'activity_reaction_missing',
 			sprintf(
@@ -2547,6 +2546,7 @@ function bp_activity_add( $args = '' ) {
 		$activity->action = bp_activity_generate_action_string( $activity );
 	}
 
+	// Setting the `mptt_left` property to 2 makes it possible to run the same query to get all reactions (including comments).
 	if ( 'activity_comment' !== $activity->type && in_array( $activity->type, bp_get_activity_types_for_role( 'reaction' ), true ) ) {
 		$activity->mptt_left  = 2;
 	}

--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -347,7 +347,7 @@ function bp_activity_get_userid_from_mentionname( $mentionname ) {
 function bp_register_activity_type( $type, $args = array() ) {
 	$activity_types = buddypress()->activity->types;
 
-	// Sanitize post type name.
+	// Sanitize the name key of the activity type.
 	$type = sanitize_key( $type );
 
 	if ( empty( $type ) || strlen( $type ) > 20 ) {
@@ -371,8 +371,7 @@ function bp_register_activity_type( $type, $args = array() ) {
  * @since 14.0.0
  *
  * @param  string $type The name key of the activity type.
- * @return bool|WP_Error The registered activity type object on success,
- *                                   WP_Error object on failure.
+ * @return bool|WP_Error True on success. A `WP_Error` object on failure.
  */
 function bp_unregister_activity_type( $type ) {
 	$type_object = bp_get_activity_type_object( $type );
@@ -2101,7 +2100,7 @@ function bp_activity_generate_action_string( $activity ) {
  *
  * @param string $action   Static activity action.
  * @param object $activity Activity data object.
- * @return string $action
+ * @return string
  */
 function bp_activity_format_activity_action_activity_update( $action, $activity ) {
 	$action = sprintf(
@@ -2128,7 +2127,7 @@ function bp_activity_format_activity_action_activity_update( $action, $activity 
  *
  * @param string $action   Static activity action.
  * @param object $activity Activity data object.
- * @return string $action
+ * @return string
  */
 function bp_activity_format_activity_action_activity_comment( $action, $activity ) {
 	$action = sprintf(
@@ -2155,7 +2154,7 @@ function bp_activity_format_activity_action_activity_comment( $action, $activity
  *
  * @param string $action   Static activity action.
  * @param object $activity Activity data object.
- * @return string $action
+ * @return string
  */
 function bp_activity_format_activity_action_activity_like( $action, $activity ) {
 	$action = sprintf(
@@ -2182,7 +2181,7 @@ function bp_activity_format_activity_action_activity_like( $action, $activity ) 
  *
  * @param string $action   Static activity action.
  * @param object $activity Activity data object.
- * @return string $action
+ * @return string
  */
 function bp_activity_format_activity_action_custom_post_type_post( $action, $activity ) {
 	$bp = buddypress();

--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -1231,7 +1231,7 @@ function bp_activity_add_reaction( $args = '' ) {
 		)
 	);
 
-	wp_cache_delete( $activity_id, 'bp_activity_reactions' );
+	wp_cache_delete( $activity->id, 'bp_activity_reactions' );
 
 	if ( 'activity_like' === $reaction_object->name ) {
 		wp_cache_delete( $user_id, 'bp_activity_user_likes' );

--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -4462,9 +4462,10 @@ function bp_get_activity_like_link( $type = 'add', $activity = null ) {
 	 *
 	 * @since 14.0.0
 	 *
-	 * @param string $url  Constructed link for liking the activity.
-	 * @param string $type Whether to `add` or `remove` the like.
-	 * @param string $slug The computed slug according to the type (`like` or `dislike`).
+	 * @param string               $url      Constructed link for liking the activity.
+	 * @param string               $type     Whether to `add` or `remove` the like.
+	 * @param string               $slug     The computed slug according to the type (`like` or `dislike`).
+	 * @param BP_Activity_Activity $activity The Activity object to add a like to.
 	 */
-	return apply_filters( 'bp_get_activity_like_link', $url, $type, $slug );
+	return apply_filters( 'bp_get_activity_like_link', $url, $type, $slug, $activity );
 }

--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -3356,15 +3356,20 @@ function bp_activity_can_comment_reply( $comment = false ) {
  * @return bool True if comment can receive comments.
  */
 function bp_activity_can_favorite() {
+	/*
+	 * In 14.0.0:
+	 * @todo Move the Favorites feature into BP Classic
+	 */
+	$can_favorite = ! bp_activity_supports_likes();
 
 	/**
 	 * Filters whether or not users can favorite activity items.
 	 *
 	 * @since 1.5.0
 	 *
-	 * @param bool $value Whether or not favoriting is enabled.
+	 * @param bool $can_favorite Whether or not favoriting is enabled.
 	 */
-	return apply_filters( 'bp_activity_can_favorite', true );
+	return apply_filters( 'bp_activity_can_favorite', $can_favorite );
 }
 
 /**

--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -4350,8 +4350,23 @@ function bp_activity_supports_likes() {
  *
  * @return integer The number of times an activity was liked.
  */
-function bp_activity_get_like_count() {
-	return 0;
+function bp_activity_get_like_count( $activity = null ) {
+	$count = 0;
+
+	if ( $activity instanceof BP_Activity_Activity ) {
+		/*
+		 * @todo Get Like count for a given activity.
+		 */
+
+	} elseif ( isset( $GLOBALS['activities_template']->activity->reactions ) ) {
+		$likes = wp_list_filter( $GLOBALS['activities_template']->activity->reactions, array( 'type' => 'activity_like' ) );
+
+		if ( $likes ) {
+			$count = count( $likes );
+		}
+	}
+
+	return $count;
 }
 
 /**

--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -4382,7 +4382,6 @@ function bp_activity_is_liked( $user_id = 0, $activity = null ) {
  * Informs about the number of times an activity was liked.
  *
  * @since 14.0.0
- * @todo Build the function!
  *
  * @param BP_Activity_Activity The Activity object. Optional.
  *                             Defaults to the current Activity in the loop.

--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -4324,3 +4324,73 @@ function bp_activity_show_filters( $context = '' ) {
 		 */
 		return apply_filters( 'bp_get_activity_show_filters', $output, $filters, $context );
 	}
+
+
+/**
+ * Are Activity likes supported by this site?
+ *
+ * @since 14.0.0
+ * @todo Build the function!
+ *
+ * @return boolean True if Activity likes are supported. False otherwise.
+ */
+function bp_activity_supports_likes() {
+	/*
+	 * This is where we'll need to check for:
+	 * current_theme_supports( 'buddypress', ['activity', ['likes'] ] );
+	 */
+	return true;
+}
+
+/**
+ * Informs about the number of times an activity was liked.
+ *
+ * @since 14.0.0
+ * @todo Build the function!
+ *
+ * @return integer The number of times an activity was liked.
+ */
+function bp_activity_get_like_count() {
+	return 0;
+}
+
+/**
+ * Gets the link to like an activity.
+ *
+ * @since 14.0.0
+ *
+ * @param BP_Activity_Activity $activity An activity object. Optional.
+ * @return string The link to like an activity.
+ */
+function bp_get_activity_like_link( $activity = null ) {
+	$url         = '';
+	$activity_id = 0;
+
+	if ( $activity instanceof BP_Activity_Activity ) {
+		$activity_id = (int) $activity->id;
+
+	} elseif ( isset( $GLOBALS['activities_template']->activity->id ) ) {
+		$activity_id = (int) $GLOBALS['activities_template']->activity->id;
+	}
+
+	if ( $activity_id ) {
+		$url = bp_rewrites_get_url(
+			array(
+				'component_id'                 => 'activity',
+				'single_item_action'           => 'like',
+				'single_item_action_variables' => array( $activity_id ),
+			)
+		);
+
+		$url = wp_nonce_url( $url, 'bp_activity_like' );
+	}
+
+	/**
+	 * Filters the link to like an activity.
+	 *
+	 * @since 14.0.0
+	 *
+	 * @param string $url Constructed link for liking the activity.
+	 */
+	return apply_filters( 'bp_get_activity_like_link', $url );
+}

--- a/src/bp-activity/classes/class-bp-activity-activity.php
+++ b/src/bp-activity/classes/class-bp-activity-activity.php
@@ -456,6 +456,11 @@ class BP_Activity_Activity {
 			)
 		);
 
+		/*
+		 * @todo $r['display_comments'] should be deprecated in favor of $r['display_reactions']
+		 */
+		$display_reactions = $r['display_comments'];
+
 		// Select conditions.
 		$select_sql = "SELECT DISTINCT a.id";
 
@@ -636,8 +641,8 @@ class BP_Activity_Activity {
 		// Alter the query based on whether we want to show activity item
 		// comments in the stream like normal comments or threaded below
 		// the activity.
-		if ( false === $r['display_comments'] || 'threaded' === $r['display_comments'] ) {
-			$excluded_types[] = 'activity_comment';
+		if ( false === $display_reactions || 'threaded' === $display_reactions ) {
+			$excluded_types = bp_get_activity_types_for_role( 'reaction' );
 		}
 
 		// Exclude 'last_activity' items unless the 'action' filter has
@@ -825,7 +830,10 @@ class BP_Activity_Activity {
 				bp_activity_update_meta_cache( $activity_ids );
 			}
 
-			if ( $activities && $r['display_comments'] ) {
+			if ( $activities && $display_reactions ) {
+				/*
+				 * This should append all possible reactions.
+				 */
 				$activities = BP_Activity_Activity::append_comments( $activities, $r['spam'] );
 			}
 

--- a/src/bp-activity/classes/class-bp-activity-activity.php
+++ b/src/bp-activity/classes/class-bp-activity-activity.php
@@ -2258,15 +2258,13 @@ class BP_Activity_Activity {
 			return array();
 		}
 
-		$user_likes_cache = array();
-		if ( 'activity_like' === $reaction_type ) {
-			$user_likes_cache = wp_cache_get( $user_id, 'bp_activity_user_likes' );
+		// Get the user's reactions cache.
+		$user_reactions_cache = wp_cache_get( $user_id, 'bp_activity_user_reactions' );
 
-			if ( 'none' === $user_likes_cache ) {
-				return array();
-			} elseif ( ! empty( $user_likes_cache ) ) {
-				return (array) $user_likes_cache;
-			}
+		if ( 'none' === $user_reactions_cache ) {
+			return array();
+		} elseif ( ! empty( $user_reactions_cache ) ) {
+			return (array) $user_reactions_cache;
 		}
 
 		if ( empty( $GLOBALS['wpdb'] ) ) {
@@ -2278,15 +2276,13 @@ class BP_Activity_Activity {
 		$sql            = $wpdb->prepare( "SELECT item_id FROM {$activity_table} WHERE user_id = %d AND type = %s", $user_id, $reaction_type );
 		$activities     = $wpdb->get_col( $sql );
 
-		if ( 'activity_like' === $reaction_type ) {
-			$user_likes_cache_value = $activities;
-
-			if ( ! $activities ) {
-				$user_likes_cache_value = 'none';
-			}
-
-			wp_cache_set( $user_id, $user_likes_cache_value, 'bp_activity_user_likes' );
+		$user_reactions_cache_value = $activities;
+		if ( ! $activities ) {
+			$user_reactions_cache_value = 'none';
 		}
+
+		// Set the user's reactions cache.
+		wp_cache_set( $user_id, $user_reactions_cache_value, 'bp_activity_user_reactions' );
 
 		return $activities;
 	}

--- a/src/bp-activity/classes/class-bp-activity-activity.php
+++ b/src/bp-activity/classes/class-bp-activity-activity.php
@@ -1623,6 +1623,14 @@ class BP_Activity_Activity {
 		return true;
 	}
 
+	/**
+	 * Build an associative array of comments and calculate comments depth.
+	 *
+	 * @since 14.0.0
+	 *
+	 * @param array $descendants The list of activity comments. Required.
+	 * @return array The list of activity comments.
+	 */
 	public static function build_assoc_array_and_calcultate_depth( $descendants ) {
 		$comments = array();
 		$ref      = array();
@@ -1679,6 +1687,22 @@ class BP_Activity_Activity {
 		return $comments;
 	}
 
+	/**
+	 * Fetch reactions for the activity. Reactions are including comments.
+	 *
+	 * @since 14.0.0
+	 *
+	 * @param array $args {
+	 *     An array of arguments.
+	 *
+	 *     @type integer $activity_id         Activity ID to fetch comments for.
+	 *     @type integer $mptt_left           Left-most node boundary.
+	 *     @type integer $mptt_right          Right-most node boundary.
+	 *     @type string  $spam                Optional. 'ham_only' (default), 'spam_only' or 'all'.
+	 *     @type integer $top_level_parent_id Optional. The id of the root-level parent activity item.
+	 * }
+	 * @return array An associative array containing Activity comments and Activity reactions.
+	 */
 	public static function get_activity_reactions( $args = array() ) {
 		$r = bp_parse_args(
 			$args,
@@ -1811,6 +1835,15 @@ class BP_Activity_Activity {
 		return $retval;
 	}
 
+	/**
+	 * Append activity reactions to their associated activity items.
+	 *
+	 * @since 14.0.0
+	 *
+	 * @param array  $activities Activities to fetch reactions for.
+	 * @param string $spam       Optional. 'ham_only' (default), 'spam_only' or 'all'.
+	 * @return array The updated activities with nested reactions.
+	 */
 	public static function append_reactions( $activities, $spam = 'ham_only' ) {
 		$activity_reactions = array();
 

--- a/src/bp-activity/classes/class-bp-activity-activity.php
+++ b/src/bp-activity/classes/class-bp-activity-activity.php
@@ -834,7 +834,7 @@ class BP_Activity_Activity {
 				/*
 				 * This should append all possible reactions.
 				 */
-				$activities = BP_Activity_Activity::append_comments( $activities, $r['spam'] );
+				$activities = BP_Activity_Activity::append_reactions( $activities, $r['spam'] );
 			}
 
 			// Pre-fetch data associated with activity users and other objects.
@@ -1594,10 +1594,242 @@ class BP_Activity_Activity {
 		return true;
 	}
 
+	public static function build_assoc_array_and_calcultate_depth( $descendants ) {
+		$comments = array();
+		$ref      = array();
+
+		// Loop descendants and build an assoc array.
+		foreach ( (array) $descendants as $d ) {
+			$d->children = array();
+
+			// If we have a reference on the parent.
+			if ( isset( $ref[ $d->secondary_item_id ] ) ) {
+				$ref[ $d->secondary_item_id ]->children[ $d->id ] = $d;
+				$ref[ $d->id ] =& $ref[ $d->secondary_item_id ]->children[ $d->id ];
+
+				// If we don't have a reference on the parent, put in the root level.
+			} else {
+				$comments[ $d->id ] = $d;
+				$ref[ $d->id ] =& $comments[ $d->id ];
+			}
+		}
+
+		// Calculate depth for each item.
+		foreach ( $ref as &$r ) {
+			$depth = 1;
+			$parent_id = $r->secondary_item_id;
+
+			while ( $parent_id !== $r->item_id ) {
+				$depth++;
+
+				// When display_comments=stream, the parent comment may not be part of the
+				// returned results, so we manually fetch it.
+				if ( empty( $ref[ $parent_id ] ) ) {
+					$direct_parent = new BP_Activity_Activity( $parent_id );
+					if ( isset( $direct_parent->secondary_item_id ) ) {
+						// If the direct parent is not an activity update, that means we've reached
+						// the parent activity item (eg. new_blog_post).
+						if ( 'activity_update' !== $direct_parent->type ) {
+							$parent_id = $r->item_id;
+
+						} else {
+							$parent_id = $direct_parent->secondary_item_id;
+						}
+
+					} else {
+						// Something went wrong.  Short-circuit the depth calculation.
+						$parent_id = $r->item_id;
+					}
+				} else {
+					$parent_id = $ref[ $parent_id ]->secondary_item_id;
+				}
+			}
+			$r->depth = $depth;
+		}
+
+		return $comments;
+	}
+
+	public static function get_activity_reactions( $args = array() ) {
+		$r = bp_parse_args(
+			$args,
+			array(
+				'activity_id'         => 0,
+				'mptt_left'           => 0,
+				'mptt_right'          => 0,
+				'spam'                => 'ham_only',
+				'top_level_parent_id' => 0,
+			)
+		);
+
+		$activity_id     = (int) $r['activity_id'];
+		$comments_cache  = wp_cache_get( $activity_id, 'bp_activity_comments' );
+		$reactions_cache = wp_cache_get( $activity_id, 'bp_activity_reactions' );
+		$retval          =  array(
+			'comments'  => array(),
+			'reactions' => array(),
+		);
+
+		// We store the string 'none' to cache the fact that the
+		// activity item has no comments.
+		if ( 'none' === $comments_cache && 'none' === $reactions_cache ) {
+			return $retval;
+		}
+
+		$wpdb = null;
+		if ( empty( $GLOBALS['wpdb'] ) ) {
+			return array();
+		}
+
+		$wpdb           = $GLOBALS['wpdb'];
+		$reaction_types = bp_get_activity_types_for_role( 'reaction' );
+
+		if ( ! empty( $comments_cache ) && 'none' !== $comments_cache ) {
+			$retval['comments'] = (array) $comments_cache;
+
+			if ( 'none' === $reactions_cache ) {
+				$retval['reactions'] = array();
+				$reaction_types      = array();
+			} else {
+				$reaction_types = array_diff( $reaction_types, array( 'activity_comments' ) );
+			}
+		}
+
+		if ( ! $reaction_types ) {
+			return $retval;
+		}
+
+		if ( ! empty( $reactions_cache ) && 'none' !== $reactions_cache ) {
+			$retval['reactions'] = (array) $reactions_cache;
+
+			if ( 'none' === $comments_cache ) {
+				$retval['comments'] = array();
+				$reaction_types     = array();
+			} else {
+				$reaction_types = array( 'activity_comments' );
+			}
+		}
+
+		if ( ! $reaction_types ) {
+			return $retval;
+		}
+
+		if ( empty( $r['top_level_parent_id'] ) ) {
+			$r['top_level_parent_id'] = $activity_id;
+		}
+
+		// Don't retrieve activity comments marked as spam.
+		if ( 'ham_only' == $r['spam'] ) {
+			$spam_sql = 'AND a.is_spam = 0';
+		} elseif ( 'spam_only' == $r['spam'] ) {
+			$spam_sql = 'AND a.is_spam = 1';
+		} else {
+			$spam_sql = '';
+		}
+
+		// Only include reaction types.
+		$in  = "'" . implode( "', '", esc_sql( $reaction_types ) ) . "'";
+		$bp  = buddypress();
+		$sql = $wpdb->prepare(
+			"SELECT id FROM {$bp->activity->table_name} a WHERE a.type IN ({$in}) {$spam_sql} AND a.item_id = %d AND a.mptt_left > %d AND a.mptt_left < %d ORDER BY a.date_recorded ASC",
+			$r['top_level_parent_id'],
+			$r['mptt_left'],
+			$r['mptt_right']
+		);
+
+		$reaction_ids = $wpdb->get_col( $sql );
+		$reactions    = self::get_activity_data( $reaction_ids );
+		$reactions    = self::append_user_fullnames( $reactions );
+		$reactions    = self::generate_action_strings( $reactions );
+
+		if ( ! $retval['comments'] ) {
+			$comments = wp_list_filter( $reactions, array( 'type' => 'activity_comment' ) );
+
+			if ( ! $comments ) {
+				$comments_cache_value = 'none';
+			} else {
+				$comments             = self::build_assoc_array_and_calcultate_depth( $comments );
+				$comments_cache_value = $comments;
+			}
+
+			wp_cache_set( $activity_id, $comments_cache_value, 'bp_activity_comments' );
+
+			$retval['comments'] = $comments;
+		}
+
+		if ( ! $retval['reactions'] ) {
+			$reactions = wp_list_filter( $reactions, array( 'type' => 'activity_comment' ), 'NOT' );
+
+			if ( ! $reactions ) {
+				$reactions_cache_value = 'none';
+			} else {
+				$reactions_cache_value = $reactions;
+			}
+
+			wp_cache_set( $activity_id, $reactions_cache_value, 'bp_activity_reactions' );
+
+			$retval['reactions'] = $reactions;
+		}
+
+		// Return comments & reactions.
+		return $retval;
+	}
+
+	public static function append_reactions( $activities, $spam = 'ham_only' ) {
+		$activity_reactions = array();
+
+		// Now fetch the activity reactions and parse them into the correct position in the activities array.
+		foreach ( (array) $activities as $activity ) {
+			$top_level_parent_id = 0;
+
+			if ( in_array( $activity->type, bp_get_activity_types_for_role( 'reaction' ), true ) ) {
+				$top_level_parent_id = $activity->item_id;
+			}
+
+			$args = array(
+				'activity_id'         => $activity->id,
+				'mptt_left'           => $activity->mptt_left,
+				'mptt_right'          => $activity->mptt_right,
+				'spam'                => $spam,
+				'top_level_parent_id' => $top_level_parent_id,
+			);
+
+			$function_args = array_values( $args );
+
+			/**
+			 * Filters if BuddyPress should use the legacy activity query.
+			 *
+			 * @since 2.0.0
+			 *
+			 * @param bool                 $value     Whether or not to use the legacy query.
+			 * @param BP_Activity_Activity $value     Magic method referring to currently called method.
+			 * @param array                $func_args Array of the method's argument list.
+			 */
+			if ( 'activity_comment' === $activity->type && apply_filters( 'bp_use_legacy_activity_query', false, 'BP_Activity_Activity::get_activity_comments', $function_args ) ) {
+				list( $activity_id, $left, $right, $spam, $top_level_parent_id ) = $function_args;
+				$activity_reactions[ $activity->id ] = BP_Activity_Activity::get_activity_comments( $activity_id, $left, $right, $spam, $top_level_parent_id );
+
+			} else {
+				$activity_reactions[ $activity->id ] = BP_Activity_Activity::get_activity_reactions( $args );
+			}
+		}
+
+		// Merge the reactions with the activity items.
+		foreach ( (array) $activities as $key => $activity ) {
+			if ( isset( $activity_reactions[$activity->id] ) ) {
+				$activities[ $key ]->children  = $activity_reactions[ $activity->id ]['comments'];
+				$activities[ $key ]->reactions = $activity_reactions[ $activity->id ]['reactions'];
+			}
+		}
+
+		return $activities;
+	}
+
 	/**
 	 * Append activity comments to their associated activity items.
 	 *
 	 * @since 1.2.0
+	 * @deprecated 14.0.0
 	 *
 	 * @global wpdb $wpdb WordPress database object.
 	 *
@@ -1606,26 +1838,15 @@ class BP_Activity_Activity {
 	 * @return array The updated activities with nested comments.
 	 */
 	public static function append_comments( $activities, $spam = 'ham_only' ) {
-		$activity_comments = array();
+		_deprecated_function( __METHOD__, '14.0.0' );
 
-		// Now fetch the activity comments and parse them into the correct position in the activities array.
-		foreach ( (array) $activities as $activity ) {
-			$top_level_parent_id = 'activity_comment' == $activity->type ? $activity->item_id : 0;
-			$activity_comments[$activity->id] = BP_Activity_Activity::get_activity_comments( $activity->id, $activity->mptt_left, $activity->mptt_right, $spam, $top_level_parent_id );
-		}
-
-		// Merge the comments with the activity items.
-		foreach ( (array) $activities as $key => $activity ) {
-			if ( isset( $activity_comments[$activity->id] ) ) {
-				$activities[$key]->children = $activity_comments[$activity->id];
-			}
-		}
-
-		return $activities;
+		return self::append_reactions( $activities, $spam );
 	}
 
 	/**
 	 * Get activity comments that are associated with a specific activity ID.
+	 *
+	 * Legacy query - not recommended.
 	 *
 	 * @since 1.2.0
 	 *
@@ -1640,8 +1861,6 @@ class BP_Activity_Activity {
 	 */
 	public static function get_activity_comments( $activity_id, $left, $right, $spam = 'ham_only', $top_level_parent_id = 0 ) {
 		global $wpdb;
-
-		$function_args = func_get_args();
 
 		if ( empty( $top_level_parent_id ) ) {
 			$top_level_parent_id = $activity_id;
@@ -1680,95 +1899,22 @@ class BP_Activity_Activity {
 				$spam_sql = '';
 			}
 
-			// Legacy query - not recommended.
-
 			/**
-			 * Filters if BuddyPress should use the legacy activity query.
+			 * Filters the MySQL prepared statement for the legacy activity query.
 			 *
-			 * @since 2.0.0
+			 * @since 1.5.0
 			 *
-			 * @param bool                 $value     Whether or not to use the legacy query.
-			 * @param BP_Activity_Activity $value     Magic method referring to currently called method.
-			 * @param array                $func_args Array of the method's argument list.
+			 * @param string $value       Prepared statement for the activity query.
+			 * @param int    $activity_id Activity ID to fetch comments for.
+			 * @param int    $left        Left-most node boundary.
+			 * @param int    $right       Right-most node boundary.
+			 * @param string $spam_sql    SQL Statement portion to differentiate between ham or spam.
 			 */
-			if ( apply_filters( 'bp_use_legacy_activity_query', false, __METHOD__, $function_args ) ) {
+			$sql = apply_filters( 'bp_activity_comments_user_join_filter', $wpdb->prepare( "SELECT a.*, u.user_email, u.user_nicename, u.user_login, u.display_name{$fullname_select} FROM {$bp->activity->table_name} a, {$wpdb->users} u{$fullname_from} WHERE u.ID = a.user_id {$fullname_where} AND a.type = 'activity_comment' {$spam_sql} AND a.item_id = %d AND a.mptt_left > %d AND a.mptt_left < %d ORDER BY a.date_recorded ASC", $top_level_parent_id, $left, $right ), $activity_id, $left, $right, $spam_sql );
 
-				/**
-				 * Filters the MySQL prepared statement for the legacy activity query.
-				 *
-				 * @since 1.5.0
-				 *
-				 * @param string $value       Prepared statement for the activity query.
-				 * @param int    $activity_id Activity ID to fetch comments for.
-				 * @param int    $left        Left-most node boundary.
-				 * @param int    $right       Right-most node boundary.
-				 * @param string $spam_sql    SQL Statement portion to differentiate between ham or spam.
-				 */
-				$sql = apply_filters( 'bp_activity_comments_user_join_filter', $wpdb->prepare( "SELECT a.*, u.user_email, u.user_nicename, u.user_login, u.display_name{$fullname_select} FROM {$bp->activity->table_name} a, {$wpdb->users} u{$fullname_from} WHERE u.ID = a.user_id {$fullname_where} AND a.type = 'activity_comment' {$spam_sql} AND a.item_id = %d AND a.mptt_left > %d AND a.mptt_left < %d ORDER BY a.date_recorded ASC", $top_level_parent_id, $left, $right ), $activity_id, $left, $right, $spam_sql );
+			$descendants = $wpdb->get_results( $sql );
 
-				$descendants = $wpdb->get_results( $sql );
-
-				// We use the mptt BETWEEN clause to limit returned
-				// descendants to the correct part of the tree.
-			} else {
-				$sql = $wpdb->prepare( "SELECT id FROM {$bp->activity->table_name} a WHERE a.type = 'activity_comment' {$spam_sql} AND a.item_id = %d and a.mptt_left > %d AND a.mptt_left < %d ORDER BY a.date_recorded ASC", $top_level_parent_id, $left, $right );
-
-				$descendant_ids = $wpdb->get_col( $sql );
-				$descendants    = self::get_activity_data( $descendant_ids );
-				$descendants    = self::append_user_fullnames( $descendants );
-				$descendants    = self::generate_action_strings( $descendants );
-			}
-
-			$ref = array();
-
-			// Loop descendants and build an assoc array.
-			foreach ( (array) $descendants as $d ) {
-				$d->children = array();
-
-				// If we have a reference on the parent.
-				if ( isset( $ref[ $d->secondary_item_id ] ) ) {
-					$ref[ $d->secondary_item_id ]->children[ $d->id ] = $d;
-					$ref[ $d->id ] =& $ref[ $d->secondary_item_id ]->children[ $d->id ];
-
-					// If we don't have a reference on the parent, put in the root level.
-				} else {
-					$comments[ $d->id ] = $d;
-					$ref[ $d->id ] =& $comments[ $d->id ];
-				}
-			}
-
-			// Calculate depth for each item.
-			foreach ( $ref as &$r ) {
-				$depth = 1;
-				$parent_id = $r->secondary_item_id;
-
-				while ( $parent_id !== $r->item_id ) {
-					$depth++;
-
-					// When display_comments=stream, the parent comment may not be part of the
-					// returned results, so we manually fetch it.
-					if ( empty( $ref[ $parent_id ] ) ) {
-						$direct_parent = new BP_Activity_Activity( $parent_id );
-						if ( isset( $direct_parent->secondary_item_id ) ) {
-							// If the direct parent is not an activity update, that means we've reached
-							// the parent activity item (eg. new_blog_post).
-							if ( 'activity_update' !== $direct_parent->type ) {
-								$parent_id = $r->item_id;
-
-							} else {
-								$parent_id = $direct_parent->secondary_item_id;
-							}
-
-						} else {
-							// Something went wrong.  Short-circuit the depth calculation.
-							$parent_id = $r->item_id;
-						}
-					} else {
-						$parent_id = $ref[ $parent_id ]->secondary_item_id;
-					}
-				}
-				$r->depth = $depth;
-			}
+			$comments = self::build_assoc_array_and_calcultate_depth( $descendants );
 
 			// If we cache an empty array, it'll count as a cache
 			// miss the next time the activity comments are fetched.

--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -474,11 +474,14 @@ class BP_Activity_Component extends BP_Component {
 	public function setup_cache_groups() {
 
 		// Global groups.
-		wp_cache_add_global_groups( array(
-			'bp_activity',
-			'bp_activity_comments',
-			'activity_meta'
-		) );
+		wp_cache_add_global_groups(
+			array(
+				'bp_activity',
+				'bp_activity_comments',
+				'bp_activity_reactions',
+				'activity_meta'
+			)
+		);
 
 		parent::setup_cache_groups();
 	}

--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -23,7 +23,7 @@ class BP_Activity_Component extends BP_Component {
 	 * Types.
 	 *
 	 * @since 14.0.0
-	 * @var array $types
+	 * @var array
 	 */
 	public $types = array();
 

--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -19,6 +19,13 @@ defined( 'ABSPATH' ) || exit;
  */
 #[AllowDynamicProperties]
 class BP_Activity_Component extends BP_Component {
+	/**
+	 * Types.
+	 *
+	 * @since 14.0.0
+	 * @var array $types
+	 */
+	public $types = array();
 
 	/**
 	 * Start the activity component setup process.

--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -126,7 +126,7 @@ class BP_Activity_Component extends BP_Component {
 		if ( bp_is_current_component( 'activity' ) ) {
 			// Authenticated actions - Only fires when JS is disabled.
 			if ( is_user_logged_in() &&
-				in_array( bp_current_action(), array( 'delete', 'spam', 'post', 'reply', 'favorite', 'unfavorite', 'like' ), true )
+				in_array( bp_current_action(), array( 'delete', 'spam', 'post', 'reply', 'favorite', 'unfavorite', 'like', 'dislike' ), true )
 			) {
 				require_once $this->path . 'bp-activity/actions/' . bp_current_action() . '.php';
 			}
@@ -490,7 +490,7 @@ class BP_Activity_Component extends BP_Component {
 				'bp_activity',
 				'bp_activity_comments',
 				'bp_activity_reactions',
-				'bp_activity_user_likes',
+				'bp_activity_user_reactions',
 				'activity_meta',
 			)
 		);

--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -126,7 +126,7 @@ class BP_Activity_Component extends BP_Component {
 		if ( bp_is_current_component( 'activity' ) ) {
 			// Authenticated actions - Only fires when JS is disabled.
 			if ( is_user_logged_in() &&
-				in_array( bp_current_action(), array( 'delete', 'spam', 'post', 'reply', 'favorite', 'unfavorite' ), true )
+				in_array( bp_current_action(), array( 'delete', 'spam', 'post', 'reply', 'favorite', 'unfavorite', 'like' ), true )
 			) {
 				require_once $this->path . 'bp-activity/actions/' . bp_current_action() . '.php';
 			}
@@ -153,6 +153,7 @@ class BP_Activity_Component extends BP_Component {
 			 * As a result, we need to map filenames with slugs.
 			 */
 			$filenames = array(
+				'likes'     => 'likes',
 				'favorites' => 'favorites',
 				'mentions'  => 'mentions',
 			);
@@ -285,6 +286,17 @@ class BP_Activity_Component extends BP_Component {
 			'position'        => 20,
 			'item_css_id'     => 'activity-mentions',
 			'generate'        => bp_activity_do_mentions(),
+		);
+
+		// Liked activity items.
+		$sub_nav[] = array(
+			'name'            => _x( 'Likes', 'Profile activity screen sub nav', 'buddypress' ),
+			'slug'            => 'likes',
+			'parent_slug'     => $slug,
+			'screen_function' => 'bp_activity_screen_likes',
+			'position'        => 30,
+			'item_css_id'     => 'activity-likes',
+			'generate'        => bp_activity_supports_likes(),
 		);
 
 		// Favorite activity items.

--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -398,6 +398,17 @@ class BP_Activity_Component extends BP_Component {
 				);
 			}
 
+			// Activity likes.
+			if ( bp_activity_supports_likes() ) {
+				$wp_admin_nav[] = array(
+					'parent'   => 'my-account-' . $this->id,
+					'id'       => 'my-account-' . $this->id . '-likes',
+					'title'    => _x( 'Likes', 'My Account Activity sub nav', 'buddypress' ),
+					'href'     => bp_loggedin_user_url( bp_members_get_path_chunks( array( $activity_slug, 'likes' ) ) ),
+					'position' => 30,
+				);
+			}
+
 			// Favorite activity items.
 			if ( bp_activity_can_favorite() ) {
 				$wp_admin_nav[] = array(
@@ -479,7 +490,8 @@ class BP_Activity_Component extends BP_Component {
 				'bp_activity',
 				'bp_activity_comments',
 				'bp_activity_reactions',
-				'activity_meta'
+				'bp_activity_user_likes',
+				'activity_meta',
 			)
 		);
 

--- a/src/bp-activity/classes/class-bp-activity-type.php
+++ b/src/bp-activity/classes/class-bp-activity-type.php
@@ -167,17 +167,47 @@ final class BP_Activity_Type {
 			$this->description = sprintf( esc_html__( 'No description provided for the %s activity type.', 'buddypress' ), esc_html( $this->name ) );
 		}
 
-		$front_filter = ucfirst( $this->name );
+		$singular_name = ucfirst( $this->name );
+		if ( $r['labels'] && isset( $r['labels']['singular_name'] ) && $r['labels']['singular_name'] ) {
+			$singular_name = esc_html( $r['labels']['singular_name'] );
+		}
+		$this->labels->singular_name = $singular_name;
+
+		$plural_name = ucfirst( $this->name );
+		if ( $r['labels'] && isset( $r['labels']['plural_name'] ) && $r['labels']['plural_name'] ) {
+			$plural_name = esc_html( $r['labels']['plural_name'] );
+		}
+		$this->labels->plural_name = $plural_name;
+
+		$front_filter = $singular_name;
 		if ( $r['labels'] && isset( $r['labels']['front_filter'] ) && $r['labels']['front_filter'] ) {
 			$front_filter = esc_html( $r['labels']['front_filter'] );
 		}
 		$this->labels->front_filter = $front_filter;
 
 		$admin_filter = $front_filter;
-		if (  $r['labels'] && isset( $r['labels']['admin_filter'] ) && $r['labels']['admin_filter'] ) {
+		if ( $r['labels'] && isset( $r['labels']['admin_filter'] ) && $r['labels']['admin_filter'] ) {
 			$admin_filter = esc_html( $r['labels']['admin_filter'] );
 		}
 		$this->labels->admin_filter = $admin_filter;
+
+		$doing_action = sprintf(
+			__( 'adding the activity type: %s', 'buddypress' ),
+			esc_html( $singular_name )
+		);
+		if ( $r['labels'] && isset( $r['labels']['doing_action'] ) && $r['labels']['doing_action'] ) {
+			$doing_action = esc_html( $r['labels']['doing_action'] );
+		}
+		$this->labels->doing_action = $doing_action;
+
+		$did_action = sprintf(
+			__( 'added the activity type: %s', 'buddypress' ),
+			esc_html( $singular_name )
+		);
+		if ( $r['labels'] && isset( $r['labels']['did_action'] ) && $r['labels']['did_action'] ) {
+			$did_action = esc_html( $r['labels']['did_action'] );
+		}
+		$this->labels->did_action = $did_action;
 
 		if ( $r['format_callback'] && is_callable( $r['format_callback'] ) ) {
 			$this->format_callback = $r['format_callback'];

--- a/src/bp-activity/classes/class-bp-activity-type.php
+++ b/src/bp-activity/classes/class-bp-activity-type.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Activity API: BP_Activity_Type class
+ *
+ * @package BuddyPress
+ * @subpackage Activity
+ * @since 14.0.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Activity class used for interacting with activity types.
+ *
+ * @since 14.0.0
+ *
+ * @see bp_register_activity_type()
+ */
+final class BP_Activity_Type {
+	/**
+	 * Activity type key.
+	 *
+	 * @since 14.0.0
+	 * @var string $name
+	 */
+	public $name;
+
+	/**
+	 * Activity type components.
+	 *
+	 * @since 14.0.0
+	 * @var string[] $components
+	 */
+	public $components;
+
+	/**
+	 * The role of the activity type.
+	 *
+	 * One of 'content', 'log', 'reaction'.
+	 *
+	 * @since 14.0.0
+	 * @var string $role
+	 */
+	public $role;
+
+	/**
+	 * Activity type description.
+	 *
+	 * @since 14.0.0
+	 * @var string $name
+	 */
+	public $description;
+
+	/**
+	 * Labels object for this activity type.
+	 *
+	 * @since 14.0.0
+	 * @var stdClass $labels
+	 */
+	public $labels;
+
+	/**
+	 * Activity action fomatting callback.
+	 *
+	 * @since 14.0.0
+	 * @var string $format_callback
+	 */
+	public $format_callback;
+
+	/**
+	 * Activity type streams.
+	 *
+	 * Possible lists may include 'activity', 'member', 'member_groups', 'group'.
+	 *
+	 * @since 14.0.0
+	 * @var string[] $streams
+	 */
+	public $streams;
+
+	/**
+	 * Activity action position when listed in filter dropdowns.
+	 *
+	 * @since 14.0.0
+	 * @var integer $position
+	 */
+	public $position;
+
+	/**
+	 * Supports object for this activity type.
+	 *
+	 * @since 14.0.0
+	 * @var stdClass $supports
+	 */
+	public $supports;
+
+	/**
+	 * Constructor.
+	 *
+	 * See the bp_register_activity_type() function for accepted arguments for `$args`.
+	 *
+	 * Will populate object properties from the provided arguments and assign other
+	 * default properties based on that information.
+	 *
+	 * @since 14.0.0
+	 *
+	 * @see bp_register_activity_type()
+	 *
+	 * @param string $type Post type key.
+	 * @param array  $args Optional. Array or string of arguments for registering an activity type.
+	 *               See bp_register_activity_type() for information on accepted arguments.
+	 *               Default empty array.
+	 */
+	public function __construct( $type, $args = array() ) {
+		$this->name = $type;
+
+		$this->set_props( $args );
+	}
+
+	/**
+	 * Sets activity type properties.
+	 *
+	 * See the bp_register_activity_type() function for accepted arguments for `$args`.
+	 *
+	 * @since 14.0.0
+	 *
+	 * @param array|string $args Array or string of arguments for registering an activity type.
+	 */
+	public function set_props( $args ) {
+		$default_prop   = array( 'activity' );
+		$roles          = array( 'content', 'log', 'reaction' );
+		$this->labels   = new stdClass();
+		$this->supports = new stdClass();
+
+		$r = bp_parse_args(
+			$args,
+			array(
+				'components'      => $default_prop,
+				'role'            => 'content',
+				'description'     => '',
+				'labels'          => array(),
+				'format_callback' => '',
+				'streams'         => $default_prop,
+				'position'        => 0,
+				'supports'        => array(),
+			),
+			'activity_type_props'
+		);
+
+		if ( $r['components'] && is_array( $r['components'] ) ) {
+			$this->components = array_map( 'sanitize_key', $r['components'] );
+		} else {
+			$this->components = $default_prop;
+		}
+
+		if ( $r['role'] && in_array( $r['role'], $roles, true ) ) {
+			$this->role = $r['role'];
+		} else {
+			$this->role = 'content';
+		}
+
+		if ( $r['description'] ) {
+			$this->description = esc_html( $r['description'] );
+		} else {
+			$this->description = sprintf( esc_html__( 'No description provided for the %s activity type.', 'buddypress' ), esc_html( $this->name ) );
+		}
+
+		$front_filter = ucfirst( $this->name );
+		if ( $r['labels'] && isset( $r['labels']['front_filter'] ) && $r['labels']['front_filter'] ) {
+			$front_filter = esc_html( $r['labels']['front_filter'] );
+		}
+		$this->labels->front_filter = $front_filter;
+
+		$admin_filter = $front_filter;
+		if (  $r['labels'] && isset( $r['labels']['admin_filter'] ) && $r['labels']['admin_filter'] ) {
+			$admin_filter = esc_html( $r['labels']['admin_filter'] );
+		}
+		$this->labels->admin_filter = $admin_filter;
+
+		if ( $r['format_callback'] && is_callable( $r['format_callback'] ) ) {
+			$this->format_callback = $r['format_callback'];
+		} else {
+			$this->format_callback = '';
+		}
+
+		if ( $r['streams'] && is_array( $r['streams'] ) ) {
+			$this->streams = array_map( 'sanitize_key', $r['streams'] );
+		} else {
+			$this->streams = $default_prop;
+		}
+
+		$this->position = (int) $r['position'];
+
+		if ( $r['supports'] && is_array( $r['supports'] ) ) {
+			foreach ( $r['supports'] as $key_feature => $feature_args ) {
+				if ( is_numeric( $key_feature ) ) {
+					$feature = sanitize_key( $feature_args );
+					$args    = true;
+				} else {
+					$feature = sanitize_key( $key_feature );
+					$args    = (array) $feature_args;
+				}
+
+				$this->add_support( $feature, $args );
+			}
+		}
+	}
+
+	/**
+	 * Sets the features support for the post type.
+	 *
+	 * @since 14.0.0
+	 *
+	 * @param string     $feature The name key for the feature.
+	 * @param bool|array $args    True or an array of properties.
+	 */
+	public function add_support( $feature, $args ) {
+		$this->supports->{$feature} = $args;
+	}
+
+	/**
+	 * Sets the features support for the post type.
+	 *
+	 * @since 14.0.0
+	 *
+	 * @param string $feature The name key for the feature.
+	 */
+	public function remove_support( $feature ) {
+		unset( $this->supports->{$feature} );
+	}
+}

--- a/src/bp-activity/classes/class-bp-activity-type.php
+++ b/src/bp-activity/classes/class-bp-activity-type.php
@@ -81,14 +81,6 @@ final class BP_Activity_Type {
 	public $format_callback;
 
 	/**
-	 * Activity primary link callback.
-	 *
-	 * @since 14.0.0
-	 * @var string $primary_link_callback
-	 */
-	public $primary_link_callback;
-
-	/**
 	 * Activity type streams.
 	 *
 	 * Possible lists may include 'activity', 'member', 'member_groups', 'group'.
@@ -161,7 +153,6 @@ final class BP_Activity_Type {
 				'description'           => '',
 				'labels'                => array(),
 				'format_callback'       => '',
-				'primary_link_callback' => '',
 				'streams'               => $default_prop,
 				'position'              => 0,
 				'supports'              => array(),
@@ -219,8 +210,17 @@ final class BP_Activity_Type {
 		}
 		$this->labels->admin_filter = $admin_filter;
 
+		$do_action = sprintf(
+			__( 'add the %s activity type', 'buddypress' ),
+			esc_html( $singular_name )
+		);
+		if ( $r['labels'] && isset( $r['labels']['do_action'] ) && $r['labels']['do_action'] ) {
+			$do_action = esc_html( $r['labels']['do_action'] );
+		}
+		$this->labels->do_action = $do_action;
+
 		$doing_action = sprintf(
-			__( 'adding the activity type: %s', 'buddypress' ),
+			__( 'adding the %s activity type', 'buddypress' ),
 			esc_html( $singular_name )
 		);
 		if ( $r['labels'] && isset( $r['labels']['doing_action'] ) && $r['labels']['doing_action'] ) {
@@ -229,7 +229,7 @@ final class BP_Activity_Type {
 		$this->labels->doing_action = $doing_action;
 
 		$did_action = sprintf(
-			__( 'added the activity type: %s', 'buddypress' ),
+			__( 'added the %s activity type', 'buddypress' ),
 			esc_html( $singular_name )
 		);
 		if ( $r['labels'] && isset( $r['labels']['did_action'] ) && $r['labels']['did_action'] ) {
@@ -237,16 +237,37 @@ final class BP_Activity_Type {
 		}
 		$this->labels->did_action = $did_action;
 
+		$undo_action = sprintf(
+			__( 'remove the %s activity type', 'buddypress' ),
+			esc_html( $singular_name )
+		);
+		if ( $r['labels'] && isset( $r['labels']['undo_action'] ) && $r['labels']['undo_action'] ) {
+			$undo_action = esc_html( $r['labels']['undo_action'] );
+		}
+		$this->labels->undo_action = $undo_action;
+
+		$undoing_action = sprintf(
+			__( 'removing the %s activity type.', 'buddypress' ),
+			esc_html( $singular_name )
+		);
+		if ( $r['labels'] && isset( $r['labels']['undoing_action'] ) && $r['labels']['undoing_action'] ) {
+			$undoing_action = esc_html( $r['labels']['undoing_action'] );
+		}
+		$this->labels->undoing_action = $undoing_action;
+
+		$undid_action = sprintf(
+			__( 'removed the %s activity type', 'buddypress' ),
+			esc_html( $singular_name )
+		);
+		if ( $r['labels'] && isset( $r['labels']['undid_action'] ) && $r['labels']['undid_action'] ) {
+			$undid_action = esc_html( $r['labels']['undid_action'] );
+		}
+		$this->labels->undid_action = $undid_action;
+
 		if ( $r['format_callback'] && is_callable( $r['format_callback'] ) ) {
 			$this->format_callback = $r['format_callback'];
 		} else {
 			$this->format_callback = '';
-		}
-
-		if ( $r['primary_link_callback'] && is_callable( $r['primary_link_callback'] ) ) {
-			$this->primary_link_callback = $r['primary_link_callback'];
-		} else {
-			$this->primary_link_callback = '';
 		}
 
 		if ( $r['streams'] && is_array( $r['streams'] ) ) {

--- a/src/bp-activity/classes/class-bp-activity-type.php
+++ b/src/bp-activity/classes/class-bp-activity-type.php
@@ -47,6 +47,16 @@ final class BP_Activity_Type {
 	public $role;
 
 	/**
+	 * The name of the activity feature.
+	 *
+	 * Eg: 'comments', 'likes', etc.
+	 *
+	 * @since 14.0.0
+	 * @var string $feature_name
+	 */
+	public $feature_name;
+
+	/**
 	 * Activity type description.
 	 *
 	 * @since 14.0.0
@@ -147,6 +157,7 @@ final class BP_Activity_Type {
 			array(
 				'components'            => $default_prop,
 				'role'                  => 'content',
+				'feature_name'          => '',
 				'description'           => '',
 				'labels'                => array(),
 				'format_callback'       => '',
@@ -168,6 +179,14 @@ final class BP_Activity_Type {
 			$this->role = $r['role'];
 		} else {
 			$this->role = 'content';
+		}
+
+		if ( 'reaction' === $this->role ) {
+			if ( ! $r['feature_name'] ) {
+				_doing_it_wrong( 'feature_name', __( 'The `feature_name` property of this Activity type (having a reaction role) is required.', 'buddypress' ), 'BuddyPress 14.0.0' );
+			} else {
+				$this->feature_name = sanitize_key( $r['feature_name'] );
+			}
 		}
 
 		if ( $r['description'] ) {

--- a/src/bp-activity/classes/class-bp-activity-type.php
+++ b/src/bp-activity/classes/class-bp-activity-type.php
@@ -71,6 +71,14 @@ final class BP_Activity_Type {
 	public $format_callback;
 
 	/**
+	 * Activity primary link callback.
+	 *
+	 * @since 14.0.0
+	 * @var string $primary_link_callback
+	 */
+	public $primary_link_callback;
+
+	/**
 	 * Activity type streams.
 	 *
 	 * Possible lists may include 'activity', 'member', 'member_groups', 'group'.
@@ -137,14 +145,15 @@ final class BP_Activity_Type {
 		$r = bp_parse_args(
 			$args,
 			array(
-				'components'      => $default_prop,
-				'role'            => 'content',
-				'description'     => '',
-				'labels'          => array(),
-				'format_callback' => '',
-				'streams'         => $default_prop,
-				'position'        => 0,
-				'supports'        => array(),
+				'components'            => $default_prop,
+				'role'                  => 'content',
+				'description'           => '',
+				'labels'                => array(),
+				'format_callback'       => '',
+				'primary_link_callback' => '',
+				'streams'               => $default_prop,
+				'position'              => 0,
+				'supports'              => array(),
 			),
 			'activity_type_props'
 		);
@@ -213,6 +222,12 @@ final class BP_Activity_Type {
 			$this->format_callback = $r['format_callback'];
 		} else {
 			$this->format_callback = '';
+		}
+
+		if ( $r['primary_link_callback'] && is_callable( $r['primary_link_callback'] ) ) {
+			$this->primary_link_callback = $r['primary_link_callback'];
+		} else {
+			$this->primary_link_callback = '';
 		}
 
 		if ( $r['streams'] && is_array( $r['streams'] ) ) {

--- a/src/bp-activity/screens/likes.php
+++ b/src/bp-activity/screens/likes.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Activity: User's "Activity > Likes" screen handler
+ *
+ * @package BuddyPress
+ * @subpackage ActivityScreens
+ * @since 14.0.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Load the 'Likes' activity page.
+ *
+ * @since 14.0.0
+ */
+function bp_activity_screen_likes() {
+	bp_update_is_item_admin( bp_current_user_can( 'bp_moderate' ), 'activity' );
+
+	/**
+	 * Fires right before the loading of the "Likes" screen template file.
+	 *
+	 * @since 14.0.0
+	 */
+	do_action( 'bp_activity_screen_likes' );
+
+	/**
+	 * Filters the template to load for the "Likes" screen.
+	 *
+	 * @since 14.0.0
+	 *
+	 * @param string $template Path to the activity template to load.
+	 */
+	bp_core_load_template( apply_filters( 'bp_activity_template_activity_likes', 'members/single/home' ) );
+}

--- a/src/bp-templates/bp-nouveau/includes/activity/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/template-tags.php
@@ -441,6 +441,25 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 		}
 
 		if ( bp_activity_type_supports( $activity_type, 'likes' ) ) {
+
+			if ( bp_activity_is_liked() ) {
+				$like_props = array(
+					'action'  => 'remove',
+					'id'      => 'alike-dislike-' . $activity_id,
+					'class'   => 'alike-remove',
+					'tooltip' => _x( 'Dislike', 'button', 'buddypress' ),
+					'text'    => _x( 'Liked', 'link', 'buddypress' ),
+				);
+			} else {
+				$like_props = array(
+					'action'  => 'add',
+					'id'      => 'alike-like-' . $activity_id,
+					'class'   => 'alike-add',
+					'tooltip' => _x( 'Like', 'button', 'buddypress' ),
+					'text'    => _x( 'Like', 'link', 'buddypress' ),
+				);
+			}
+
 			$buttons['activity_like'] =  array(
 				'id'                => 'activity_like',
 				'position'          => 20,
@@ -450,23 +469,23 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 				'must_be_logged_in' => true,
 				'button_element'    => $button_element,
 				'button_attr'       => array(
-					'id'              => 'alike-like-' . $activity_id,
-					'class'           => 'button alike-add bp-primary-action bp-tooltip',
-					'data-bp-tooltip' => _x( 'Like', 'button', 'buddypress' ),
+					'id'              => $like_props['id'],
+					'class'           => sprintf( 'button %s bp-primary-action bp-tooltip', $like_props['class'] ),
+					'data-bp-tooltip' => $like_props['tooltip'],
 					'aria-expanded'   => 'false',
 				),
 				'link_text'  => sprintf(
 					'<span class="bp-screen-reader-text">%1$s</span> <span class="like-count">%2$s</span>',
-					_x( 'Like', 'link', 'buddypress' ),
+					$like_props['text'],
 					esc_html( bp_activity_get_like_count() )
 				),
 			);
 
 			// If button element set add href link to data-attr
 			if ( 'button' === $button_element ) {
-				$buttons['activity_like']['button_attr']['data-bp-url'] = bp_get_activity_like_link();
+				$buttons['activity_like']['button_attr']['data-bp-url'] = bp_get_activity_like_link( $like_props['action'] );
 			} else {
-				$buttons['activity_like']['button_attr']['href'] = bp_get_activity_like_link();
+				$buttons['activity_like']['button_attr']['href'] = bp_get_activity_like_link( $like_props['action'] );
 				$buttons['activity_like']['button_attr']['role'] = 'button';
 			}
 		}

--- a/src/bp-templates/bp-nouveau/includes/activity/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/activity/template-tags.php
@@ -440,6 +440,37 @@ function bp_nouveau_activity_entry_buttons( $args = array() ) {
 			);
 		}
 
+		if ( bp_activity_type_supports( $activity_type, 'likes' ) ) {
+			$buttons['activity_like'] =  array(
+				'id'                => 'activity_like',
+				'position'          => 20,
+				'component'         => 'activity',
+				'parent_element'    => $parent_element,
+				'parent_attr'       => $parent_attr,
+				'must_be_logged_in' => true,
+				'button_element'    => $button_element,
+				'button_attr'       => array(
+					'id'              => 'alike-like-' . $activity_id,
+					'class'           => 'button alike-add bp-primary-action bp-tooltip',
+					'data-bp-tooltip' => _x( 'Like', 'button', 'buddypress' ),
+					'aria-expanded'   => 'false',
+				),
+				'link_text'  => sprintf(
+					'<span class="bp-screen-reader-text">%1$s</span> <span class="like-count">%2$s</span>',
+					_x( 'Like', 'link', 'buddypress' ),
+					esc_html( bp_activity_get_like_count() )
+				),
+			);
+
+			// If button element set add href link to data-attr
+			if ( 'button' === $button_element ) {
+				$buttons['activity_like']['button_attr']['data-bp-url'] = bp_get_activity_like_link();
+			} else {
+				$buttons['activity_like']['button_attr']['href'] = bp_get_activity_like_link();
+				$buttons['activity_like']['button_attr']['role'] = 'button';
+			}
+		}
+
 		// The delete button is always created, and removed later on if needed.
 		$delete_args = array();
 

--- a/src/bp-templates/bp-nouveau/js/buddypress-activity.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-activity.js
@@ -816,6 +816,12 @@ window.bp = window.bp || {};
 					comment_content.prop( 'disabled', false );
 				} );
 			}
+
+			// Liking.
+			if ( target.hasClass('alike-add') ) {
+				// Stop event propagation
+				// event.preventDefault();
+			}
 		},
 
 		/**

--- a/tests/phpunit/testcases/activity/functions.php
+++ b/tests/phpunit/testcases/activity/functions.php
@@ -2045,6 +2045,7 @@ Bar!';
 
 	/**
 	 * @group bp_register_activity_type
+	 * @group activity_type
 	 */
 	public function test_bp_register_activity_type_no_args() {
 		$type = bp_register_activity_type( 'greeting' );
@@ -2057,6 +2058,7 @@ Bar!';
 
 	/**
 	 * @group bp_register_activity_type
+	 * @group activity_type
 	 * @expectedIncorrectUsage bp_register_activity_type
 	 */
 	public function test_bp_register_activity_type_empty_key() {
@@ -2067,6 +2069,7 @@ Bar!';
 
 	/**
 	 * @group bp_register_activity_type
+	 * @group activity_type
 	 */
 	public function test_bp_register_activity_type_support_numeric_keys() {
 		$type = bp_register_activity_type(
@@ -2083,8 +2086,8 @@ Bar!';
 	}
 
 	/**
-	 * @group bp_register_activity_type
 	 * @group bp_unregister_activity_type
+	 * @group activity_type
 	 */
 	public function test_bp_unregister_activity_type() {
 		bp_register_activity_type( 'greeting' );
@@ -2094,8 +2097,8 @@ Bar!';
 	}
 
 	/**
-	 * @group bp_register_activity_type
 	 * @group bp_unregister_activity_type
+	 * @group activity_type
 	 */
 	public function test_bp_unregister_activity_type_invalid() {
 		$type = bp_unregister_activity_type( 'greeting' );
@@ -2105,8 +2108,69 @@ Bar!';
 
 	/**
 	 * @group bp_get_activity_types_for_role
+	 * @group activity_type
 	 */
 	public function test_bp_get_activity_types_for_role_reaction() {
 		$this->assertTrue( in_array( 'activity_comment', bp_get_activity_types_for_role( 'reaction' ), true ) );
+	}
+
+	/**
+	 * @group bp_activity_add_reaction
+	 * @group activity_type
+	 */
+	function test_bp_activity_add_like_reaction() {
+		$u1 = self::factory()->user->create();
+		$a1 = self::factory()->activity->create(
+			array(
+				'user_id'   => $u1,
+				'component' => 'activity',
+				'type'      => 'activity_update',
+			)
+		);
+
+		$r1 = bp_activity_add_reaction(
+			array(
+				'user_id'     => $u1,
+				'activity_id' => $a1,
+			)
+		);
+
+		$this->assertTrue( ! is_wp_error( $r1 ) );
+
+		$reaction = bp_activity_get(
+			array(
+				'in'               => array( $r1 ),
+				'display_comments' => 'stream',
+			)
+		);
+
+		$activity_like = wp_list_pluck( $reaction['activities'], 'type' );
+		$this->assertEquals( 'activity_like', $activity_like[0] );
+	}
+
+	/**
+	 * @group bp_activity_add_reaction
+	 * @group activity_type
+	 */
+	function test_bp_activity_add_like_reaction_unexisting() {
+		$u1 = self::factory()->user->create();
+		$a1 = self::factory()->activity->create(
+			array(
+				'user_id'   => $u1,
+				'component' => 'activity',
+				'type'      => 'activity_update',
+			)
+		);
+
+		bp_activity_delete( array( 'id' => $a1 ) );
+
+		$r1 = bp_activity_add_reaction(
+			array(
+				'user_id'     => $u1,
+				'activity_id' => $a1,
+			)
+		);
+
+		$this->assertTrue( is_wp_error( $r1 ) );
 	}
 }

--- a/tests/phpunit/testcases/activity/functions.php
+++ b/tests/phpunit/testcases/activity/functions.php
@@ -2130,8 +2130,8 @@ Bar!';
 
 		$r1 = bp_activity_add_reaction(
 			array(
-				'user_id'     => $u1,
-				'activity_id' => $a1,
+				'user_id'  => $u1,
+				'activity' => $a1,
 			)
 		);
 

--- a/tests/phpunit/testcases/activity/functions.php
+++ b/tests/phpunit/testcases/activity/functions.php
@@ -2042,4 +2042,71 @@ Bar!';
 
 		$this->assertTrue( 5 === (int) $count_activities['total'] );
 	}
+
+	/**
+	 * @group bp_register_activity_type
+	 */
+	public function test_bp_register_activity_type_no_args() {
+		$type = bp_register_activity_type( 'greeting' );
+
+		$this->assertInstanceOf( 'BP_Activity_Type', $type );
+		$this->assertSame( 'Greeting', $type->labels->front_filter );
+
+		bp_unregister_activity_type( 'greeting' );
+	}
+
+	/**
+	 * @group bp_register_activity_type
+	 * @expectedIncorrectUsage bp_register_activity_type
+	 */
+	public function test_bp_register_activity_type_empty_key() {
+		$type = bp_register_activity_type( '' );
+
+		$this->assertInstanceOf( 'WP_Error', $type );
+	}
+
+	/**
+	 * @group bp_register_activity_type
+	 */
+	public function test_bp_register_activity_type_support_numeric_keys() {
+		$type = bp_register_activity_type(
+			'greetings_support',
+			array(
+				'supports' => array( 'comments', 'favorites' ),
+			)
+		);
+
+		$this->assertTrue( bp_activity_type_supports( 'greetings_support', 'comments' ) );
+		$this->assertTrue( bp_activity_type_supports( 'greetings_support', 'favorites' ) );
+
+		bp_unregister_activity_type( 'greetings_support' );
+	}
+
+	/**
+	 * @group bp_register_activity_type
+	 * @group bp_unregister_activity_type
+	 */
+	public function test_bp_unregister_activity_type() {
+		bp_register_activity_type( 'greeting' );
+		$type = bp_unregister_activity_type( 'greeting' );
+
+		$this->assertTrue( $type );
+	}
+
+	/**
+	 * @group bp_register_activity_type
+	 * @group bp_unregister_activity_type
+	 */
+	public function test_bp_unregister_activity_type_invalid() {
+		$type = bp_unregister_activity_type( 'greeting' );
+
+		$this->assertInstanceOf( 'WP_Error', $type );
+	}
+
+	/**
+	 * @group bp_get_activity_types_for_role
+	 */
+	public function test_bp_get_activity_types_for_role_reaction() {
+		$this->assertTrue( in_array( 'activity_comment', bp_get_activity_types_for_role( 'reaction' ), true ) );
+	}
 }

--- a/tests/phpunit/testcases/activity/functions.php
+++ b/tests/phpunit/testcases/activity/functions.php
@@ -2075,12 +2075,12 @@ Bar!';
 		$type = bp_register_activity_type(
 			'greetings_support',
 			array(
-				'supports' => array( 'comments', 'favorites' ),
+				'supports' => array( 'comments', 'likes' ),
 			)
 		);
 
 		$this->assertTrue( bp_activity_type_supports( 'greetings_support', 'comments' ) );
-		$this->assertTrue( bp_activity_type_supports( 'greetings_support', 'favorites' ) );
+		$this->assertTrue( bp_activity_type_supports( 'greetings_support', 'likes' ) );
 
 		bp_unregister_activity_type( 'greetings_support' );
 	}

--- a/tests/phpunit/testcases/activity/template.php
+++ b/tests/phpunit/testcases/activity/template.php
@@ -1685,4 +1685,56 @@ class BP_Tests_Activity_Template extends BP_UnitTestCase {
 
 		$_REQUEST = $request;
 	}
+
+	/**
+	 * @group likes
+	 * @group bp_activity_is_liked
+	 */
+	public function test_bp_activity_is_liked() {
+		$a1 = self::factory()->activity->create();
+		$u1 = self::factory()->user->create();
+		$u2 = self::factory()->user->create();
+
+		$r1 = bp_activity_add_reaction(
+			array(
+				'user_id'  => $u1,
+				'activity' => $a1,
+			)
+		);
+
+		$r2 = bp_activity_add_reaction(
+			array(
+				'user_id'  => $u2,
+				'activity' => $a1,
+			)
+		);
+
+		$this->assertTrue( bp_activity_is_liked( $u2, $a1 ) );
+	}
+
+	/**
+	 * @group likes
+	 * @group bp_activity_get_like_count
+	 */
+	public function test_bp_activity_get_like_count() {
+		$a1 = self::factory()->activity->create();
+		$u1 = self::factory()->user->create();
+		$u2 = self::factory()->user->create();
+
+		$r1 = bp_activity_add_reaction(
+			array(
+				'user_id'  => $u1,
+				'activity' => $a1,
+			)
+		);
+
+		$r2 = bp_activity_add_reaction(
+			array(
+				'user_id'  => $u2,
+				'activity' => $a1,
+			)
+		);
+
+		$this->assertTrue( 2 === bp_activity_get_like_count( $a1 ) );
+	}
 }


### PR DESCRIPTION
I'm back again with Favorites improvement. The story of this ticket highlighted the fact we should consider moving to **Likes**. I agree and now we have a Backward Compatibility Add-on (BP Classic). I believe we should move the Activity Favorites feature into this Add-on and finally have **Likes** instead into BuddyPress.

I've tested many ways to fix this ticket and I believe I finally have something solid to improve how we deal with **Likes** or more globally with **Reactions** to an activity. My reasoning to build the Activity Likes feature is Activity comments or Activity Likes are both reactions to an activity: I like what the activity says or I reply to it. So **Activity Likes** can be compared to Activity comments without content. If this PR is still a WIP, it already contains:

- An Activity Type API (it should help us fix [#6429](https://buddypress.trac.wordpress.org/ticket/6429)
- Examples of what improvements this API can bring: see the `bp_activity_type_supports()` function.
- An initial Reaction API I'm inaugurating with the **Activity Likes** feature.
- Adding/Removing Likes, getting likes count for an activity, getting the activity the user liked

Next steps if we agree on this scenario:
- List the users who liked an activity on the Activity single screen
- Ajax/JavaScript implementation into Template packs

More possible ambitious steps:
- Sort Activity stream according to number of activity likes
- Sort Activity stream according to number of comments.

I really think we should go this road for Activity Reactions/Likes. What do you think? Should we make this the 14.0.0 release top feature?

Trac ticket: https://buddypress.trac.wordpress.org/ticket/5644

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
