### PR TITLE
Deprecate the backcompat feature about creating a user out of a signup

### DIFF
--- a/src/bp-core/admin/bp-core-admin-tools.php
+++ b/src/bp-core/admin/bp-core-admin-tools.php
@@ -927,7 +927,7 @@ function bp_core_admin_debug_information( $debug_info = array() ) {
 				'debug' => defined( 'BP_GROUPS_DEFAULT_EXTENSION' ) ? BP_GROUPS_DEFAULT_EXTENSION : 'undefined',
 			),
 			'BP_SIGNUPS_SKIP_USER_CREATION' => array(
-				'label' => 'BP_SIGNUPS_SKIP_USER_CREATION',
+				'label' => 'BP_SIGNUPS_SKIP_USER_CREATION (deprecated)',
 				'value' => defined( 'BP_SIGNUPS_SKIP_USER_CREATION' ) && BP_SIGNUPS_SKIP_USER_CREATION ? __( 'Enabled', 'buddypress' ) : __( 'Disabled', 'buddypress' ),
 				'debug' => defined( 'BP_SIGNUPS_SKIP_USER_CREATION' ) ? BP_SIGNUPS_SKIP_USER_CREATION : 'undefined',
 			),

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -1858,6 +1858,15 @@ function bp_core_signup_user( $user_login, $user_password, $user_email, $usermet
 		$user_login     = preg_replace( '/\s+/', '', sanitize_user( $user_login, true ) );
 		$user_email     = sanitize_email( $user_email );
 		$activation_key = wp_generate_password( 32, false );
+		$create_user    = false;
+
+		// @deprecated.
+		if ( defined( 'BP_SIGNUPS_SKIP_USER_CREATION' ) ) {
+			_doing_it_wrong( 'BP_SIGNUPS_SKIP_USER_CREATION', esc_html__( 'the `BP_SIGNUPS_SKIP_USER_CREATION` constant is deprecated as skipping user creation is now the default behavior.', 'buddypress' ), 'BuddyPress 14.0.0' );
+
+			// Creating a user is the opposite of skipping user creation.
+			$create_user = ! BP_SIGNUPS_SKIP_USER_CREATION;
+		}
 
 		/**
 		 * Filter here to keep creating a user when a registration is performed on regular WordPress configs.
@@ -1865,10 +1874,10 @@ function bp_core_signup_user( $user_login, $user_password, $user_email, $usermet
 		 * @since 14.0.0
 		 * @todo Fully deprecate in 15.0.0
 		 *
-		 * @param boolean $value True to carry on creating a user when a registration is performed.
-		 *                       False otherwise.
+		 * @param boolean $create_user True to carry on creating a user when a registration is performed.
+		 *                             False otherwise.
 		 */
-		if ( apply_filters( 'bp_signups_create_user', false ) ) {
+		if ( apply_filters( 'bp_signups_create_user', $create_user ) ) {
 			$user_id = BP_Signup::add_backcompat( $user_login, $user_password, $user_email, $usermeta );
 
 			if ( is_wp_error( $user_id ) ) {

--- a/src/bp-members/classes/class-bp-signup.php
+++ b/src/bp-members/classes/class-bp-signup.php
@@ -533,6 +533,7 @@ class BP_Signup {
 	 * default behavior.
 	 *
 	 * @since 2.0.0
+	 * @deprecated 14.0.0
 	 *
 	 * @global wpdb $wpdb The WordPress database object.
 	 *
@@ -543,6 +544,8 @@ class BP_Signup {
 	 * @return int User id.
 	 */
 	public static function add_backcompat( $user_login = '', $user_password = '', $user_email = '', $usermeta = array() ) {
+		_deprecated_function( __METHOD__, '14.0.0' );
+
 		global $wpdb;
 
 		$user_id = wp_insert_user(
@@ -603,19 +606,21 @@ class BP_Signup {
 		 * Fires after adding a new WP User (backcompat).
 		 *
 		 * @since 10.0.0
+		 * @deprecated 14.0.0
 		 *
 		 * @param int $user_id ID of the WP_User just added.
 		 */
-		do_action( 'bp_core_signups_after_add_backcompat', $user_id );
+		do_action_deprecated( 'bp_core_signups_after_add_backcompat', array( $user_id ), '14.0.0' );
 
 		/**
 		 * Filters the user ID for the backcompat functionality.
 		 *
 		 * @since 2.0.0
+		 * @deprecated 14.0.0
 		 *
 		 * @param int $user_id User ID being registered.
 		 */
-		return apply_filters( 'bp_core_signups_add_backcompat', $user_id );
+		return apply_filters_deprecated( 'bp_core_signups_add_backcompat', array( $user_id ), '14.0.0' );
 	}
 
 	/**


### PR DESCRIPTION
This backwards compatibility feature was introduced in version 2.0.0, it's causing an issue as the just registered user's profile can already be seen on the front-end. Moreover as it's not yet a user, let's be consistent and only deal with our BP Signups API to manage signups.

The goal of this PR is to stop creating a user on regular WordPress site when a registration is performed.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/6123

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
