### PR TITLE
Update commit access doc & migrate it to Contributor Handbook

### DIFF
--- a/docs/contributor/manifest.json
+++ b/docs/contributor/manifest.json
@@ -18,6 +18,12 @@
 		"parent": null
 	},
 	{
+		"title": "BuddyPress commit access",
+		"slug": "commit-access",
+		"markdown_source": "../contributor/project/commit-access.md",
+		"parent": null
+	},
+	{
 		"title": "How a release cycle works?",
 		"slug": "about-release",
 		"markdown_source": "../contributor/project/release/README.md",

--- a/docs/contributor/project/README.md
+++ b/docs/contributor/project/README.md
@@ -2,5 +2,5 @@
 
 - Project organization
 - [Release cycle](./release/README.md)
-- Commit access
+- [Commit access](./commit-access.md)
 - [Version Numbering](./version-numbering.md)

--- a/docs/contributor/project/commit-access.md
+++ b/docs/contributor/project/commit-access.md
@@ -1,0 +1,21 @@
+# BuddyPress commit access
+
+## What is commit access?
+
+The code that comprises BuddyPress is written by volunteers. Anyone who wants to suggest an improvement or a bugfix to the BP codebase is welcome to do so, by submitting their proposed changes to our [Trac site](https://buddypress.trac.wordpress.org/) or pulling a request from our [GitHub repository](https://github.com/buddypress/buddypress).
+
+The ability to add patches directly to BuddyPress is limited to those with commit access to the [BP Subversion repository](https://buddypress.svn.wordpress.org/). Committers are individuals who have demonstrated, through ongoing contribution to the codebase and the BuddyPress community, a deep understanding of the codebase as well as the project ethos.
+
+## What is the role of a committer?
+
+The primary duty of a committer is to assist community members with their code contributions to the project, through code review, technical consultation, and committing patches. When reviewing contributions, a number of different kinds of considerations should be weighed. First, the technical merits of a proposed change: performance, security, architectural and stylistic coherence with the rest of the codebase, etc. Just as important are the strategic and philosophical appropriateness of a contribution – whether it moves us closer to project goals, and so forth.
+
+The BP project is proud of its collaborative nature. Most large architectural decisions in BuddyPress are made by rough consensus, and peer code review is an important part of the project culture. However, committers have the right to make final decisions about most issues: commit access means that you don’t need permission to make changes to BuddyPress. In cases where committers cannot come to consensus about technical decisions, the lead developers may serve as tiebreakers.
+
+## How are committers chosen?
+
+Individuals may be nominated for guest commit access by any current committer. Nominations are reviewed by existing committers, with lead developers serving as the final decision makers. Guest committers may be offered permanent commit status at the discretion of the team.
+
+## Current committers
+
+The following contributors have commit access to BuddyPress: [John James Jacoby](https://profiles.wordpress.org/johnjamesjacoby/), [Paul Gibbs](https://profiles.wordpress.org/djpaul/), [Boone Gorges](https://profiles.wordpress.org/boonebgorges/), [r-a-y](https://profiles.wordpress.org/r-a-y/), [Mathieu Viet](https://profiles.wordpress.org/imath/), [mercime](https://profiles.wordpress.org/mercime/), [Hugo Ashmore](https://profiles.wordpress.org/hnla/), [David Cavins](https://profiles.wordpress.org/dcavins/), [Michael Beckwith](https://profiles.wordpress.org/tw2113/), [Slava Abakumov](https://profiles.wordpress.org/slaffik/), [Stephen Edgar](https://profiles.wordpress.org/netweb/), [Laurens Offereins](https://profiles.wordpress.org/offereins/) and [Renato Alves](https://profiles.wordpress.org/espellcaste/).


### PR DESCRIPTION
This PR is achieving this task: https://github.com/buddypress/bp-documentation/issues/118
