### PR TITLE
Buffer dynamic widgets template part instead of getting its content

### DIFF
--- a/src/bp-core/bp-core-template-loader.php
+++ b/src/bp-core/bp-core-template-loader.php
@@ -110,7 +110,10 @@ function bp_get_dynamic_template_part( $template = '', $type = 'js', $tokens = a
 	// Use the BP Theme Compat API to allow template override.
 	$template_path = bp_locate_template( $template );
 	if ( $template_path ) {
-		$template_string = file_get_contents( $template_path );
+		ob_start();
+		load_template( $template_path, false );
+
+		$template_string = ob_get_clean();
 	}
 
 	if ( ! $template_string ) {


### PR DESCRIPTION
This template part is used to preview and display the dynamic widget blocks content. As previewing is made using the REST API, we need to buffer the rendered template to perform token replacements.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9079

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
