### PR TITLE
Remove the tool to repair the last active members

### DIFF
--- a/src/bp-core/admin/bp-core-admin-tools.php
+++ b/src/bp-core/admin/bp-core-admin-tools.php
@@ -112,12 +112,6 @@ function bp_admin_repair_list() {
 		'bp_admin_repair_count_members',
 	);
 
-	$repair_list[25] = array(
-		'bp-last-activity',
-		__( 'Repair member "last activity" data.', 'buddypress' ),
-		'bp_admin_repair_last_activity',
-	);
-
 	// Friends:
 	// - user friend count.
 	if ( bp_is_active( 'friends' ) ) {
@@ -470,20 +464,6 @@ function bp_admin_repair_count_members() {
 	$statement = __( 'Counting the number of active members on the site&hellip; %s', 'buddypress' );
 	delete_transient( 'bp_active_member_count' );
 	bp_core_get_active_member_count();
-	return array( 0, sprintf( $statement, __( 'Complete!', 'buddypress' ) ) );
-}
-
-/**
- * Repair user last_activity data.
- *
- * Re-runs the migration from usermeta introduced in BP 2.0.
- *
- * @since 2.0.0
- */
-function bp_admin_repair_last_activity() {
-	/* translators: %s: the result of the action performed by the repair tool */
-	$statement = __( 'Determining last activity dates for each user&hellip; %s', 'buddypress' );
-	bp_last_activity_migrate();
 	return array( 0, sprintf( $statement, __( 'Complete!', 'buddypress' ) ) );
 }
 

--- a/src/bp-core/deprecated/12.0.php
+++ b/src/bp-core/deprecated/12.0.php
@@ -1620,3 +1620,16 @@ function bp_core_get_all_posts_for_user( $user_id = 0 ) {
 
 	return apply_filters( 'bp_core_get_all_posts_for_user', array( $all_posts ), '12.0.0' );
 }
+
+/**
+ * Repair user last_activity data.
+ *
+ * Re-runs the migration from usermeta introduced in BP 2.0.
+ *
+ * @since 2.0.0
+ * @deprecated 12.4.0
+ */
+function bp_admin_repair_last_activity() {
+	_deprecated_function( __FUNCTION__, '12.4.0' );
+	return array();
+}


### PR DESCRIPTION
This tool was designed to be used in case a `last_activity` user meta migration went wrong during 2.0.0 uprade process. Since this version we stopped using this user meta in favor of a logging "hidden" activity entry.

As `bp_admin_repair_last_activity()` now only remove all trace of last active members without regenarating it. We are deprecating and stop using this function.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9096

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
