### PR TITLE
Use the `$bp->pages` global as a fallback to set the BP queried object

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -507,8 +507,7 @@ class BP_Activity_Component extends BP_Component {
 
 			// Set the BuddyPress queried object.
 			if ( isset( $bp->pages->activity->id ) ) {
-				$query->queried_object    = get_post( $bp->pages->activity->id );
-				$query->queried_object_id = $query->queried_object->ID;
+				$this->set_queried_object( $query );
 			}
 		}
 

--- a/src/bp-blogs/classes/class-bp-blogs-component.php
+++ b/src/bp-blogs/classes/class-bp-blogs-component.php
@@ -488,8 +488,7 @@ class BP_Blogs_Component extends BP_Component {
 
 			// Set the BuddyPress queried object.
 			if ( isset( $bp->pages->blogs->id ) && ( ! bp_current_action() || bp_is_current_action( 'create' ) ) ) {
-				$query->queried_object    = get_post( $bp->pages->blogs->id );
-				$query->queried_object_id = $query->queried_object->ID;
+				$this->set_queried_object( $query );
 			}
 		}
 

--- a/src/bp-core/classes/class-bp-component.php
+++ b/src/bp-core/classes/class-bp-component.php
@@ -1256,6 +1256,31 @@ class BP_Component {
 	}
 
 	/**
+	 * Set the queried BuddyPress object.
+	 *
+	 * @since 12.4.0
+	 *
+	 * @param WP_Query $query Main WP_Query object. Passed by reference.
+	 */
+	public function set_queried_object( &$query ) {
+		$bp             = buddypress();
+		$queried_object = get_post( $bp->pages->{ $this->id }->id );
+
+		// Reset the BP Directory Page if the post weirdly does not exist.
+		if ( is_null( $queried_object ) ) {
+			$queried_object                 = get_post( $bp->pages->{ $this->id } );
+			$queried_object->ID             = (int) $bp->pages->{ $this->id }->id;
+			$queried_object->post_type      = bp_core_get_directory_post_type();
+			$queried_object->post_title     = $bp->pages->{ $this->id }->title;
+			$queried_object->post_name      = $bp->pages->{ $this->id }->name;
+			$queried_object->comment_status = 'closed';
+		}
+
+		$query->queried_object    = $queried_object;
+		$query->queried_object_id = $queried_object->ID;
+	}
+
+	/**
 	 * Make sure to avoid querying for regular posts when displaying a BuddyPress page.
 	 *
 	 * @since 12.0.0

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -1189,8 +1189,7 @@ class BP_Groups_Component extends BP_Component {
 			 * Set the BuddyPress queried object.
 			 */
 			if ( isset( $bp->pages->groups->id ) ) {
-				$query->queried_object    = get_post( $bp->pages->groups->id );
-				$query->queried_object_id = $query->queried_object->ID;
+				$this->set_queried_object( $query );
 
 				if ( $this->current_group ) {
 					$query->queried_object->single_item_name = $this->current_group->name;

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -946,8 +946,7 @@ class BP_Members_Component extends BP_Component {
 
 			// Set the BuddyPress queried object.
 			if ( isset( $bp->pages->members->id ) ) {
-				$query->queried_object    = get_post( $bp->pages->members->id );
-				$query->queried_object_id = $query->queried_object->ID;
+				$this->set_queried_object( $query );
 
 				if ( $member ) {
 					$query->queried_object->single_item_name = $member->display_name;

--- a/tests/phpunit/testcases/core/cache.php
+++ b/tests/phpunit/testcases/core/cache.php
@@ -29,5 +29,56 @@ class BP_Tests_Core_Cache extends BP_UnitTestCase {
 
 		$this->assertSame( array(), wp_cache_get( $a1, 'activity_meta' ) );
 	}
+
+	public function is_active_filter( $is_active, $component ) {
+		if ( ! $is_active && 'attachments' === $component ) {
+			$is_active = true;
+		}
+
+		return $is_active;
+	}
+
+	/**
+	 * @group bp_core_add_page_mappings
+	 * @group bp_core_get_directory_page_ids
+	 * @ticket BP9076
+	 */
+	public function test_object_cache_for_directory_pages() {
+		$bp = buddypress();
+
+		wp_cache_delete( 'directory_pages', 'bp_pages' );
+		$bp_pages    = bp_core_get_directory_pages();
+		$cache       = wp_cache_get( 'directory_pages', 'bp_pages' );
+		$member_page = get_post( $bp->pages->members->id );
+
+		$this->assertNotEmpty( $cache );
+		$this->assertNotEmpty( $member_page->ID );
+
+		$orphaned_component = array(
+			'attachments' => array(
+				'name'  => 'bp-attachments',
+				'title' => 'Community Media',
+			)
+		);
+
+		add_filter( 'bp_is_active', array( $this, 'is_active_filter' ), 10, 2 );
+
+		bp_core_add_page_mappings( $orphaned_component, 'keep', true );
+
+		$updated_cache       = wp_cache_get( 'directory_pages', 'bp_pages' );
+		$updated_member_page = get_post( $bp->pages->members->id );
+
+		$this->assertEmpty( $updated_cache );
+		$this->assertEquals( $updated_member_page->ID, $member_page->ID );
+
+		$bp_pages        = bp_core_get_directory_pages();
+		$new_cache       = wp_cache_get( 'directory_pages', 'bp_pages' );
+		$new_member_page = get_post( $bp->pages->members->id );
+
+		remove_filter( 'bp_is_active', array( $this, 'is_active_filter' ), 10 );
+
+		$this->assertNotEmpty( $new_cache->attachments );
+		$this->assertEquals( $new_member_page->ID, $member_page->ID );
+	}
 }
 


### PR DESCRIPTION
Introduce the `BP_Component->set_queried_object()` to set the BP queried object even for some failed object cache reason a post does not exist although it does!

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9076

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
