### PR TITLE
Only parse `heartbeat` requests which relates to BuddyPress context

### DIFF
--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -33,6 +33,10 @@ function bp_core_set_ajax_uri_globals() {
 		return;
 	}
 
+	if ( 'heartbeat' === $action && empty( $_REQUEST['data']['bp_heartbeat'] ) ) {
+		return;
+	}
+
 	bp_reset_query( bp_get_referer_path(), $GLOBALS['wp_query'] );
 }
 

--- a/src/bp-core/bp-core-template-loader.php
+++ b/src/bp-core/bp-core-template-loader.php
@@ -619,6 +619,10 @@ function bp_parse_ajax_referer_query( $referer_query ) {
 		return;
 	}
 
+	if ( isset( $_POST['action'] ) && 'heartbeat' === $_POST['action'] && empty( $_POST['data']['bp_heartbeat'] ) ) {
+		return;
+	}
+
 	// Prevent doing this again.
 	remove_action( 'parse_query', 'bp_parse_ajax_referer_query', 2 );
 


### PR DESCRIPTION
The Query Monitor plugin is showing some notice errors about the way some specific Ajax requests were handled by the BP Rewrites API. This PR aims to remove these notices making sure the `heartbeat` action is about a BuddyPress context.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9099

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
