### PR TITLE
Add support forums etiquette to Handbooks generic area

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,6 @@ _Welcome to the BuddyPress Handbooks; if you’re looking for a structured way t
 - Nice to meet you, let us introduce ourselves!
 - [Releases history](./changelogs/README.md)
 - License
-- Etiquette
+- [Support forums etiquette](./etiquette.md)
 - Security
 - Official logos & graphics

--- a/docs/etiquette.md
+++ b/docs/etiquette.md
@@ -1,0 +1,15 @@
+# Support forums etiquette
+
+What follows are the “rules of etiquette” for the [BP support forums](https://buddypress.org/support/), and can be summed up as “being cool” which is a good way to be anyhow, particularly if you appreciate the Fonz.
+
+1. **Be cool**. This means respect the other users of the BP support forums and mind what you say. If you wouldn’t walk into your grandmothers house and say to her bridge club what you feel you want to say here, probably filter it down and sensor yourself just a smidge. Not that we can’t take the heat (or gramma can’t either), but it just isn’t productive.
+
+2. **Stay on topic**. Naturally conversations die off and people run out of things to say. When that happens, hop onto your activity stream and start shouting to the world there instead. The BP support forums are explicitly for supporting and helping develop **BuddyPress**, and anything else gets in the way of that.
+
+3. **Moderators on duty**. If things get out of hand, we have a volunteer staff of gentle giants that can still be angered. They’re like hybrid Terminator/Frankenstein/Zombies that, while kind and mild mannered, are chomping at the bit to mark you as a spammer.
+
+4. **Do not feed the animals**. If someone is bullying you or someone else around or just starting fires randomly, ignore them and ping one of the moderators. These forums are meant to be fun for people of all ages and skill levels; so be kind, rewind.
+
+5. **No put downs**. Or else you won’t get milk at lunch. If you do get milk, and if the arrow on your carton is pointing at someone, that means you love them. And yes, if it’s pointing at yourself, that means you love yourself.
+
+We want everyone to feel welcome, comfortable, and appreciated. In order to do that it seems we’ve gotten to the point where it will pay to have some loose rules to refer people to if things go awry. If you do your best to follow this guide, there will be cake.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -16,5 +16,11 @@
 		"slug": "branch-9-0",
 		"markdown_source": "../changelogs/branch-9-0.md",
 		"parent": null
+	},
+	{
+		"title": "Support forums etiquette",
+		"slug": "support-forums-etiquette",
+		"markdown_source": "../etiquette.md",
+		"parent": null
 	}
 ]


### PR DESCRIPTION
This migrates the "etiquette" codex page. See https://github.com/buddypress/bp-documentation/issues/95.

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
