### PR TITLE
Apply @emaralive patch, copy @espellcaste unit test & improve some parts

### DIFF
--- a/src/bp-core/admin/bp-core-admin-settings.php
+++ b/src/bp-core/admin/bp-core-admin-settings.php
@@ -351,6 +351,18 @@ function bp_admin_setting_callback_group_cover_image_uploads() {
 <?php
 }
 
+/**
+ * 'Enable group activity deletions.
+ *
+ * @since 14.0.0
+ */
+function bp_admin_setting_callback_group_activity_deletions() {
+?>
+	<input id="bp-disable-group-activity-deletions" name="bp-disable-group-activity-deletions" type="checkbox" value="1" <?php checked( ! bp_disable_group_activity_deletions() ); ?> />
+	<label for="bp-disable-group-activity-deletions"><?php esc_html_e( "Allow group administrators and moderators to delete activity items from their group's activity stream", 'buddypress' ); ?></label>
+<?php
+}
+
 /** Account settings Section ************************************************************/
 
 /**

--- a/src/bp-core/admin/bp-core-admin-settings.php
+++ b/src/bp-core/admin/bp-core-admin-settings.php
@@ -447,6 +447,7 @@ function bp_core_admin_settings_save() {
 			'bp-disable-cover-image-uploads',
 			'bp-disable-group-avatar-uploads',
 			'bp-disable-group-cover-image-uploads',
+			'bp-disable-group-activity-deletions',
 			'bp_disable_blogforum_comments',
 			'bp-disable-profile-sync',
 			'bp_restrict_group_creation',

--- a/src/bp-core/bp-core-options.php
+++ b/src/bp-core/bp-core-options.php
@@ -62,6 +62,9 @@ function bp_get_default_options() {
 		// Group Cover image uploads.
 		'bp-disable-group-cover-image-uploads' => false,
 
+		// Allow Group Activity Deletions.
+		'bp-disable-group-activity-deletions'   => false,
+
 		// Allow users to delete their own accounts.
 		'bp-disable-account-deletion'          => false,
 
@@ -583,6 +586,27 @@ function bp_disable_group_cover_image_uploads( $default = false ) {
 	 * @param bool $value Whether or not members are able to upload thier groups cover images.
 	 */
 	return (bool) apply_filters( 'bp_disable_group_cover_image_uploads', (bool) bp_get_option( 'bp-disable-group-cover-image-uploads', $default ) );
+}
+
+/**
+ * Are group activity deletions disabled?
+ *
+ * @since 14.0.0
+ *
+ * @param bool $default Optional. Fallback value if not found in the database.
+ *                      Default: true.
+ * @return bool True if group activity deletions are disabled, otherwise false.
+ */
+function bp_disable_group_activity_deletions( $default = false ) {
+
+	/**
+	 * Filters whether or not group creator, group admin or group mod are able to delete group activity posts.
+	 *
+	 * @since 14.0.0
+	 *
+	 * @param bool $value Whether or not group creator, group admin or group mod are able to delete group activity post.
+	 */
+	return (bool) apply_filters( 'bp_disable_group_activity_deletions', (bool) bp_get_option( 'bp-disable-group-activity-deletions', $default ) );
 }
 
 /**

--- a/src/bp-core/bp-core-options.php
+++ b/src/bp-core/bp-core-options.php
@@ -594,7 +594,7 @@ function bp_disable_group_cover_image_uploads( $default = false ) {
  * @since 14.0.0
  *
  * @param bool $default Optional. Fallback value if not found in the database.
- *                      Default: true.
+ *                      Default: false.
  * @return bool True if group activity deletions are disabled, otherwise false.
  */
 function bp_disable_group_activity_deletions( $default = false ) {

--- a/src/bp-core/classes/class-bp-admin.php
+++ b/src/bp-core/classes/class-bp-admin.php
@@ -567,6 +567,10 @@ class BP_Admin {
 				add_settings_field( 'bp-disable-group-cover-image-uploads', __( 'Group Cover Image Uploads', 'buddypress' ), 'bp_admin_setting_callback_group_cover_image_uploads', 'buddypress', 'bp_groups' );
 				register_setting( 'buddypress', 'bp-disable-group-cover-image-uploads', 'intval' );
 			}
+
+			// Allow group activity deletions.
+			add_settings_field( 'bp-disable-group-activity-deletions', esc_html__( 'Group Activity Deletions', 'buddypress' ), 'bp_admin_setting_callback_group_activity_deletions', 'buddypress', 'bp_groups' );
+			register_setting( 'buddypress', 'bp-disable-group-activity-deletions', 'intval' );
 		}
 
 		/* Activity Section **************************************************/

--- a/tests/phpunit/testcases/groups/activity.php
+++ b/tests/phpunit/testcases/groups/activity.php
@@ -353,4 +353,152 @@ class BP_Tests_Groups_Activity extends BP_UnitTestCase {
 
 		return $args;
 	}
+
+	/**
+	 * @ticket BP8728
+	 */
+	public function test_user_can_delete_group_activity() {
+		$u1             = self::factory()->user->create();
+		$u2             = self::factory()->user->create();
+		$original_user = bp_loggedin_user_id();
+
+		$this->set_current_user( $u1 );
+
+		$g = self::factory()->group->create();
+
+		$a = self::factory()->activity->create(
+			array(
+				'user_id'   => $u2,
+				'component' => buddypress()->groups->id,
+				'type'      => 'activity_update',
+				'item_id'   => $g,
+				'content'   => 'Random content',
+			)
+		);
+
+		// Activity for group creator.
+		$b = self::factory()->activity->create(
+			array(
+				'user_id'   => $u1,
+				'component' => buddypress()->groups->id,
+				'type'      => 'activity_update',
+				'item_id'   => $g,
+				'content'   => 'Random content',
+			)
+		);
+
+		// Add user to group.
+		self::add_user_to_group( $u2, $g );
+
+		$activity   = self::factory()->activity->get_object_by_id( $a );
+		$activity_b = self::factory()->activity->get_object_by_id( $b );
+
+		// User can delete his own activity.
+		$this->set_current_user( $u2 );
+		$this->assertTrue( bp_activity_user_can_delete( $activity ) );
+
+		// Activity from site admins can't be deleted by non site admins.
+		$this->set_current_user( $u2 );
+		$this->assertFalse( bp_activity_user_can_delete( $activity_b ) );
+
+		// Activity from site admins can be deleted by other site admins.
+		$site_admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->set_current_user( $site_admin );
+		$this->assertTrue( bp_activity_user_can_delete( $activity_b ) );
+
+		// Group creator can delete activity.
+		$this->set_current_user( $u1 );
+		$this->assertTrue( bp_activity_user_can_delete( $activity ) );
+
+		// Logged-out user can't delete activity.
+		$this->set_current_user( 0 );
+		$this->assertFalse( bp_activity_user_can_delete( $activity ) );
+
+		// Misc user can't delete activity.
+		$misc_user = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$this->set_current_user( $misc_user );
+		$this->assertFalse( bp_activity_user_can_delete( $activity ) );
+
+		// Misc group member can't delete activity.
+		$misc_user_2 = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		self::add_user_to_group( $misc_user_2, $g );
+		$this->set_current_user( $misc_user_2 );
+		$this->assertFalse( bp_activity_user_can_delete( $activity ) );
+
+		// Group mod can delete activity.
+		$misc_user_3 = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		self::add_user_to_group( $misc_user_3, $g, [ 'is_mod' => true ] );
+		$this->set_current_user( $misc_user_3 );
+		$this->assertTrue( bp_activity_user_can_delete( $activity ) );
+
+		// Group admin can delete activity.
+		$misc_user_4 = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		self::add_user_to_group( $misc_user_4, $g, [ 'is_admin' => true ] );
+		$this->set_current_user( $misc_user_4 );
+		$this->assertTrue( bp_activity_user_can_delete( $activity ) );
+
+		$this->set_current_user( $original_user );
+	}
+
+	/**
+	 * @ticket BP8728
+	 */
+	public function test_group_admins_cannot_delete_activity() {
+		$u1            = self::factory()->user->create();
+		$u2            = self::factory()->user->create();
+		$original_user = bp_loggedin_user_id();
+
+		$this->set_current_user( $u1 );
+
+		$g  = self::factory()->group->create();
+		$g2 = self::factory()->group->create();
+		$a  = self::factory()->activity->create(
+			array(
+				'user_id'   => $u1,
+				'content'   => 'Random Activity content',
+			)
+		);
+
+		// Activity for group creator.
+		$a2 = self::factory()->activity->create(
+			array(
+				'user_id'   => $u1,
+				'component' => buddypress()->groups->id,
+				'type'      => 'activity_update',
+				'item_id'   => $g,
+				'content'   => 'Random first Group Activity content',
+			)
+		);
+
+		$a3 = self::factory()->activity->create(
+			array(
+				'user_id'   => $u1,
+				'component' => buddypress()->groups->id,
+				'type'      => 'activity_update',
+				'item_id'   => $g2,
+				'content'   => 'Random second Group Activity content',
+			)
+		);
+
+		$activity = self::factory()->activity->get_object_by_id( $a );
+
+		// Add u2 as Admin of g2.
+		self::add_user_to_group( $u2, $g, [ 'is_admin' => true ] );
+
+		$this->set_current_user( $u2 );
+		$this->assertFalse( bp_activity_user_can_delete( $activity ), 'Group Admins or Mods shouldn not be able to delete activities that are not attached to a group' );
+
+		$activity = self::factory()->activity->get_object_by_id( $a2 );
+
+		add_filter( 'bp_disable_group_activity_deletions', '__return_true' );
+
+		$this->assertFalse( bp_activity_user_can_delete( $activity ), 'Group Admins or Mods should not be able to delete group activities when Site admin globally disallowed it.' );
+
+		remove_filter( 'bp_disable_group_activity_deletions', '__return_true' );
+
+		$activity = self::factory()->activity->get_object_by_id( $a3 );
+		$this->assertFalse( bp_activity_user_can_delete( $activity ), 'Group Admins or Mods should not be able to delete another group activities.' );
+
+		$this->set_current_user( $original_user );
+	}
 }


### PR DESCRIPTION
+ Include tests from this PR https://github.com/buddypress/buddypress/pull/273 (putting them into a more appropriate file).
+ Add some other tests to make sure a group admin cannot delete any activity, an activity posted in a group he's not a member of, or activities of the group he's an admin of when the Admin globally disabled the group activity deletion.
+ Use the same logic than other options:  by default group Admins/Mods can delete activities. The Admin needs to uncheck the global settings to disable it.
+ Let's rename options/functions the "disable" way !

PS: @emaralive, @needle is right (thanks a lot for your input), so I've updated the patch accordingly.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8728

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
