### PR TITLE
Fix some inline comment typo errors

### DIFF
--- a/src/bp-activity/bp-activity-embeds.php
+++ b/src/bp-activity/bp-activity-embeds.php
@@ -128,7 +128,7 @@ function bp_activity_embed_excerpt( $content = '' ) {
 	 * Generates excerpt for an activity embed item.
 	 *
 	 * @since 2.6.0
-	 * 
+	 *
 	 * @global BP_Activity_Template $activities_template The Activity template loop.
 	 *
 	 * @param  string $content The content to generate an excerpt for.
@@ -166,9 +166,9 @@ function bp_activity_embed_excerpt( $content = '' ) {
  * Outputs the first embedded item in the activity oEmbed template.
  *
  * @since 2.6.0
- * 
+ *
  * @global BP_Activity_Template $activities_template The Activity template loop.
- * 
+ *
  */
 function bp_activity_embed_media() {
 	// Bail if oEmbed request explicitly hides media.
@@ -356,7 +356,7 @@ EOD;
 }
 
 /**
- * Make sure the Activity embed template will be used if neded.
+ * Make sure the Activity embed template will be used if needed.
  *
  * @since 12.0.0
  *

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -835,7 +835,7 @@ function bp_core_process_spammer_status( $user_id, $status, $do_wp_cleanup = tru
 	}
 
 	/**
-	 * Fires at the end of the process for hanlding spammer status.
+	 * Fires at the end of the process for handling spammer status.
 	 *
 	 * @since 1.5.5
 	 *
@@ -1587,7 +1587,7 @@ add_filter( 'pre_update_site_option_illegal_names', 'bp_core_get_illegal_names' 
  *   - Is the email address well-formed?
  *   - Is the email address already used?
  *   - If there are disallowed email domains, is the current domain among them?
- *   - If there's an email domain whitelest, is the current domain on it?
+ *   - If there's an email domain whitelist, is the current domain on it?
  *
  * @since 1.6.2
  *
@@ -1621,7 +1621,7 @@ function bp_core_validate_email_address( $user_email ) {
 		}
 	}
 
-	// Is the email alreday in use?
+	// Is the email already in use?
 	if ( email_exists( $user_email ) ) {
 		$errors['in_use'] = 1;
 	}
@@ -2729,7 +2729,7 @@ function bp_get_member_type_tax_labels() {
 			'new_item_name'              => _x( 'New Member Type Name', 'Member type taxonomy new item name label', 'buddypress' ),
 			'separate_items_with_commas' => _x( 'Separate member types with commas', 'Member type taxonomy separate items with commas label', 'buddypress' ),
 			'add_or_remove_items'        => _x( 'Add or remove member types', 'Member type taxonomy add or remove items label', 'buddypress' ),
-			'choose_from_most_used'      => _x( 'Choose from the most used meber types', 'Member type taxonomy choose from most used label', 'buddypress' ),
+			'choose_from_most_used'      => _x( 'Choose from the most used member types', 'Member type taxonomy choose from most used label', 'buddypress' ),
 			'not_found'                  => _x( 'No member types found.', 'Member type taxonomy not found label', 'buddypress' ),
 			'no_terms'                   => _x( 'No member types', 'Member type taxonomy no terms label', 'buddypress' ),
 			'items_list_navigation'      => _x( 'Member Types list navigation', 'Member type taxonomy items list navigation label', 'buddypress' ),
@@ -2899,7 +2899,7 @@ function bp_register_member_type( $member_type, $args = array() ) {
 
 	// Directory slug.
 	if ( $r['has_directory'] ) {
-		// A string value is intepreted as the directory slug. Otherwise fall back on member type.
+		// A string value is interpreted as the directory slug. Otherwise fall back on member type.
 		if ( is_string( $r['has_directory'] ) ) {
 			$directory_slug = $r['has_directory'];
 		} else {
@@ -3457,7 +3457,7 @@ function bp_members_invitations_invite_user( $args = array() ) {
 		'send_invite'   => $r['send_invite'],
 	);
 
-	// Create the invitataion.
+	// Create the invitation.
 	$invites_class = new BP_Members_Invitation_Manager();
 	$created       = $invites_class->add_invitation( $inv_args );
 

--- a/src/bp-messages/bp-messages-star.php
+++ b/src/bp-messages/bp-messages-star.php
@@ -232,7 +232,7 @@ function bp_the_message_star_action_link( $args = array() ) {
  *     @type string $action     The star action. Either 'star' or 'unstar'. Default: 'star'.
  *     @type int    $thread_id  The message thread ID. Default: 0. If not zero, this takes precedence over
  *                              $message_id.
- *     @type int    $message_id The indivudal message ID to star or unstar.  Default: 0.
+ *     @type int    $message_id The individual message ID to star or unstar.  Default: 0.
  *     @type int    $user_id    The user ID. Defaults to the logged-in user ID.
  *     @type bool   $bulk       Whether to mark all messages in a thread as a certain action. Only relevant
  *                              when $action is 'unstar' at the moment. Default: false.

--- a/src/bp-messages/bp-messages-template.php
+++ b/src/bp-messages/bp-messages-template.php
@@ -809,7 +809,7 @@ function bp_message_thread_avatar( $args = '' ) {
 /**
  * Output the unread messages count for the current inbox.
  *
- * @since 2.6.x Added the `$user_id` paremeter.
+ * @since 2.6.x Added the `$user_id` parameter.
  *
  * @param int $user_id The user ID.
  */
@@ -819,7 +819,7 @@ function bp_total_unread_messages_count( $user_id = 0 ) {
 	/**
 	 * Get the unread messages count for the current inbox.
 	 *
-	 * @since 2.6.x Added the `$user_id` paremeter.
+	 * @since 2.6.x Added the `$user_id` parameter.
 	 *
 	 * @param int $user_id The user ID.
 	 *
@@ -1027,7 +1027,7 @@ function bp_messages_content_value() {
 	echo esc_textarea( bp_get_messages_content_value() );
 }
 	/**
-	 * Get the default value fo the Compose content field.
+	 * Get the default value for the Compose content field.
 	 *
 	 * Will get a value out of $_POST['content'] if available (ie after a
 	 * failed submission).

--- a/src/bp-templates/bp-nouveau/includes/template-tags.php
+++ b/src/bp-templates/bp-nouveau/includes/template-tags.php
@@ -161,7 +161,7 @@ function bp_nouveau_has_dismiss_button() {
 }
 
 /**
- * Ouptut the dismiss type.
+ * Output the dismiss type.
  *
  * $type is used to set the data-attr for the button.
  * 'clear' is tested for & used to remove cookies, if set, in buddypress-nouveau.js.
@@ -577,7 +577,7 @@ function bp_nouveau_loop_classes() {
 			'blogs'   => true,
 
 			/*
-			 * Technically not a component but allows us to check the single group members loop as a seperate loop.
+			 * Technically not a component but allows us to check the single group members loop as a separate loop.
 			 */
 			'members_group'   => true,
 			'members_friends' => true,


### PR DESCRIPTION
Clean the patch to remove prefixes (`a/` & `b/`)

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9109

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
