### PR TITLE
BP Block themes simple & minimal template hierarchy

### DIFF
--- a/src/bp-activity/screens/favorites.php
+++ b/src/bp-activity/screens/favorites.php
@@ -22,12 +22,18 @@ function bp_activity_screen_favorites() {
 	 */
 	do_action( 'bp_activity_screen_favorites' );
 
-	/**
-	 * Filters the template to load for the "Favorites" screen.
-	 *
-	 * @since 1.2.0
-	 *
-	 * @param string $template Path to the activity template to load.
-	 */
-	bp_core_load_template( apply_filters( 'bp_activity_template_favorite_activity', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the "Favorites" screen.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @param string $template Path to the activity template to load.
+		 */
+		apply_filters( 'bp_activity_template_favorite_activity', 'members/single/home' ),
+		'members/single/index',
+	);
+
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-activity/screens/friends.php
+++ b/src/bp-activity/screens/friends.php
@@ -11,10 +11,12 @@
  * Load the 'My Friends' activity page.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function bp_activity_screen_friends() {
 	if ( ! bp_is_active( 'friends' ) ) {
-		return false;
+		return;
 	}
 
 	bp_update_is_item_admin( bp_current_user_can( 'bp_moderate' ), 'activity' );

--- a/src/bp-activity/screens/friends.php
+++ b/src/bp-activity/screens/friends.php
@@ -13,8 +13,9 @@
  * @since 1.0.0
  */
 function bp_activity_screen_friends() {
-	if ( !bp_is_active( 'friends' ) )
+	if ( ! bp_is_active( 'friends' ) ) {
 		return false;
+	}
 
 	bp_update_is_item_admin( bp_current_user_can( 'bp_moderate' ), 'activity' );
 
@@ -25,12 +26,17 @@ function bp_activity_screen_friends() {
 	 */
 	do_action( 'bp_activity_screen_friends' );
 
-	/**
-	 * Filters the template to load for the "My Friends" screen.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $template Path to the activity template to load.
-	 */
-	bp_core_load_template( apply_filters( 'bp_activity_template_friends_activity', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the "My Friends" screen.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $template Path to the activity template to load.
+		 */
+		apply_filters( 'bp_activity_template_friends_activity', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-activity/screens/groups.php
+++ b/src/bp-activity/screens/groups.php
@@ -11,10 +11,12 @@
  * Load the 'My Groups' activity page.
  *
  * @since 1.2.0
+ *
+ * @return void
  */
 function bp_activity_screen_groups() {
 	if ( ! bp_is_active( 'groups' ) ) {
-		return false;
+		return;
 	}
 
 	bp_update_is_item_admin( bp_current_user_can( 'bp_moderate' ), 'activity' );

--- a/src/bp-activity/screens/groups.php
+++ b/src/bp-activity/screens/groups.php
@@ -13,8 +13,9 @@
  * @since 1.2.0
  */
 function bp_activity_screen_groups() {
-	if ( !bp_is_active( 'groups' ) )
+	if ( ! bp_is_active( 'groups' ) ) {
 		return false;
+	}
 
 	bp_update_is_item_admin( bp_current_user_can( 'bp_moderate' ), 'activity' );
 
@@ -25,12 +26,17 @@ function bp_activity_screen_groups() {
 	 */
 	do_action( 'bp_activity_screen_groups' );
 
-	/**
-	 * Filters the template to load for the "My Groups" screen.
-	 *
-	 * @since 1.2.0
-	 *
-	 * @param string $template Path to the activity template to load.
-	 */
-	bp_core_load_template( apply_filters( 'bp_activity_template_groups_activity', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the "My Groups" screen.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @param string $template Path to the activity template to load.
+		 */
+		apply_filters( 'bp_activity_template_groups_activity', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-activity/screens/just-me.php
+++ b/src/bp-activity/screens/just-me.php
@@ -21,12 +21,17 @@ function bp_activity_screen_my_activity() {
 	 */
 	do_action( 'bp_activity_screen_my_activity' );
 
-	/**
-	 * Filters the template to load for the "My Activity" screen.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $template Path to the activity template to load.
-	 */
-	bp_core_load_template( apply_filters( 'bp_activity_template_my_activity', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the "My Activity" screen.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $template Path to the activity template to load.
+		 */
+		apply_filters( 'bp_activity_template_my_activity', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-activity/screens/mentions.php
+++ b/src/bp-activity/screens/mentions.php
@@ -22,24 +22,31 @@ function bp_activity_screen_mentions() {
 	 */
 	do_action( 'bp_activity_screen_mentions' );
 
-	/**
-	 * Filters the template to load for the "Mentions" screen.
-	 *
-	 * @since 1.2.0
-	 *
-	 * @param string $template Path to the activity template to load.
-	 */
-	bp_core_load_template( apply_filters( 'bp_activity_template_mention_activity', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the "Mentions" screen.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @param string $template Path to the activity template to load.
+		 */
+		apply_filters( 'bp_activity_template_mention_activity', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }
 
 /**
  * Reset the logged-in user's new mentions data when he visits his mentions screen.
  *
  * @since 1.5.0
- *
  */
 function bp_activity_reset_my_new_mentions() {
-	if ( bp_is_my_profile() )
-		bp_activity_clear_new_mentions( bp_loggedin_user_id() );
+	if ( ! bp_is_my_profile() ) {
+		return;
+	}
+
+	bp_activity_clear_new_mentions( bp_loggedin_user_id() );
 }
 add_action( 'bp_activity_screen_mentions', 'bp_activity_reset_my_new_mentions' );

--- a/src/bp-activity/screens/mentions.php
+++ b/src/bp-activity/screens/mentions.php
@@ -41,6 +41,8 @@ function bp_activity_screen_mentions() {
  * Reset the logged-in user's new mentions data when he visits his mentions screen.
  *
  * @since 1.5.0
+ *
+ * @return void
  */
 function bp_activity_reset_my_new_mentions() {
 	if ( ! bp_is_my_profile() ) {

--- a/src/bp-activity/screens/permalink.php
+++ b/src/bp-activity/screens/permalink.php
@@ -161,16 +161,18 @@ function bp_activity_screen_single_activity_permalink() {
 		}
 	}
 
-	/**
-	 * Filters the template to load for a single activity screen.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $template Path to the activity template to load.
-	 */
-	$template = apply_filters( 'bp_activity_template_profile_activity_permalink', 'members/single/activity/permalink' );
+	$templates = array(
+		/**
+		 * Filters the template to load for a single activity screen.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $template Path to the activity template to load.
+		 */
+		apply_filters( 'bp_activity_template_profile_activity_permalink', 'members/single/activity/permalink' ),
+		'members/single/activity',
+	);
 
-	// Load the template.
-	bp_core_load_template( $template );
+	bp_core_load_template( $templates );
 }
 add_action( 'bp_screens', 'bp_activity_screen_single_activity_permalink' );

--- a/src/bp-activity/screens/permalink.php
+++ b/src/bp-activity/screens/permalink.php
@@ -96,25 +96,27 @@ add_action( 'bp_actions', 'bp_activity_action_permalink_router' );
  *
  * @since 1.2.0
  *
- * @return bool|string Boolean on false or the template for a single activity item on success.
+ * @return void
  */
 function bp_activity_screen_single_activity_permalink() {
 	// No displayed user or not viewing activity component.
 	if ( ! bp_is_activity_component() ) {
-		return false;
+		return;
 	}
 
 	$action = bp_current_action();
 	if ( ! $action || ! is_numeric( $action ) ) {
-		return false;
+		return;
 	}
 
 	// Get the activity details.
-	$activity = bp_activity_get_specific( array(
-		'activity_ids' => $action,
-		'show_hidden'  => true,
-		'spam'         => 'ham_only',
-	) );
+	$activity = bp_activity_get_specific(
+		array(
+			'activity_ids' => $action,
+			'show_hidden'  => true,
+			'spam'         => 'ham_only',
+		)
+	);
 
 	// 404 if activity does not exist.
 	if ( empty( $activity['activities'][0] ) || bp_action_variables() ) {

--- a/src/bp-blogs/screens/create.php
+++ b/src/bp-blogs/screens/create.php
@@ -11,11 +11,13 @@
  * Load the "Create a Blog" screen.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function bp_blogs_screen_create_a_blog() {
 
 	if ( ! is_multisite() || ! bp_is_blogs_component() || ! bp_is_current_action( 'create' ) || ! is_user_logged_in() || ! bp_blog_signup_enabled() ) {
-		return false;
+		return;
 	}
 
 	/**

--- a/src/bp-blogs/screens/directory.php
+++ b/src/bp-blogs/screens/directory.php
@@ -10,7 +10,7 @@
 /**
  * Load the top-level Blogs directory.
  *
- * @since 1.5-beta-1
+ * @since 1.0.0
  */
 function bp_blogs_screen_index() {
 	if ( bp_is_blogs_directory() ) {

--- a/src/bp-blogs/screens/my-blogs.php
+++ b/src/bp-blogs/screens/my-blogs.php
@@ -11,10 +11,12 @@
  * Load the "My Blogs" screen.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function bp_blogs_screen_my_blogs() {
 	if ( ! is_multisite() ) {
-		return false;
+		return;
 	}
 
 	/**

--- a/src/bp-blogs/screens/my-blogs.php
+++ b/src/bp-blogs/screens/my-blogs.php
@@ -13,8 +13,9 @@
  * @since 1.0.0
  */
 function bp_blogs_screen_my_blogs() {
-	if ( !is_multisite() )
+	if ( ! is_multisite() ) {
 		return false;
+	}
 
 	/**
 	 * Fires right before the loading of the My Blogs screen template file.
@@ -23,5 +24,17 @@ function bp_blogs_screen_my_blogs() {
 	 */
 	do_action( 'bp_blogs_screen_my_blogs' );
 
-	bp_core_load_template( apply_filters( 'bp_blogs_template_my_blogs', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the "My blogs" screen.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $template Path to the activity template to load.
+		 */
+		apply_filters( 'bp_blogs_template_my_blogs', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -214,16 +214,21 @@ function bp_core_load_template( $templates ) {
  * @since 1.0.0
  */
 function bp_core_catch_profile_uri() {
-	if ( !bp_is_active( 'xprofile' ) ) {
+	if ( ! bp_is_active( 'xprofile' ) ) {
 
-		/**
-		 * Filters the path to redirect users to if XProfile is not enabled.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param string $value Path to redirect users to.
-		 */
-		bp_core_load_template( apply_filters( 'bp_core_template_display_profile', 'members/single/home' ) );
+		$templates = array(
+			/**
+			 * Filters the path to redirect users to if XProfile is not enabled.
+			 *
+			 * @since 1.0.0
+			 *
+			 * @param string $value Path to redirect users to.
+			 */
+			apply_filters( 'bp_core_template_display_profile', 'members/single/home' ),
+			'members/single/index',
+		);
+
+		bp_core_load_template( $templates );
 	}
 }
 

--- a/src/bp-friends/screens/my-friends.php
+++ b/src/bp-friends/screens/my-friends.php
@@ -21,12 +21,17 @@ function friends_screen_my_friends() {
 	 */
 	do_action( 'friends_screen_my_friends' );
 
-	/**
-	 * Filters the template used to display the My Friends page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $template Path to the my friends template to load.
-	 */
-	bp_core_load_template( apply_filters( 'friends_template_my_friends', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template used to display the My Friends page.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $template Path to the my friends template to load.
+		 */
+		apply_filters( 'friends_template_my_friends', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-friends/screens/requests.php
+++ b/src/bp-friends/screens/requests.php
@@ -67,12 +67,17 @@ function friends_screen_requests() {
 	 */
 	do_action( 'friends_screen_requests' );
 
-	/**
-	 * Filters the template used to display the My Friends page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $template Path to the friends request template to load.
-	 */
-	bp_core_load_template( apply_filters( 'friends_template_requests', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template used to display the My Friends page.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $template Path to the friends request template to load.
+		 */
+		apply_filters( 'friends_template_requests', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-groups/actions/create.php
+++ b/src/bp-groups/actions/create.php
@@ -12,17 +12,17 @@
  *
  * @since 1.2.0
  *
- * @return bool
+ * @return void
  */
 function groups_action_create_group() {
 
 	// If we're not at domain.org/groups/create/ then return false.
 	if ( ! bp_is_groups_component() || ! bp_is_current_action( 'create' ) ) {
-		return false;
+		return;
 	}
 
 	if ( ! is_user_logged_in() ) {
-		return false;
+		return;
 	}
 
 	if ( ! bp_user_can_create_groups() ) {

--- a/src/bp-groups/actions/join.php
+++ b/src/bp-groups/actions/join.php
@@ -12,17 +12,17 @@
  *
  * @since 1.0.0
  *
- * @return bool
+ * @return void
  */
 function groups_action_join_group() {
 
 	if ( ! bp_is_single_item() || ! bp_is_groups_component() || ! bp_is_current_action( 'join' ) ) {
-		return false;
+		return;
 	}
 
 	// Nonce check.
 	if ( ! check_admin_referer( 'groups_join_group' ) ) {
-		return false;
+		return;
 	}
 
 	$bp = buddypress();

--- a/src/bp-groups/actions/join.php
+++ b/src/bp-groups/actions/join.php
@@ -16,42 +16,50 @@
  */
 function groups_action_join_group() {
 
-	if ( !bp_is_single_item() || !bp_is_groups_component() || !bp_is_current_action( 'join' ) )
+	if ( ! bp_is_single_item() || ! bp_is_groups_component() || ! bp_is_current_action( 'join' ) ) {
 		return false;
+	}
 
 	// Nonce check.
-	if ( !check_admin_referer( 'groups_join_group' ) )
+	if ( ! check_admin_referer( 'groups_join_group' ) ) {
 		return false;
+	}
 
 	$bp = buddypress();
 
 	// Skip if banned or already a member.
-	if ( !groups_is_user_member( bp_loggedin_user_id(), $bp->groups->current_group->id ) && !groups_is_user_banned( bp_loggedin_user_id(), $bp->groups->current_group->id ) ) {
+	if ( ! groups_is_user_member( bp_loggedin_user_id(), $bp->groups->current_group->id ) && ! groups_is_user_banned( bp_loggedin_user_id(), $bp->groups->current_group->id ) ) {
 
 		// User wants to join a group that requires an invitation to join.
 		if ( ! bp_current_user_can( 'groups_join_group', array( 'group_id' => $bp->groups->current_group->id ) ) ) {
-			if ( !groups_check_user_has_invite( bp_loggedin_user_id(), $bp->groups->current_group->id ) ) {
+			if ( ! groups_check_user_has_invite( bp_loggedin_user_id(), $bp->groups->current_group->id ) ) {
 				bp_core_add_message( __( 'There was an error joining the group.', 'buddypress' ), 'error' );
 				bp_core_redirect( bp_get_group_url( $bp->groups->current_group ) );
 			}
 		}
 
 		// User wants to join any group.
-		if ( !groups_join_group( $bp->groups->current_group->id ) )
+		if ( ! groups_join_group( $bp->groups->current_group->id ) ) {
 			bp_core_add_message( __( 'There was an error joining the group.', 'buddypress' ), 'error' );
-		else
+		} else {
 			bp_core_add_message( __( 'You joined the group!', 'buddypress' ) );
+		}
 
 		bp_core_redirect( bp_get_group_url( $bp->groups->current_group ) );
 	}
 
-	/**
-	 * Filters the template to load for the single group screen.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $value Path to the single group template to load.
-	 */
-	bp_core_load_template( apply_filters( 'groups_template_group_home', 'groups/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the single group screen.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $value Path to the single group template to load.
+		 */
+		apply_filters( 'groups_template_group_home', 'groups/single/home' ),
+		'groups/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }
 add_action( 'bp_actions', 'groups_action_join_group' );

--- a/src/bp-groups/actions/leave-group.php
+++ b/src/bp-groups/actions/leave-group.php
@@ -55,8 +55,13 @@ function groups_action_leave_group() {
 		bp_core_redirect( $redirect );
 	}
 
-	/** This filter is documented in bp-groups/bp-groups-actions.php */
-	bp_core_load_template( apply_filters( 'groups_template_group_home', 'groups/single/home' ) );
+	$templates = array(
+		/** This filter is documented in bp-groups/actions/join.php */
+		apply_filters( 'groups_template_group_home', 'groups/single/home' ),
+		'groups/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }
 add_action( 'bp_actions', 'groups_action_leave_group' );
 

--- a/src/bp-groups/actions/leave-group.php
+++ b/src/bp-groups/actions/leave-group.php
@@ -18,16 +18,16 @@
  *
  * @since 1.2.4
  *
- * @return bool
+ * @return void
  */
 function groups_action_leave_group() {
 	if ( ! bp_is_single_item() || ! bp_is_groups_component() || ! bp_is_current_action( 'leave-group' ) ) {
-		return false;
+		return;
 	}
 
 	// Nonce check.
 	if ( ! check_admin_referer( 'groups_leave_group' ) ) {
-		return false;
+		return;
 	}
 
 	// User wants to leave any group.

--- a/src/bp-groups/screens/single/activity-permalink.php
+++ b/src/bp-groups/screens/single/activity-permalink.php
@@ -14,10 +14,12 @@
  * Handle the display of a single group activity item.
  *
  * @since 1.2.0
+ *
+ * @return void
  */
 function groups_screen_group_activity_permalink() {
 	if ( ! bp_is_groups_component() || ! bp_is_active( 'activity' ) || ( bp_is_active( 'activity' ) && ! bp_is_current_action( bp_get_activity_slug() ) ) || ! bp_action_variable( 0 ) ) {
-		return false;
+		return;
 	}
 
 	buddypress()->is_single_item = true;

--- a/src/bp-groups/screens/single/activity-permalink.php
+++ b/src/bp-groups/screens/single/activity-permalink.php
@@ -16,12 +16,18 @@
  * @since 1.2.0
  */
 function groups_screen_group_activity_permalink() {
-	if ( !bp_is_groups_component() || !bp_is_active( 'activity' ) || ( bp_is_active( 'activity' ) && !bp_is_current_action( bp_get_activity_slug() ) ) || !bp_action_variable( 0 ) )
+	if ( ! bp_is_groups_component() || ! bp_is_active( 'activity' ) || ( bp_is_active( 'activity' ) && ! bp_is_current_action( bp_get_activity_slug() ) ) || ! bp_action_variable( 0 ) ) {
 		return false;
+	}
 
 	buddypress()->is_single_item = true;
 
-	/** This filter is documented in bp-groups/bp-groups-screens.php */
-	bp_core_load_template( apply_filters( 'groups_template_group_home', 'groups/single/home' ) );
+	$templates = array(
+		/** This filter is documented in bp-groups/screens/home.php */
+		apply_filters( 'groups_template_group_home', 'groups/single/home' ),
+		'groups/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }
 add_action( 'bp_screens', 'groups_screen_group_activity_permalink' );

--- a/src/bp-groups/screens/single/activity.php
+++ b/src/bp-groups/screens/single/activity.php
@@ -25,12 +25,17 @@ function groups_screen_group_activity() {
 	 */
 	do_action( 'groups_screen_group_activity' );
 
-	/**
-	 * Filters the template to load for a single group's activity page.
-	 *
-	 * @since 2.4.0
-	 *
-	 * @param string $value Path to a single group's template to load.
-	 */
-	bp_core_load_template( apply_filters( 'groups_screen_group_activity', 'groups/single/activity' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for a single group's activity page.
+		 *
+		 * @since 2.4.0
+		 *
+		 * @param string $value Path to a single group's template to load.
+		 */
+		apply_filters( 'groups_screen_group_activity', 'groups/single/activity' ),
+		'groups/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-groups/screens/single/activity.php
+++ b/src/bp-groups/screens/single/activity.php
@@ -11,11 +11,13 @@
  * Handle the loading of a single group's activity.
  *
  * @since 2.4.0
+ *
+ * @return void
  */
 function groups_screen_group_activity() {
 
 	if ( ! bp_is_single_item() ) {
-		return false;
+		return;
 	}
 
 	/**

--- a/src/bp-groups/screens/single/admin/delete-group.php
+++ b/src/bp-groups/screens/single/admin/delete-group.php
@@ -70,13 +70,18 @@ function groups_screen_group_admin_delete_group() {
 	 */
 	do_action( 'groups_screen_group_admin_delete_group', $bp->groups->current_group->id );
 
-	/**
-	 * Filters the template to load for the Delete Group page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $value Path to the Delete Group template.
-	 */
-	bp_core_load_template( apply_filters( 'groups_template_group_admin_delete_group', 'groups/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the Delete Group page.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $value Path to the Delete Group template.
+		 */
+		apply_filters( 'groups_template_group_admin_delete_group', 'groups/single/home' ),
+		'groups/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }
 add_action( 'bp_screens', 'groups_screen_group_admin_delete_group' );

--- a/src/bp-groups/screens/single/admin/delete-group.php
+++ b/src/bp-groups/screens/single/admin/delete-group.php
@@ -11,15 +11,17 @@
  * Handle the display of the Delete Group page.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function groups_screen_group_admin_delete_group() {
 
 	if ( 'delete-group' != bp_get_group_current_admin_tab() ) {
-		return false;
+		return;
 	}
 
 	if ( ! bp_is_item_admin() && ! bp_current_user_can( 'bp_moderate' ) ) {
-		return false;
+		return;
 	}
 
 	$bp = buddypress();
@@ -30,7 +32,7 @@ function groups_screen_group_admin_delete_group() {
 
 		// Check the nonce first.
 		if ( ! check_admin_referer( 'groups_delete_group' ) ) {
-			return false;
+			return;
 		}
 
 		/**

--- a/src/bp-groups/screens/single/admin/edit-details.php
+++ b/src/bp-groups/screens/single/admin/edit-details.php
@@ -11,11 +11,14 @@
  * Handle the display of a group's admin/edit-details page.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function groups_screen_group_admin_edit_details() {
 
-	if ( 'edit-details' != bp_get_group_current_admin_tab() )
-		return false;
+	if ( 'edit-details' !== bp_get_group_current_admin_tab() ) {
+		return;
+	}
 
 	if ( bp_is_item_admin() ) {
 
@@ -24,8 +27,9 @@ function groups_screen_group_admin_edit_details() {
 		// If the edit form has been submitted, save the edited details.
 		if ( isset( $_POST['save'] ) ) {
 			// Check the nonce.
-			if ( !check_admin_referer( 'groups_edit_group_details' ) )
-				return false;
+			if ( ! check_admin_referer( 'groups_edit_group_details' ) ) {
+				return;
+			}
 
 			$group_notify_members = isset( $_POST['group-notify-members'] ) ? (int) $_POST['group-notify-members'] : 0;
 

--- a/src/bp-groups/screens/single/admin/edit-details.php
+++ b/src/bp-groups/screens/single/admin/edit-details.php
@@ -70,14 +70,19 @@ function groups_screen_group_admin_edit_details() {
 		 */
 		do_action( 'groups_screen_group_admin_edit_details', $bp->groups->current_group->id );
 
-		/**
-		 * Filters the template to load for a group's admin/edit-details page.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param string $value Path to a group's admin/edit-details template.
-		 */
-		bp_core_load_template( apply_filters( 'groups_template_group_admin', 'groups/single/home' ) );
+		$templates = array(
+			/**
+			 * Filters the template to load for a group's admin/edit-details page.
+			 *
+			 * @since 1.0.0
+			 *
+			 * @param string $value Path to a group's admin/edit-details template.
+			 */
+			apply_filters( 'groups_template_group_admin', 'groups/single/home' ),
+			'groups/single/index',
+		);
+
+		bp_core_load_template( $templates );
 	}
 }
 add_action( 'bp_screens', 'groups_screen_group_admin_edit_details' );

--- a/src/bp-groups/screens/single/admin/group-avatar.php
+++ b/src/bp-groups/screens/single/admin/group-avatar.php
@@ -14,12 +14,14 @@
  */
 function groups_screen_group_admin_avatar() {
 
-	if ( 'group-avatar' != bp_get_group_current_admin_tab() )
+	if ( 'group-avatar' !== bp_get_group_current_admin_tab() ) {
 		return false;
+	}
 
 	// If the logged-in user doesn't have permission or if avatar uploads are disabled, then stop here.
-	if ( ! bp_is_item_admin() || bp_disable_group_avatar_uploads() || ! buddypress()->avatar->show_avatars )
+	if ( ! bp_is_item_admin() || bp_disable_group_avatar_uploads() || ! buddypress()->avatar->show_avatars ) {
 		return false;
+	}
 
 	$bp = buddypress();
 
@@ -104,13 +106,18 @@ function groups_screen_group_admin_avatar() {
 	 */
 	do_action( 'groups_screen_group_admin_avatar', $bp->groups->current_group->id );
 
-	/**
-	 * Filters the template to load for a group's Change Avatar page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $value Path to a group's Change Avatar template.
-	 */
-	bp_core_load_template( apply_filters( 'groups_template_group_admin_avatar', 'groups/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for a group's Change Avatar page.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $value Path to a group's Change Avatar template.
+		 */
+		apply_filters( 'groups_template_group_admin_avatar', 'groups/single/home' ),
+		'groups/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }
 add_action( 'bp_screens', 'groups_screen_group_admin_avatar' );

--- a/src/bp-groups/screens/single/admin/group-avatar.php
+++ b/src/bp-groups/screens/single/admin/group-avatar.php
@@ -11,16 +11,18 @@
  * Handle the display of a group's Change Avatar page.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function groups_screen_group_admin_avatar() {
 
 	if ( 'group-avatar' !== bp_get_group_current_admin_tab() ) {
-		return false;
+		return;
 	}
 
 	// If the logged-in user doesn't have permission or if avatar uploads are disabled, then stop here.
 	if ( ! bp_is_item_admin() || bp_disable_group_avatar_uploads() || ! buddypress()->avatar->show_avatars ) {
-		return false;
+		return;
 	}
 
 	$bp = buddypress();
@@ -44,7 +46,7 @@ function groups_screen_group_admin_avatar() {
 
 	$bp->avatar_admin->step = 'upload-image';
 
-	if ( !empty( $_FILES ) ) {
+	if ( ! empty( $_FILES ) ) {
 
 		// Check the nonce.
 		check_admin_referer( 'bp_avatar_upload' );

--- a/src/bp-groups/screens/single/admin/group-cover-image.php
+++ b/src/bp-groups/screens/single/admin/group-cover-image.php
@@ -11,15 +11,17 @@
  * Handle the display of a group's Change cover image page.
  *
  * @since 2.4.0
+ *
+ * @return void
  */
 function groups_screen_group_admin_cover_image() {
 	if ( 'group-cover-image' != bp_get_group_current_admin_tab() ) {
-		return false;
+		return;
 	}
 
 	// If the logged-in user doesn't have permission or if cover image uploads are disabled, then stop here.
 	if ( ! bp_is_item_admin() || ! bp_group_use_cover_image_header() ) {
-		return false;
+		return;
 	}
 
 	/**
@@ -31,13 +33,18 @@ function groups_screen_group_admin_cover_image() {
 	 */
 	do_action( 'groups_screen_group_admin_cover_image', bp_get_current_group_id() );
 
-	/**
-	 * Filters the template to load for a group's Change cover image page.
-	 *
-	 * @since 2.4.0
-	 *
-	 * @param string $value Path to a group's Change cover image template.
-	 */
-	bp_core_load_template( apply_filters( 'groups_template_group_admin_cover_image', 'groups/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for a group's Change cover image page.
+		 *
+		 * @since 2.4.0
+		 *
+		 * @param string $value Path to a group's Change cover image template.
+		 */
+		apply_filters( 'groups_template_group_admin_cover_image', 'groups/single/home' ),
+		'groups/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }
 add_action( 'bp_screens', 'groups_screen_group_admin_cover_image' );

--- a/src/bp-groups/screens/single/admin/group-settings.php
+++ b/src/bp-groups/screens/single/admin/group-settings.php
@@ -11,14 +11,18 @@
  * Handle the display of a group's admin/group-settings page.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function groups_screen_group_admin_settings() {
 
-	if ( 'group-settings' != bp_get_group_current_admin_tab() )
-		return false;
+	if ( 'group-settings' !== bp_get_group_current_admin_tab() ) {
+		return;
+	}
 
-	if ( ! bp_is_item_admin() )
-		return false;
+	if ( ! bp_is_item_admin() ) {
+		return;
+	}
 
 	$bp = buddypress();
 
@@ -37,8 +41,9 @@ function groups_screen_group_admin_settings() {
 		$invite_status	       = isset( $_POST['group-invite-status'] ) && in_array( $_POST['group-invite-status'], (array) $allowed_invite_status ) ? $_POST['group-invite-status'] : 'members';
 
 		// Check the nonce.
-		if ( !check_admin_referer( 'groups_edit_group_settings' ) )
-			return false;
+		if ( ! check_admin_referer( 'groups_edit_group_settings' ) ) {
+			return;
+		}
 
 		$group_id = bp_get_current_group_id();
 
@@ -100,13 +105,18 @@ function groups_screen_group_admin_settings() {
 	 */
 	do_action( 'groups_screen_group_admin_settings', $bp->groups->current_group->id );
 
-	/**
-	 * Filters the template to load for a group's admin/group-settings page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $value Path to a group's admin/group-settings template.
-	 */
-	bp_core_load_template( apply_filters( 'groups_template_group_admin_settings', 'groups/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for a group's admin/group-settings page.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $value Path to a group's admin/group-settings template.
+		 */
+		apply_filters( 'groups_template_group_admin_settings', 'groups/single/home' ),
+		'groups/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }
 add_action( 'bp_screens', 'groups_screen_group_admin_settings' );

--- a/src/bp-groups/screens/single/admin/manage-members.php
+++ b/src/bp-groups/screens/single/admin/manage-members.php
@@ -11,15 +11,17 @@
  * This function handles actions related to member management on the group admin.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function groups_screen_group_admin_manage_members() {
 
 	if ( 'manage-members' != bp_get_group_current_admin_tab() ) {
-		return false;
+		return;
 	}
 
 	if ( ! bp_is_item_admin() ) {
-		return false;
+		return;
 	}
 
 	$bp       = buddypress();
@@ -35,7 +37,7 @@ function groups_screen_group_admin_manage_members() {
 
 			// Check the nonce first.
 			if ( ! check_admin_referer( 'groups_promote_member' ) ) {
-				return false;
+				return;
 			}
 
 			// Promote a user.
@@ -65,7 +67,7 @@ function groups_screen_group_admin_manage_members() {
 
 			// Check the nonce first.
 			if ( ! check_admin_referer( 'groups_demote_member' ) ) {
-				return false;
+				return;
 			}
 
 			// Stop sole admins from abandoning their group.
@@ -98,7 +100,7 @@ function groups_screen_group_admin_manage_members() {
 
 			// Check the nonce first.
 			if ( ! check_admin_referer( 'groups_ban_member' ) ) {
-				return false;
+				return;
 			}
 
 			// Ban a user.
@@ -126,7 +128,7 @@ function groups_screen_group_admin_manage_members() {
 
 			// Check the nonce first.
 			if ( ! check_admin_referer( 'groups_unban_member' ) ) {
-				return false;
+				return;
 			}
 
 			// Remove a ban for user.
@@ -154,7 +156,7 @@ function groups_screen_group_admin_manage_members() {
 
 			// Check the nonce first.
 			if ( ! check_admin_referer( 'groups_remove_member' ) ) {
-				return false;
+				return;
 			}
 
 			// Remove a user.
@@ -187,13 +189,18 @@ function groups_screen_group_admin_manage_members() {
 	 */
 	do_action( 'groups_screen_group_admin_manage_members', $bp->groups->current_group->id );
 
-	/**
-	 * Filters the template to load for a group's manage members page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $value Path to a group's manage members template.
-	 */
-	bp_core_load_template( apply_filters( 'groups_template_group_admin_manage_members', 'groups/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for a group's manage members page.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $value Path to a group's manage members template.
+		 */
+		apply_filters( 'groups_template_group_admin_manage_members', 'groups/single/home' ),
+		'groups/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }
 add_action( 'bp_screens', 'groups_screen_group_admin_manage_members' );

--- a/src/bp-groups/screens/single/admin/membership-requests.php
+++ b/src/bp-groups/screens/single/admin/membership-requests.php
@@ -11,16 +11,18 @@
  * Handle the display of Admin > Membership Requests.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function groups_screen_group_admin_requests() {
 	$bp = buddypress();
 
 	if ( 'membership-requests' != bp_get_group_current_admin_tab() ) {
-		return false;
+		return;
 	}
 
-	if ( ! bp_is_item_admin() || ( 'public' == $bp->groups->current_group->status ) ) {
-		return false;
+	if ( ! bp_is_item_admin() || ( 'public' === $bp->groups->current_group->status ) ) {
+		return;
 	}
 
 	$request_action = isset( $_GET['action'] ) ? $_GET['action'] : false;
@@ -32,7 +34,7 @@ function groups_screen_group_admin_requests() {
 
 			// Check the nonce first.
 			if ( ! check_admin_referer( 'groups_accept_membership_request' ) ) {
-				return false;
+				return;
 			}
 
 			// Accept the membership request.
@@ -45,7 +47,7 @@ function groups_screen_group_admin_requests() {
 		} elseif ( 'reject' === $request_action ) {
 			/* Check the nonce first. */
 			if ( ! check_admin_referer( 'groups_reject_membership_request' ) ) {
-				return false;
+				return;
 			}
 
 			// Reject the membership request.
@@ -89,13 +91,18 @@ function groups_screen_group_admin_requests() {
 	 */
 	do_action( 'groups_screen_group_admin_requests', $bp->groups->current_group->id );
 
-	/**
-	 * Filters the template to load for a group's membership request page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $value Path to a group's membership request template.
-	 */
-	bp_core_load_template( apply_filters( 'groups_template_group_admin_requests', 'groups/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for a group's membership request page.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $value Path to a group's membership request template.
+		 */
+		apply_filters( 'groups_template_group_admin_requests', 'groups/single/home' ),
+		'groups/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }
 add_action( 'bp_screens', 'groups_screen_group_admin_requests' );

--- a/src/bp-groups/screens/single/home.php
+++ b/src/bp-groups/screens/single/home.php
@@ -11,11 +11,13 @@
  * Handle the loading of a single group's page.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function groups_screen_group_home() {
 
 	if ( ! bp_is_single_item() ) {
-		return false;
+		return;
 	}
 
 	/**

--- a/src/bp-groups/screens/single/home.php
+++ b/src/bp-groups/screens/single/home.php
@@ -25,12 +25,17 @@ function groups_screen_group_home() {
 	 */
 	do_action( 'groups_screen_group_home' );
 
-	/**
-	 * Filters the template to load for a single group's page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $value Path to a single group's template to load.
-	 */
-	bp_core_load_template( apply_filters( 'groups_template_group_home', 'groups/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for a single group's page.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $value Path to a single group's template to load.
+		 */
+		apply_filters( 'groups_template_group_home', 'groups/single/home' ),
+		'groups/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-groups/screens/single/members.php
+++ b/src/bp-groups/screens/single/members.php
@@ -11,11 +11,13 @@
  * Handle the display of a group's Members page.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function groups_screen_group_members() {
 
 	if ( ! bp_is_single_item() ) {
-		return false;
+		return;
 	}
 
 	$bp = buddypress();

--- a/src/bp-groups/screens/single/members.php
+++ b/src/bp-groups/screens/single/members.php
@@ -29,12 +29,17 @@ function groups_screen_group_members() {
 	 */
 	do_action( 'groups_screen_group_members', $bp->groups->current_group->id );
 
-	/**
-	 * Filters the template to load for a group's Members page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $value Path to a group's Members template.
-	 */
-	bp_core_load_template( apply_filters( 'groups_template_group_members', 'groups/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for a group's Members page.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $value Path to a group's Members template.
+		 */
+		apply_filters( 'groups_template_group_members', 'groups/single/home' ),
+		'groups/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-groups/screens/single/request-membership.php
+++ b/src/bp-groups/screens/single/request-membership.php
@@ -11,17 +11,19 @@
  * Handle the display of a group's Request Membership page.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function groups_screen_group_request_membership() {
 
 	if ( ! is_user_logged_in() ) {
-		return false;
+		return;
 	}
 
 	$bp = buddypress();
 
 	if ( 'private' != $bp->groups->current_group->status ) {
-		return false;
+		return;
 	}
 
 	// If the user is already invited, accept invitation.
@@ -40,7 +42,7 @@ function groups_screen_group_request_membership() {
 
 		// Check the nonce.
 		if ( ! check_admin_referer( 'groups_request_membership' ) ) {
-			return false;
+			return;
 		}
 
 		// Default arguments for the membership request.
@@ -59,6 +61,7 @@ function groups_screen_group_request_membership() {
 		} else {
 			bp_core_add_message( __( 'Your membership request was sent to the group administrator successfully. You will be notified when the group administrator responds to your request.', 'buddypress' ) );
 		}
+
 		bp_core_redirect( bp_get_group_url( $bp->groups->current_group ) );
 	}
 

--- a/src/bp-groups/screens/single/request-membership.php
+++ b/src/bp-groups/screens/single/request-membership.php
@@ -71,12 +71,17 @@ function groups_screen_group_request_membership() {
 	 */
 	do_action( 'groups_screen_group_request_membership', $bp->groups->current_group->id );
 
-	/**
-	 * Filters the template to load for a group's Request Membership page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $value Path to a group's Request Membership template.
-	 */
-	bp_core_load_template( apply_filters( 'groups_template_group_request_membership', 'groups/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for a group's Request Membership page.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $value Path to a group's Request Membership template.
+		 */
+		apply_filters( 'groups_template_group_request_membership', 'groups/single/home' ),
+		'groups/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-groups/screens/single/send-invites.php
+++ b/src/bp-groups/screens/single/send-invites.php
@@ -11,11 +11,13 @@
  * Handle the display of a group's Send Invites page.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function groups_screen_group_invite() {
 
 	if ( ! bp_is_single_item() ) {
-		return false;
+		return;
 	}
 
 	$bp = buddypress();
@@ -23,7 +25,7 @@ function groups_screen_group_invite() {
 	if ( bp_is_action_variable( 'send', 0 ) ) {
 
 		if ( ! check_admin_referer( 'groups_send_invites', '_wpnonce_send_invites' ) ) {
-			return false;
+			return;
 		}
 
 		if ( ! empty( $_POST['friends'] ) ) {
@@ -74,6 +76,8 @@ function groups_screen_group_invite() {
  * Remove Invite removes the invitation via AJAX.
  *
  * @since 2.0.0
+ *
+ * @return void
  */
 function groups_remove_group_invite() {
 	if ( ! bp_is_group_invites() ) {
@@ -85,7 +89,7 @@ function groups_remove_group_invite() {
 	}
 
 	if ( ! check_admin_referer( 'groups_invite_uninvite_user' ) ) {
-		return false;
+		return;
 	}
 
 	$friend_id = intval( bp_action_variable( 1 ) );

--- a/src/bp-groups/screens/single/send-invites.php
+++ b/src/bp-groups/screens/single/send-invites.php
@@ -14,17 +14,19 @@
  */
 function groups_screen_group_invite() {
 
-	if ( !bp_is_single_item() )
+	if ( ! bp_is_single_item() ) {
 		return false;
+	}
 
 	$bp = buddypress();
 
 	if ( bp_is_action_variable( 'send', 0 ) ) {
 
-		if ( !check_admin_referer( 'groups_send_invites', '_wpnonce_send_invites' ) )
+		if ( ! check_admin_referer( 'groups_send_invites', '_wpnonce_send_invites' ) ) {
 			return false;
+		}
 
-		if ( !empty( $_POST['friends'] ) ) {
+		if ( ! empty( $_POST['friends'] ) ) {
 			foreach( (array) $_POST['friends'] as $friend ) {
 				groups_invite_user( array( 'user_id' => $friend, 'group_id' => $bp->groups->current_group->id ) );
 			}
@@ -44,16 +46,21 @@ function groups_screen_group_invite() {
 		do_action( 'groups_screen_group_invite', $bp->groups->current_group->id );
 		bp_core_redirect( bp_get_group_url( $bp->groups->current_group ) );
 
-	} elseif ( !bp_action_variable( 0 ) ) {
+	} elseif ( ! bp_action_variable( 0 ) ) {
 
-		/**
-		 * Filters the template to load for a group's Send Invites page.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param string $value Path to a group's Send Invites template.
-		 */
-		bp_core_load_template( apply_filters( 'groups_template_group_invite', 'groups/single/home' ) );
+		$templates = array(
+			/**
+			 * Filters the template to load for a group's Send Invites page.
+			 *
+			 * @since 1.0.0
+			 *
+			 * @param string $value Path to a group's Send Invites template.
+			 */
+			apply_filters( 'groups_template_group_invite', 'groups/single/home' ),
+			'groups/single/index',
+		);
+
+		bp_core_load_template( $templates );
 
 	} else {
 		bp_do_404();

--- a/src/bp-groups/screens/user/invites.php
+++ b/src/bp-groups/screens/user/invites.php
@@ -11,6 +11,8 @@
  * Handle the loading of a user's Groups > Invites page.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function groups_screen_group_invites() {
 	$group_id = (int) bp_action_variable( 1 );
@@ -18,7 +20,7 @@ function groups_screen_group_invites() {
 	if ( bp_is_action_variable( 'accept' ) && is_numeric( $group_id ) ) {
 		// Check the nonce.
 		if ( ! check_admin_referer( 'groups_accept_invite' ) ) {
-			return false;
+			return;
 		}
 
 		if ( ! groups_accept_invite( bp_displayed_user_id(), $group_id ) ) {
@@ -49,8 +51,8 @@ function groups_screen_group_invites() {
 
 	} elseif ( bp_is_action_variable( 'reject' ) && is_numeric( $group_id ) ) {
 		// Check the nonce.
-		if ( !check_admin_referer( 'groups_reject_invite' ) )
-			return false;
+		if ( ! check_admin_referer( 'groups_reject_invite' ) )
+			return;
 
 		if ( ! groups_reject_invite( bp_displayed_user_id(), $group_id ) ) {
 			bp_core_add_message( __( 'Group invite could not be rejected', 'buddypress' ), 'error' );
@@ -77,12 +79,17 @@ function groups_screen_group_invites() {
 	 */
 	do_action( 'groups_screen_group_invites', $group_id );
 
-	/**
-	 * Filters the template to load for a users Groups > Invites page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $value Path to a users Groups > Invites page template.
-	 */
-	bp_core_load_template( apply_filters( 'groups_template_group_invites', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for a users Groups > Invites page.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $value Path to a users Groups > Invites page template.
+		 */
+		apply_filters( 'groups_template_group_invites', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-groups/screens/user/my-groups.php
+++ b/src/bp-groups/screens/user/my-groups.php
@@ -21,12 +21,17 @@ function groups_screen_my_groups() {
 	 */
 	do_action( 'groups_screen_my_groups' );
 
-	/**
-	 * Filters the template to load for the My Groups page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $value Path to the My Groups page template to load.
-	 */
-	bp_core_load_template( apply_filters( 'groups_template_my_groups', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the My Groups page.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $value Path to the My Groups page template to load.
+		 */
+		apply_filters( 'groups_template_my_groups', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-members/screens/activate.php
+++ b/src/bp-members/screens/activate.php
@@ -11,12 +11,14 @@
  * Handle the loading of the Activate screen.
  *
  * @since 1.1.0
+ *
+ * @return void
  */
 function bp_core_screen_activation() {
 
 	// Bail if not viewing the activation page.
 	if ( ! bp_is_current_component( 'activate' ) ) {
-		return false;
+		return;
 	}
 
 	// If the user is already logged in, redirect away from here.
@@ -52,9 +54,12 @@ function bp_core_screen_activation() {
 	 *
 	 * @since 1.1.1
 	 *
-	 * @param string $value Path to the Member activation template to load.
+	 * @param string[] $value Path to the list of Member activation template to load.
 	 */
-	bp_core_load_template( apply_filters( 'bp_core_template_activate', array( 'activate', 'registration/activate' ) ) );
+	$templates   = apply_filters( 'bp_core_template_activate', array( 'activate', 'registration/activate' ) );
+	$templates[] = 'members/activate';
+
+	bp_core_load_template( $templates );
 }
 add_action( 'bp_screens', 'bp_core_screen_activation' );
 

--- a/src/bp-members/screens/change-avatar.php
+++ b/src/bp-members/screens/change-avatar.php
@@ -11,11 +11,13 @@
  * Handle the display of the profile Change Avatar page by loading the correct template file.
  *
  * @since 6.0.0
+ *
+ * @return void
  */
 function bp_members_screen_change_avatar() {
 	// Bail if not the correct screen.
 	if ( ! bp_is_my_profile() && ! bp_current_user_can( 'bp_moderate' ) ) {
-		return false;
+		return;
 	}
 
 	// Bail if there are action variables.
@@ -32,7 +34,7 @@ function bp_members_screen_change_avatar() {
 
 	$bp->avatar_admin->step = 'upload-image';
 
-	if ( !empty( $_FILES ) ) {
+	if ( ! empty( $_FILES ) ) {
 
 		// Check the nonce.
 		check_admin_referer( 'bp_avatar_upload' );
@@ -99,15 +101,18 @@ function bp_members_screen_change_avatar() {
 	 */
 	do_action( 'bp_members_screen_change_avatar' );
 
-	/** This filter is documented in wp-includes/deprecated.php */
-	$template = apply_filters_deprecated( 'xprofile_template_change_avatar', array( 'members/single/home' ), '6.0.0', 'bp_members_template_change_avatar' );
+	$templates = array(
+		/** This filter is documented in wp-includes/deprecated.php */
+		apply_filters_deprecated( 'xprofile_template_change_avatar', array( 'members/single/home' ), '6.0.0', 'bp_members_template_change_avatar' ),
+		'members/single/index'
+	);
 
 	/**
 	 * Filters the template to load for the Member Change Avatar page screen.
 	 *
 	 * @since 6.0.0
 	 *
-	 * @param string $template Path to the Member template to load.
+	 * @param string[] $templates Path to the Member templates to load.
 	 */
-	bp_core_load_template( apply_filters( 'bp_members_template_change_avatar', $template ) );
+	bp_core_load_template( apply_filters( 'bp_members_template_change_avatar', $templates ) );
 }

--- a/src/bp-members/screens/change-cover-image.php
+++ b/src/bp-members/screens/change-cover-image.php
@@ -28,15 +28,18 @@ function bp_members_screen_change_cover_image() {
 	 */
 	do_action( 'bp_members_screen_change_cover_image' );
 
-	/** This filter is documented in wp-includes/deprecated.php */
-	$template = apply_filters_deprecated( 'xprofile_template_cover_image', array( 'members/single/home' ), '6.0.0', 'bp_members_template_change_cover_image' );
+	$templates = array(
+		/** This filter is documented in wp-includes/deprecated.php */
+		apply_filters_deprecated( 'xprofile_template_cover_image', array( 'members/single/home' ), '6.0.0', 'bp_members_template_change_cover_image' ),
+		'members/single/index',
+	);
 
 	/**
 	 * Filters the template to load for the Member Change Cover Image page screen.
 	 *
 	 * @since 6.0.0
 	 *
-	 * @param string $template Path to the Member template to load.
+	 * @param string[] $templates Path to the list of Member templates to load.
 	 */
-	bp_core_load_template( apply_filters( 'bp_members_template_change_cover_image', $template ) );
+	bp_core_load_template( apply_filters( 'bp_members_template_change_cover_image', $templates ) );
 }

--- a/src/bp-members/screens/invitations.php
+++ b/src/bp-members/screens/invitations.php
@@ -51,14 +51,19 @@ function members_screen_send_invites() {
 	 */
 	do_action( 'members_screen_send_invites' );
 
-	/**
-	 * Filters the template used to display the send membership invitations page.
-	 *
-	 * @since 8.0.0
-	 *
-	 * @param string $template Path to the send membership invitations template to load.
-	 */
-	bp_core_load_template( apply_filters( 'members_template_send_invites', 'members/single/invitations' ) );
+	$templates = array(
+		/**
+		 * Filters the template used to display the send membership invitations page.
+		 *
+		 * @since 8.0.0
+		 *
+		 * @param string $template Path to the send membership invitations template to load.
+		 */
+		apply_filters( 'members_template_send_invites', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }
 
 /**
@@ -112,12 +117,17 @@ function members_screen_list_sent_invites() {
 	 */
 	do_action( 'members_screen_list_sent_invites' );
 
-	/**
-	 * Filters the template used to display the send membership invitations page.
-	 *
-	 * @since 8.0.0
-	 *
-	 * @param string $template Path to the send membership invitations template to load.
-	 */
-	bp_core_load_template( apply_filters( 'members_template_list_sent_invites', 'members/single/invitations' ) );
+	$templates = array(
+		/**
+		 * Filters the template used to display the send membership invitations page.
+		 *
+		 * @since 8.0.0
+		 *
+		 * @param string $template Path to the send membership invitations template to load.
+		 */
+		apply_filters( 'members_template_list_sent_invites', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-members/screens/profile.php
+++ b/src/bp-members/screens/profile.php
@@ -21,12 +21,17 @@ function bp_members_screen_display_profile() {
 	 */
 	do_action( 'bp_members_screen_display_profile' );
 
-	/**
-	 * Filters the template to load for the Member profile page screen.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $template Path to the Member template to load.
-	 */
-	bp_core_load_template( apply_filters( 'bp_members_screen_display_profile', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the Member profile page screen.
+		 *
+		 * @since 1.5.0
+		 *
+		 * @param string $template Path to the Member template to load.
+		 */
+		apply_filters( 'bp_members_screen_display_profile', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-members/screens/register.php
+++ b/src/bp-members/screens/register.php
@@ -292,8 +292,11 @@ function bp_core_screen_signup() {
 	 *
 	 * @since 1.5.0
 	 *
-	 * @param string $value Path to the Member registration template to load.
+	 * @param string[] $value Path to the list of Member registration templates to load.
 	 */
-	bp_core_load_template( apply_filters( 'bp_core_template_register', array( 'register', 'registration/register' ) ) );
+	$templates   = apply_filters( 'bp_core_template_register', array( 'register', 'registration/register' ) );
+	$templates[] = 'members/register';
+
+	bp_core_load_template( $templates );
 }
 add_action( 'bp_screens', 'bp_core_screen_signup' );

--- a/src/bp-messages/screens/compose.php
+++ b/src/bp-messages/screens/compose.php
@@ -11,6 +11,8 @@
  * Load the Messages > Compose screen.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function messages_screen_compose() {
 
@@ -29,12 +31,17 @@ function messages_screen_compose() {
 	 */
 	do_action( 'messages_screen_compose' );
 
-	/**
-	 * Filters the template to load for the Messages compose screen.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $template Path to the messages template to load.
-	 */
-	bp_core_load_template( apply_filters( 'messages_template_compose', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the Messages compose screen.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $template Path to the messages template to load.
+		 */
+		apply_filters( 'messages_template_compose', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-messages/screens/inbox.php
+++ b/src/bp-messages/screens/inbox.php
@@ -11,6 +11,8 @@
  * Load the Messages > Inbox screen.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function messages_screen_inbox() {
 
@@ -26,12 +28,17 @@ function messages_screen_inbox() {
 	 */
 	do_action( 'messages_screen_inbox' );
 
-	/**
-	 * Filters the template to load for the Messages inbox screen.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $template Path to the messages template to load.
-	 */
-	bp_core_load_template( apply_filters( 'messages_template_inbox', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the Messages inbox screen.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $template Path to the messages template to load.
+		 */
+		apply_filters( 'messages_template_inbox', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-messages/screens/notices.php
+++ b/src/bp-messages/screens/notices.php
@@ -11,6 +11,8 @@
  * Load the Messages > Notices screen.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function messages_screen_notices() {
 
@@ -26,12 +28,17 @@ function messages_screen_notices() {
 	 */
 	do_action( 'messages_screen_notices' );
 
-	/**
-	 * Filters the template to load for the Messages notices screen.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $template Path to the messages template to load.
-	 */
-	bp_core_load_template( apply_filters( 'messages_template_notices', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the Messages notices screen.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $template Path to the messages template to load.
+		 */
+		apply_filters( 'messages_template_notices', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-messages/screens/sentbox.php
+++ b/src/bp-messages/screens/sentbox.php
@@ -11,6 +11,8 @@
  * Load the Messages > Sent screen.
  *
  * @since 1.0.0
+ *
+ * @return void
  */
 function messages_screen_sentbox() {
 
@@ -26,12 +28,17 @@ function messages_screen_sentbox() {
 	 */
 	do_action( 'messages_screen_sentbox' );
 
-	/**
-	 * Filters the template to load for the Messages sentbox screen.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $template Path to the messages template to load.
-	 */
-	bp_core_load_template( apply_filters( 'messages_template_sentbox', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the Messages sentbox screen.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $template Path to the messages template to load.
+		 */
+		apply_filters( 'messages_template_sentbox', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-messages/screens/view.php
+++ b/src/bp-messages/screens/view.php
@@ -12,13 +12,13 @@
  *
  * @since 1.0.0
  *
- * @return bool False on failure.
+ * @return void.
  */
 function messages_screen_conversation() {
 
 	// Bail if not viewing a single message.
 	if ( ! bp_is_messages_component() || ! bp_is_current_action( 'view' ) ) {
-		return false;
+		return;
 	}
 
 	$thread_id = (int) bp_action_variable( 0 );
@@ -61,9 +61,12 @@ function messages_screen_conversation() {
 	$nav_name = sprintf( __( 'Messages <span class="%1$s">%2$s</span>', 'buddypress' ), esc_attr( $class ), bp_core_number_format( $count ) );
 
 	// Edit the Navigation name.
-	$bp->members->nav->edit_nav( array(
-		'name' => $nav_name,
-	), $bp->messages->slug );
+	$bp->members->nav->edit_nav(
+		array(
+			'name' => $nav_name,
+		),
+		$bp->messages->slug
+	);
 
 	/**
 	 * Fires right before the loading of the Messages view screen template file.
@@ -72,13 +75,18 @@ function messages_screen_conversation() {
 	 */
 	do_action( 'messages_screen_conversation' );
 
-	/**
-	 * Filters the template to load for the Messages view screen.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $template Path to the messages template to load.
-	 */
-	bp_core_load_template( apply_filters( 'messages_template_view_message', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the Messages view screen.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $template Path to the messages template to load.
+		 */
+		apply_filters( 'messages_template_view_message', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }
 add_action( 'bp_screens', 'messages_screen_conversation' );

--- a/src/bp-notifications/screens/read.php
+++ b/src/bp-notifications/screens/read.php
@@ -21,14 +21,19 @@ function bp_notifications_screen_read() {
 	 */
 	do_action( 'bp_notifications_screen_read' );
 
-	/**
-	 * Filters the template to load for the notifications read screen.
-	 *
-	 * @since 1.9.0
-	 *
-	 * @param string $template Path to the notifications read template to load.
-	 */
-	bp_core_load_template( apply_filters( 'bp_notifications_template_read', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the notifications read screen.
+		 *
+		 * @since 1.9.0
+		 *
+		 * @param string $template Path to the notifications read template to load.
+		 */
+		apply_filters( 'bp_notifications_template_read', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }
 
 /**
@@ -36,23 +41,23 @@ function bp_notifications_screen_read() {
  *
  * @since 1.9.0
  *
- * @return bool
+ * @return void
  */
 function bp_notifications_action_mark_unread() {
 
 	// Bail if not the read screen.
 	if ( ! bp_is_notifications_component() || ! bp_is_current_action( 'read' ) ) {
-		return false;
+		return;
 	}
 
 	// Get the action.
-	$action = !empty( $_GET['action']          ) ? $_GET['action']          : '';
-	$nonce  = !empty( $_GET['_wpnonce']        ) ? $_GET['_wpnonce']        : '';
-	$id     = !empty( $_GET['notification_id'] ) ? $_GET['notification_id'] : '';
+	$action = ! empty( $_GET['action']          ) ? $_GET['action']          : '';
+	$nonce  = ! empty( $_GET['_wpnonce']        ) ? $_GET['_wpnonce']        : '';
+	$id     = ! empty( $_GET['notification_id'] ) ? $_GET['notification_id'] : '';
 
 	// Bail if no action or no ID.
 	if ( ( 'unread' !== $action ) || empty( $id ) || empty( $nonce ) ) {
-		return false;
+		return;
 	}
 
 	// Check the nonce and mark the notification.

--- a/src/bp-notifications/screens/unread.php
+++ b/src/bp-notifications/screens/unread.php
@@ -21,14 +21,19 @@ function bp_notifications_screen_unread() {
 	 */
 	do_action( 'bp_notifications_screen_unread' );
 
-	/**
-	 * Filters the template to load for the notifications unread screen.
-	 *
-	 * @since 1.9.0
-	 *
-	 * @param string $template Path to the notifications unread template to load.
-	 */
-	bp_core_load_template( apply_filters( 'bp_notifications_template_unread', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the notifications unread screen.
+		 *
+		 * @since 1.9.0
+		 *
+		 * @param string $template Path to the notifications unread template to load.
+		 */
+		apply_filters( 'bp_notifications_template_unread', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }
 
 /**
@@ -36,23 +41,23 @@ function bp_notifications_screen_unread() {
  *
  * @since 1.9.0
  *
- * @return bool
+ * @return void
  */
 function bp_notifications_action_mark_read() {
 
 	// Bail if not the unread screen.
 	if ( ! bp_is_notifications_component() || ! bp_is_current_action( 'unread' ) ) {
-		return false;
+		return;
 	}
 
 	// Get the action.
-	$action = !empty( $_GET['action']          ) ? $_GET['action']          : '';
-	$nonce  = !empty( $_GET['_wpnonce']        ) ? $_GET['_wpnonce']        : '';
-	$id     = !empty( $_GET['notification_id'] ) ? $_GET['notification_id'] : '';
+	$action = ! empty( $_GET['action']          ) ? $_GET['action']          : '';
+	$nonce  = ! empty( $_GET['_wpnonce']        ) ? $_GET['_wpnonce']        : '';
+	$id     = ! empty( $_GET['notification_id'] ) ? $_GET['notification_id'] : '';
 
 	// Bail if no action or no ID.
 	if ( ( 'read' !== $action ) || empty( $id ) || empty( $nonce ) ) {
-		return false;
+		return;
 	}
 
 	// Check the nonce and mark the notification.

--- a/src/bp-settings/screens/capabilities.php
+++ b/src/bp-settings/screens/capabilities.php
@@ -11,6 +11,8 @@
  * Show the capabilities settings template.
  *
  * @since 1.6.0
+ *
+ * @return void
  */
 function bp_settings_screen_capabilities() {
 
@@ -19,12 +21,17 @@ function bp_settings_screen_capabilities() {
 		return;
 	}
 
-	/**
-	 * Filters the template file path to use for the capabilities settings screen.
-	 *
-	 * @since 1.6.0
-	 *
-	 * @param string $value Directory path to look in for the template file.
-	 */
-	bp_core_load_template( apply_filters( 'bp_settings_screen_capabilities', 'members/single/settings/capabilities' ) );
+	$templates = array(
+		/**
+		 * Filters the template file path to use for the capabilities settings screen.
+		 *
+		 * @since 1.6.0
+		 *
+		 * @param string $value Directory path to look in for the template file.
+		 */
+		apply_filters( 'bp_settings_screen_capabilities', 'members/single/settings/capabilities' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-settings/screens/data.php
+++ b/src/bp-settings/screens/data.php
@@ -11,6 +11,8 @@
  * Show the data settings template.
  *
  * @since 4.0.0
+ *
+ * @return void
  */
 function bp_settings_screen_data() {
 
@@ -19,12 +21,17 @@ function bp_settings_screen_data() {
 		return;
 	}
 
-	/**
-	 * Filters the template file path to use for the data settings screen.
-	 *
-	 * @since 4.0.0
-	 *
-	 * @param string $value Directory path to look in for the template file.
-	 */
-	bp_core_load_template( apply_filters( 'bp_settings_screen_data', 'members/single/settings/data' ) );
+	$templates = array(
+		/**
+		 * Filters the template file path to use for the data settings screen.
+		 *
+		 * @since 4.0.0
+		 *
+		 * @param string $value Directory path to look in for the template file.
+		 */
+		apply_filters( 'bp_settings_screen_data', 'members/single/settings/data' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-settings/screens/delete-account.php
+++ b/src/bp-settings/screens/delete-account.php
@@ -11,6 +11,8 @@
  * Show the delete-account settings template.
  *
  * @since 1.5.0
+ *
+ * @return void
  */
 function bp_settings_screen_delete_account() {
 
@@ -19,12 +21,17 @@ function bp_settings_screen_delete_account() {
 		return;
 	}
 
-	/**
-	 * Filters the template file path to use for the delete-account settings screen.
-	 *
-	 * @since 1.6.0
-	 *
-	 * @param string $value Directory path to look in for the template file.
-	 */
-	bp_core_load_template( apply_filters( 'bp_settings_screen_delete_account', 'members/single/settings/delete-account' ) );
+	$templates = array(
+		/**
+		 * Filters the template file path to use for the delete-account settings screen.
+		 *
+		 * @since 1.6.0
+		 *
+		 * @param string $value Directory path to look in for the template file.
+		 */
+		apply_filters( 'bp_settings_screen_delete_account', 'members/single/settings/delete-account' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-settings/screens/general.php
+++ b/src/bp-settings/screens/general.php
@@ -19,14 +19,20 @@ function bp_settings_screen_general() {
 		return;
 	}
 
-	/**
-	 * Filters the template file path to use for the general settings screen.
-	 *
-	 * @since 1.6.0
-	 *
-	 * @param string $value Directory path to look in for the template file.
-	 */
-	bp_core_load_template( apply_filters( 'bp_settings_screen_general_settings', 'members/single/settings/general' ) );
+	$templates = array(
+		/**
+		 * Filters the template file path to use for the general settings screen.
+		 *
+		 * @since 1.6.0
+		 *
+		 * @param string $template Directory path to look in for the template file.
+		 */
+		apply_filters( 'bp_settings_screen_general_settings', 'members/single/settings/general' ),
+		'members/single/index',
+	);
+
+
+	bp_core_load_template( $templates );
 }
 
 /**

--- a/src/bp-settings/screens/general.php
+++ b/src/bp-settings/screens/general.php
@@ -11,6 +11,8 @@
  * Show the general settings template.
  *
  * @since 1.5.0
+ *
+ * @return void
  */
 function bp_settings_screen_general() {
 

--- a/src/bp-settings/screens/notifications.php
+++ b/src/bp-settings/screens/notifications.php
@@ -11,6 +11,8 @@
  * Show the notifications settings template.
  *
  * @since 1.5.0
+ *
+ * @return void
  */
 function bp_settings_screen_notification() {
 
@@ -19,12 +21,17 @@ function bp_settings_screen_notification() {
 		return;
 	}
 
-	/**
-	 * Filters the template file path to use for the notification settings screen.
-	 *
-	 * @since 1.6.0
-	 *
-	 * @param string $value Directory path to look in for the template file.
-	 */
-	bp_core_load_template( apply_filters( 'bp_settings_screen_notification_settings', 'members/single/settings/notifications' ) );
+	$templates = array(
+		/**
+		 * Filters the template file path to use for the notification settings screen.
+		 *
+		 * @since 1.6.0
+		 *
+		 * @param string $value Directory path to look in for the template file.
+		 */
+		apply_filters( 'bp_settings_screen_notification_settings', 'members/single/settings/notifications' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-xprofile/screens/edit.php
+++ b/src/bp-xprofile/screens/edit.php
@@ -13,11 +13,12 @@
  *
  * @since 1.0.0
  *
+ * @return void
  */
 function xprofile_screen_edit_profile() {
 
 	if ( ! bp_is_my_profile() && ! bp_current_user_can( 'bp_moderate' ) ) {
-		return false;
+		return;
 	}
 
 	// Make sure a group is set.
@@ -171,12 +172,17 @@ function xprofile_screen_edit_profile() {
 	 */
 	do_action( 'xprofile_screen_edit_profile' );
 
-	/**
-	 * Filters the template to load for the XProfile edit screen.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $template Path to the XProfile edit template to load.
-	 */
-	bp_core_load_template( apply_filters( 'xprofile_template_edit_profile', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the XProfile edit screen.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $template Path to the XProfile edit template to load.
+		 */
+		apply_filters( 'xprofile_template_edit_profile', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-xprofile/screens/public.php
+++ b/src/bp-xprofile/screens/public.php
@@ -25,12 +25,17 @@ function xprofile_screen_display_profile() {
 	 */
 	do_action( 'xprofile_screen_display_profile', $new );
 
-	/**
-	 * Filters the template to load for the XProfile screen.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $template Path to the XProfile template to load.
-	 */
-	bp_core_load_template( apply_filters( 'xprofile_template_display_profile', 'members/single/home' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the XProfile screen.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $template Path to the XProfile template to load.
+		 */
+		apply_filters( 'xprofile_template_display_profile', 'members/single/home' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }

--- a/src/bp-xprofile/screens/settings-profile.php
+++ b/src/bp-xprofile/screens/settings-profile.php
@@ -11,6 +11,8 @@
  * Show the xprofile settings template.
  *
  * @since 2.0.0
+ *
+ * @return void
  */
 function bp_xprofile_screen_settings() {
 
@@ -20,20 +22,27 @@ function bp_xprofile_screen_settings() {
 		return;
 	}
 
-	/**
-	 * Filters the template to load for the XProfile settings screen.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param string $template Path to the XProfile change avatar template to load.
-	 */
-	bp_core_load_template( apply_filters( 'bp_settings_screen_xprofile', '/members/single/settings/profile' ) );
+	$templates = array(
+		/**
+		 * Filters the template to load for the XProfile settings screen.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param string $template Path to the XProfile change avatar template to load.
+		 */
+		apply_filters( 'bp_settings_screen_xprofile', '/members/single/settings/profile' ),
+		'members/single/index',
+	);
+
+	bp_core_load_template( $templates );
 }
 
 /**
  * Handles the saving of xprofile field visibilities.
  *
  * @since 1.9.0
+ *
+ * @return void
  */
 function bp_xprofile_action_settings() {
 


### PR DESCRIPTION
Make the BP Block themes template hierarchy more inline with BP Template packs one as well as with WP Block Themes (using `index.html` instead of `home.html`. See https://github.com/buddypress/buddyvibes/pull/7.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9118

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
