### PR TITLE
`BP_XProfile_Field` Update sets `parent_id` to 0

### DIFF
--- a/src/bp-xprofile/classes/class-bp-xprofile-field.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-field.php
@@ -448,9 +448,36 @@ class BP_XProfile_Field {
 		$is_new_field = is_null( $this->id );
 
 		if ( ! $is_new_field ) {
-			$sql = $wpdb->prepare( "UPDATE {$bp->profile->table_name_fields} SET group_id = %d, parent_id = 0, type = %s, name = %s, description = %s, is_required = %d, order_by = %s, field_order = %d, option_order = %d, can_delete = %d, is_default_option = %d WHERE id = %d", $this->group_id, $this->type, $this->name, $this->description, $this->is_required, $this->order_by, $this->field_order, $this->option_order, $this->can_delete, $this->is_default_option, $this->id );
+			$sql = $wpdb->prepare(
+				"UPDATE {$bp->profile->table_name_fields} SET group_id = %d, parent_id = %d, type = %s, name = %s, description = %s, is_required = %d, order_by = %s, field_order = %d, option_order = %d, can_delete = %d, is_default_option = %d WHERE id = %d",
+				$this->group_id,
+				$this->parent_id,
+				$this->type,
+				$this->name,
+				$this->description,
+				$this->is_required,
+				$this->order_by,
+				$this->field_order,
+				$this->option_order,
+				$this->can_delete,
+				$this->is_default_option,
+				$this->id
+			);
 		} else {
-			$sql = $wpdb->prepare( "INSERT INTO {$bp->profile->table_name_fields} (group_id, parent_id, type, name, description, is_required, order_by, field_order, option_order, can_delete, is_default_option ) VALUES ( %d, %d, %s, %s, %s, %d, %s, %d, %d, %d, %d )", $this->group_id, $this->parent_id, $this->type, $this->name, $this->description, $this->is_required, $this->order_by, $this->field_order, $this->option_order, $this->can_delete, $this->is_default_option );
+			$sql = $wpdb->prepare(
+				"INSERT INTO {$bp->profile->table_name_fields} (group_id, parent_id, type, name, description, is_required, order_by, field_order, option_order, can_delete, is_default_option ) VALUES ( %d, %d, %s, %s, %s, %d, %s, %d, %d, %d, %d )",
+				$this->group_id,
+				$this->parent_id,
+				$this->type,
+				$this->name,
+				$this->description,
+				$this->is_required,
+				$this->order_by,
+				$this->field_order,
+				$this->option_order,
+				$this->can_delete,
+				$this->is_default_option
+			);
 		}
 
 		/**

--- a/tests/phpunit/testcases/xprofile/functions.php
+++ b/tests/phpunit/testcases/xprofile/functions.php
@@ -698,6 +698,42 @@ Bar!';
 	}
 
 	/**
+	 * @ticket BP9130
+	 */
+	public function test_xprofile_update_keep_parent_id() {
+		$g      = self::factory()->xprofile_group->create();
+		$parent = self::factory()->xprofile_field->create( array(
+			'field_group_id' => $g,
+			'type'           => 'selectbox',
+			'name'           => 'Parent',
+		) );
+
+		$f = xprofile_insert_field(
+			array(
+				'field_group_id' => $g,
+				'parent_id'      => $parent,
+				'type'           => 'option',
+				'name'           => 'Option 1',
+				'option_order'   => 5,
+			)
+		);
+
+		$field = new BP_XProfile_Field( $f );
+
+		$this->assertEquals( $parent, $field->parent_id );
+		$this->assertNotEquals( 0, $field->parent_id );
+
+		$field->name = 'Option 2';
+		$field->save(); // Perform the `UPDATE` query. The reason for the bug.
+
+		// Fetch the new DB value.
+		$field = new BP_XProfile_Field( $f );
+
+		$this->assertNotEquals( 0, $field->parent_id );
+		$this->assertEquals( $parent, $field->parent_id );
+	}
+
+	/**
 	 * @group xprofile_insert_field
 	 */
 	public function test_xprofile_insert_field_type_option_option_order() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9130

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
