### PR TITLE
Apply 9111.patch but use SCSS to generate styles

### DIFF
--- a/src/bp-core/admin/css/hello-rtl.css
+++ b/src/bp-core/admin/css/hello-rtl.css
@@ -33,6 +33,24 @@ TABLE OF CONTENTS:
 	font-size: 16px;
 }
 
+.bp-hello-content p.has-white-color.has-text-color.has-background.has-medium-font-size {
+	color: #fff;
+	padding: 1.25em 2.375em !important;
+}
+
+.bp-hello-content p a {
+	text-decoration: none;
+}
+
+.bp-hello-content p a:hover {
+	color: #dd823b;
+	text-decoration: underline;
+}
+
+.bp-hello-content p a mark.has-inline-color.has-white-color {
+	color: #fff;
+}
+
 .bp-hello-content ul,
 .bp-hello-content ol {
 	list-style: inherit;
@@ -45,6 +63,27 @@ TABLE OF CONTENTS:
 .bp-hello-content h3 {
 	font-size: 1.1em;
 	font-weight: 500;
+}
+
+.bp-hello-content .wp-container-core-buttons-is-layout-1 {
+	display: flex;
+	justify-content: center;
+}
+
+.bp-hello-content .has-vivid-red-background-color {
+	background-color: #be3631;
+}
+
+.bp-hello-content .wp-block-button.is-style-fill a:hover {
+	text-decoration: underline;
+}
+
+.bp-hello-content .wp-block-button__link {
+	color: #fff;
+	box-shadow: none;
+	text-decoration: none;
+	padding: calc(0.667em + 2px) calc(1.333em + 2px);
+	font-size: 1.125em;
 }
 
 /*------------------------------------------------------------------------------

--- a/src/bp-core/admin/css/hello.css
+++ b/src/bp-core/admin/css/hello.css
@@ -33,6 +33,24 @@ TABLE OF CONTENTS:
 	font-size: 16px;
 }
 
+.bp-hello-content p.has-white-color.has-text-color.has-background.has-medium-font-size {
+	color: #fff;
+	padding: 1.25em 2.375em !important;
+}
+
+.bp-hello-content p a {
+	text-decoration: none;
+}
+
+.bp-hello-content p a:hover {
+	color: #dd823b;
+	text-decoration: underline;
+}
+
+.bp-hello-content p a mark.has-inline-color.has-white-color {
+	color: #fff;
+}
+
 .bp-hello-content ul,
 .bp-hello-content ol {
 	list-style: inherit;
@@ -45,6 +63,27 @@ TABLE OF CONTENTS:
 .bp-hello-content h3 {
 	font-size: 1.1em;
 	font-weight: 500;
+}
+
+.bp-hello-content .wp-container-core-buttons-is-layout-1 {
+	display: flex;
+	justify-content: center;
+}
+
+.bp-hello-content .has-vivid-red-background-color {
+	background-color: #be3631;
+}
+
+.bp-hello-content .wp-block-button.is-style-fill a:hover {
+	text-decoration: underline;
+}
+
+.bp-hello-content .wp-block-button__link {
+	color: #fff;
+	box-shadow: none;
+	text-decoration: none;
+	padding: calc(0.667em + 2px) calc(1.333em + 2px);
+	font-size: 1.125em;
 }
 
 /*------------------------------------------------------------------------------

--- a/src/bp-core/admin/sass/hello.scss
+++ b/src/bp-core/admin/sass/hello.scss
@@ -34,6 +34,27 @@ TABLE OF CONTENTS:
 
 	p {
 		font-size: 16px;
+
+		&.has-white-color.has-text-color.has-background.has-medium-font-size {
+			color: #fff;
+			padding: 1.25em 2.375em !important;
+		}
+
+		a {
+			text-decoration: none;
+
+			&:hover {
+				color: #dd823b;
+				text-decoration: underline;
+			}
+
+			mark {
+
+				&.has-inline-color.has-white-color {
+					color: #fff;
+				}
+			}
+		}
 	}
 
 	ul,
@@ -48,6 +69,27 @@ TABLE OF CONTENTS:
 	h3 {
 		font-size: 1.1em;
 		font-weight: 500;
+	}
+
+	.wp-container-core-buttons-is-layout-1 {
+		display: flex;
+		justify-content: center;
+	}
+
+	.has-vivid-red-background-color {
+		background-color: #be3631;
+	}
+
+	.wp-block-button.is-style-fill a:hover {
+		text-decoration: underline;
+	}
+
+	.wp-block-button__link {
+		color: #fff;
+		box-shadow: none;
+		text-decoration: none;
+		padding: calc(0.667em + 2px) calc(1.333em + 2px);
+		font-size: 1.125em;
 	}
 }
 

--- a/src/bp-core/classes/class-bp-admin.php
+++ b/src/bp-core/classes/class-bp-admin.php
@@ -185,7 +185,9 @@ class BP_Admin {
 		add_action( 'bp_register_admin_settings', array( $this, 'register_admin_settings' ) );
 
 		// Add a link to BuddyPress Hello in the admin bar.
-		add_action( 'admin_bar_menu', array( $this, 'admin_bar_about_link' ), 100 );
+		if ( bp_current_user_can( 'bp_moderate' ) ) {
+			add_action( 'admin_bar_menu', array( $this, 'admin_bar_about_link' ), 100 );
+		}
 
 		// Add a description of BuddyPress tools in the available tools page.
 		if ( bp_current_user_can( 'bp_moderate' ) ) {


### PR DESCRIPTION
Some parts of BuddyPress (like this one) are using SCSS, so we need to edit the corresponding SCSS file otherwise when running `grunt commit` or `grunt style` or `grunt build` the `.css` edits are removed.

PS:  sorry @emaralive I forgot to mention it in my previous comment on the ticket. Otherwise, I've tested the patch and I confirm it behaves as expected 👍. Great job.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9111

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
