### PR TITLE
Migrate the Release Leads & Deputies codex page

### DIFF
--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -2,6 +2,7 @@
 
 Welcome to the BuddyPress Contributor Handbook.
 
+- [About the BuddyPress open source project](./project/README.md)
 - [Contribute to documentation](./documentation/README.md)
 - Contribute to translation
 - Contribute to tests

--- a/docs/contributor/manifest.json
+++ b/docs/contributor/manifest.json
@@ -6,6 +6,24 @@
 		"parent": null
 	},
 	{
+		"title": "About the BuddyPress open source project",
+		"slug": "about",
+		"markdown_source": "../contributor/project/README.md",
+		"parent": null
+	},
+	{
+		"title": "How a release cycle works?",
+		"slug": "about-release",
+		"markdown_source": "../contributor/project/release/README.md",
+		"parent": null
+	},
+	{
+		"title": "Release Leads & Deputies",
+		"slug": "about-release-leads",
+		"markdown_source": "../contributor/project/release/leads.md",
+		"parent": null
+	},
+	{
 		"title": "Contribute to documentation",
 		"slug": "contribute-to-documentation",
 		"markdown_source": "../contributor/documentation/README.md",

--- a/docs/contributor/project/README.md
+++ b/docs/contributor/project/README.md
@@ -1,0 +1,6 @@
+# About the BuddyPress open source project
+
+- Project organization
+- [Release cycle](./release/README.md)
+- Commit access
+- Version numbering

--- a/docs/contributor/project/release/README.md
+++ b/docs/contributor/project/release/README.md
@@ -1,0 +1,4 @@
+# How a release cycle works?
+
+- [Release Leads & Deputies](./leads.md)
+- Prelaunch checklist

--- a/docs/contributor/project/release/leads.md
+++ b/docs/contributor/project/release/leads.md
@@ -1,0 +1,14 @@
+# Release Leads & Deputies
+
+The release lead works with all contributors to ensure the success of the release. The role blends aspects of being a product manager, project manager, engineering manager, release manager, and community manager. Release leads do not need to be developers, but having experience contributing to open source projects is required.
+
+Release leads are supported by the lead developers, the project team, and deputies of their choosing. Volunteering as a release deputy is a great way to give it a try and learn about the process, but with a smaller time commitment.
+
+For the sake of clarity, BuddyPress release leads and their deputies, between them, can expect to:
+
+- Run our bi-weekly project meeting, and write and publish meeting notes on our [development blog](https://bpdevel.wordpress.com/).
+- Coordinate blog posts and announcements on social media.
+- Make final decisions about whether a proposed feature is able to be put into the release.
+- **Help new contributors make their contributions seen and heard in project meetings**.
+
+While BuddyPress is built by people volunteering their own time, contributing whatever they want, however they want, the release lead should take advantage of their position and use it to shape BuddyPress. For example, if the release lead feels that the next release should have a focus on specific aspects, we expect them to declare this, and try to encourage regular contributors to make that a reality.


### PR DESCRIPTION
Copy the existing text as is. @paulgibbs did a great work about it 👏. Simply update the project meeting frequency (from weekly to bi-weekly)

See https://github.com/buddypress/bp-documentation/issues/119

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
