### PR TITLE
Allow regular WP child pages to use BP Directory slugs

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -968,12 +968,14 @@ function bp_core_get_directory_page_default_titles() {
  * @param string $original_slug The original post slug.
  */
 function bp_core_set_unique_directory_page_slug( $slug = '', $post_ID = 0, $post_status = '', $post_type = '', $post_parent = 0, $original_slug = '' ) {
-	if ( ( 'buddypress' === $post_type || 'page' === $post_type ) && $slug === $original_slug ) {
+	if ( ( 'buddypress' === $post_type || 'page' === $post_type ) && $slug === $original_slug && ! $post_parent ) {
 		$pages = get_posts(
 			array(
 				'post__not_in' => array( $post_ID ),
 				'post_status'  => bp_core_get_directory_pages_stati(),
 				'post_type'    => array( 'buddypress', 'page' ),
+				'post_parent'  => 0,     // Only get a top level page.
+				'name'         => $slug, // Only get the same name page.
 			)
 		);
 


### PR DESCRIPTION
This PR also improves how Slug check is performed only requesting for pages / BuddyPress directories potentially having the same `post_name` and not being a child of another item.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9086

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
