### PR TITLE
Cast `ctype_digit` value to `string`

### DIFF
--- a/src/bp-core/bp-core-attachments.php
+++ b/src/bp-core/bp-core-attachments.php
@@ -1573,7 +1573,7 @@ function bp_attachments_cover_image_ajax_delete() {
 		wp_send_json_error();
 	}
 
-	if ( empty( $_POST['object'] ) || empty( $_POST['item_id'] ) || ( ! ctype_digit( $_POST['item_id'] ) && ! is_int( $_POST['item_id'] ) ) ) {
+	if ( empty( $_POST['object'] ) || empty( $_POST['item_id'] ) || ( ! ctype_digit( (string) $_POST['item_id'] ) && ! is_int( $_POST['item_id'] ) ) ) {
 		wp_send_json_error();
 	}
 

--- a/src/bp-core/classes/class-bp-media-extractor.php
+++ b/src/bp-core/classes/class-bp-media-extractor.php
@@ -777,11 +777,11 @@ class BP_Media_Extractor {
 			if ( isset( $extra_args['width'] ) ) {
 
 				// A width was specified but not a height, so calculate it assuming a 4:3 ratio.
-				if ( ! isset( $extra_args['height'] ) && ctype_digit( $extra_args['width'] ) ) {
+				if ( ! isset( $extra_args['height'] ) && ctype_digit( (string) $extra_args['width'] ) ) {
 					$extra_args['height'] = round( ( $extra_args['width'] / 4 ) * 3 );
 				}
 
-				if ( ctype_digit( $extra_args['width'] ) ) {
+				if ( ctype_digit( (string) $extra_args['width'] ) ) {
 					$image_size = array( $extra_args['width'], $extra_args['height'] );
 				} else {
 					$image_size = $extra_args['width'];  // E.g. "thumb", "medium".
@@ -876,12 +876,12 @@ class BP_Media_Extractor {
 		if ( $thumb ) {
 			// Validate the size of the images requested.
 			if ( isset( $extra_args['width'] ) ) {
-				if ( ! isset( $extra_args['height'] ) && ctype_digit( $extra_args['width'] ) ) {
+				if ( ! isset( $extra_args['height'] ) && ctype_digit( (string) $extra_args['width'] ) ) {
 					// A width was specified but not a height, so calculate it assuming a 4:3 ratio.
 					$extra_args['height'] = round( ( $extra_args['width'] / 4 ) * 3 );
 				}
 
-				if ( ctype_digit( $extra_args['width'] ) ) {
+				if ( ctype_digit( (string) $extra_args['width'] ) ) {
 					$image_size = array( $extra_args['width'], $extra_args['height'] );
 				} else {
 					$image_size = $extra_args['width'];  // E.g. "thumb", "medium".


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9125

I noticed that some of those values are already integers. But to avoid messing anything up, I opted for a more conservative approach, fixing only the following "issue":

> ctype_digit(): Argument of type int will be interpreted as string in the future

Related: https://www.php.net/manual/en/function.ctype-digit.php#refsect1-function.ctype-digit-parameters

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
