### PR TITLE
Use a more appropriated function to escape slugs

### DIFF
--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  *
  */
 function bp_activity_slug() {
-	echo esc_url( bp_get_activity_slug() );
+	echo esc_attr( bp_get_activity_slug() );
 }
 	/**
 	 * Return the activity component slug.
@@ -46,7 +46,7 @@ function bp_activity_slug() {
  *
  */
 function bp_activity_root_slug() {
-	echo esc_url( bp_get_activity_root_slug() );
+	echo esc_attr( bp_get_activity_root_slug() );
 }
 	/**
 	 * Return the activity component root slug.

--- a/src/bp-blogs/bp-blogs-template.php
+++ b/src/bp-blogs/bp-blogs-template.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  *
  */
 function bp_blogs_slug() {
-	echo esc_url( bp_get_blogs_slug() );
+	echo esc_attr( bp_get_blogs_slug() );
 }
 	/**
 	 * Return the blogs component slug.
@@ -45,7 +45,7 @@ function bp_blogs_slug() {
  *
  */
 function bp_blogs_root_slug() {
-	echo esc_url( bp_get_blogs_root_slug() );
+	echo esc_attr( bp_get_blogs_root_slug() );
 }
 	/**
 	 * Return the blogs component root slug.
@@ -1185,7 +1185,7 @@ function bp_blogs_signup_blog( $blogname = '', $blog_title = '', $errors = '' ) 
 				esc_attr( $blogname ),
 				// phpcs:ignore WordPress.Security.EscapeOutput
 				bp_get_form_field_attributes( 'blogname' ),
-				esc_url( bp_signup_get_subdomain_base() )
+				esc_attr( bp_signup_get_subdomain_base() )
 			);
 		}
 		if ( is_wp_error( $errors ) && $errors->get_error_message( 'blogname' ) ) {

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -1333,7 +1333,7 @@ function bp_root_url() {
  * @param string $component The component name.
  */
 function bp_root_slug( $component = '' ) {
-	echo esc_url( bp_get_root_slug( $component ) );
+	echo esc_attr( bp_get_root_slug( $component ) );
 }
 	/**
 	 * Get the root slug for given component.
@@ -1463,7 +1463,7 @@ function bp_user_has_access() {
  *
  */
 function bp_search_slug() {
-	echo esc_url( bp_get_search_slug() );
+	echo esc_attr( bp_get_search_slug() );
 }
 	/**
 	 * Return the search slug.

--- a/src/bp-friends/bp-friends-template.php
+++ b/src/bp-friends/bp-friends-template.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.5.0
  */
 function bp_friends_slug() {
-	echo esc_url( bp_get_friends_slug() );
+	echo esc_attr( bp_get_friends_slug() );
 }
 	/**
 	 * Return the friends component slug.
@@ -43,7 +43,7 @@ function bp_friends_slug() {
  * @since 1.5.0
  */
 function bp_friends_root_slug() {
-	echo esc_url( bp_get_friends_root_slug() );
+	echo esc_attr( bp_get_friends_root_slug() );
 }
 	/**
 	 * Return the friends component root slug.

--- a/src/bp-groups/bp-groups-template.php
+++ b/src/bp-groups/bp-groups-template.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.5.0
  */
 function bp_groups_slug() {
-	echo esc_url( bp_get_groups_slug() );
+	echo esc_attr( bp_get_groups_slug() );
 }
 	/**
 	 * Return the groups component slug.
@@ -43,7 +43,7 @@ function bp_groups_slug() {
  * @since 1.5.0
  */
 function bp_groups_root_slug() {
-	echo esc_url( bp_get_groups_root_slug() );
+	echo esc_attr( bp_get_groups_root_slug() );
 }
 	/**
 	 * Return the groups component root slug.
@@ -70,7 +70,7 @@ function bp_groups_root_slug() {
  * @since 2.7.0
  */
 function bp_groups_group_type_base() {
-	echo esc_url( bp_get_groups_group_type_base() );
+	echo esc_attr( bp_get_groups_group_type_base() );
 }
 	/**
 	 * Get the group type base slug.
@@ -1430,7 +1430,7 @@ function bp_get_group_manage_url( $group = false, $path_chunks = array() ) {
  *                                                Default: false.
  */
 function bp_group_slug( $group = false ) {
-	echo esc_url( bp_get_group_slug( $group ) );
+	echo esc_attr( bp_get_group_slug( $group ) );
 }
 	/**
 	 * Return the slug for the group.
@@ -4509,7 +4509,7 @@ function bp_group_member_needs_pagination() {
  * @since 1.0.0
  */
 function bp_group_pag_id() {
-	echo esc_url( bp_get_group_pag_id() );
+	echo esc_attr( bp_get_group_pag_id() );
 }
 	/**
 	 * @since 1.0.0
@@ -6486,7 +6486,7 @@ function bp_current_group_id() {
  * @since 1.5.0
  */
 function bp_current_group_slug() {
-	echo esc_url( bp_get_current_group_slug() );
+	echo esc_attr( bp_get_current_group_slug() );
 }
 	/**
 	 * Returns the slug of the current group.

--- a/src/bp-members/bp-members-template.php
+++ b/src/bp-members/bp-members-template.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 2.4.0
  */
 function bp_profile_slug() {
-	echo esc_url( bp_get_profile_slug() );
+	echo esc_attr( bp_get_profile_slug() );
 }
 	/**
 	 * Return the profile component slug.
@@ -45,7 +45,7 @@ function bp_profile_slug() {
  * @since 1.5.0
  */
 function bp_members_slug() {
-	echo esc_url( bp_get_members_slug() );
+	echo esc_attr( bp_get_members_slug() );
 }
 	/**
 	 * Return the members component slug.
@@ -72,7 +72,7 @@ function bp_members_slug() {
  * @since 1.5.0
  */
 function bp_members_root_slug() {
-	echo esc_url( bp_get_members_root_slug() );
+	echo esc_attr( bp_get_members_root_slug() );
 }
 	/**
 	 * Return the members component root slug.
@@ -99,7 +99,7 @@ function bp_members_root_slug() {
  * @since 2.5.0
  */
 function bp_members_member_type_base() {
-	echo esc_url( bp_get_members_member_type_base() );
+	echo esc_attr( bp_get_members_member_type_base() );
 }
 	/**
 	 * Get the member type URL base.
@@ -215,7 +215,7 @@ function bp_member_type_directory_permalink( $member_type = '' ) {
  * @since 1.5.0
  */
 function bp_signup_slug() {
-	echo esc_url( bp_get_signup_slug() );
+	echo esc_attr( bp_get_signup_slug() );
 }
 	/**
 	 * Return the sign-up slug.
@@ -248,7 +248,7 @@ function bp_signup_slug() {
  * @since 1.5.0
  */
 function bp_activate_slug() {
-	echo esc_url( bp_get_activate_slug() );
+	echo esc_attr( bp_get_activate_slug() );
 }
 	/**
 	 * Return the activation slug.
@@ -281,7 +281,7 @@ function bp_activate_slug() {
  * @since 8.0.0
  */
 function bp_members_invitations_slug() {
-	echo esc_url( bp_get_members_invitations_slug() );
+	echo esc_attr( bp_get_members_invitations_slug() );
 }
 	/**
 	 * Return the members invitations root slug.
@@ -2737,7 +2737,7 @@ function bp_signup_blog_url_value() {
  * @since 2.1.0
  */
 function bp_signup_subdomain_base() {
-	echo esc_url( bp_signup_get_subdomain_base() );
+	echo esc_attr( bp_signup_get_subdomain_base() );
 }
 	/**
 	 * Return the base URL for subdomain installations of WordPress Multisite.

--- a/src/bp-messages/bp-messages-template.php
+++ b/src/bp-messages/bp-messages-template.php
@@ -1462,7 +1462,7 @@ function bp_message_notice_dismiss_link() {
  *
  */
 function bp_messages_slug() {
-	echo esc_url( bp_get_messages_slug() );
+	echo esc_attr( bp_get_messages_slug() );
 }
 	/**
 	 * Return the messages component slug.

--- a/src/bp-notifications/bp-notifications-template.php
+++ b/src/bp-notifications/bp-notifications-template.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.9.0
  */
 function bp_notifications_slug() {
-	echo esc_url( bp_get_notifications_slug() );
+	echo esc_attr( bp_get_notifications_slug() );
 }
 	/**
 	 * Return the notifications component slug.

--- a/src/bp-settings/bp-settings-template.php
+++ b/src/bp-settings/bp-settings-template.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.5.0
  */
 function bp_settings_slug() {
-	echo esc_url( bp_get_settings_slug() );
+	echo esc_attr( bp_get_settings_slug() );
 }
 
 /**
@@ -44,7 +44,7 @@ function bp_get_settings_slug() {
  * @since 1.5.0
  */
 function bp_settings_root_slug() {
-	echo esc_url( bp_get_settings_root_slug() );
+	echo esc_attr( bp_get_settings_root_slug() );
 }
 
 /**

--- a/src/bp-xprofile/bp-xprofile-template.php
+++ b/src/bp-xprofile/bp-xprofile-template.php
@@ -330,7 +330,7 @@ function bp_the_profile_group_name() {
  * @since 1.1.0
  */
 function bp_the_profile_group_slug() {
-	echo esc_url( bp_get_the_profile_group_slug() );
+	echo esc_attr( bp_get_the_profile_group_slug() );
 }
 
 	/**


### PR DESCRIPTION
Using `esc_url()` is a mistake (my bad) as it prepends the `http` protocol.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9143

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
