### PR TITLE
Add Help tabs to inform about BP Emails management & BP Email token

### DIFF
--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -702,12 +702,8 @@ add_action( 'bp_admin_tabs', 'bp_backcompat_admin_tabs', 1, 2 );
  */
 function bp_core_add_contextual_help( $screen = '' ) {
 
-	$screen   = get_current_screen();
-	$bp_forum = sprintf(
-		'<a href="%1$s">%2$s</a>',
-		esc_url( 'https://buddypress.org/support/' ),
-		esc_html__( 'Support Forums', 'buddypress' )
-	);
+	$screen             = get_current_screen();
+	$documentation_link = '';
 
 	switch ( $screen->id ) {
 
@@ -723,17 +719,10 @@ function bp_core_add_contextual_help( $screen = '' ) {
 				)
 			);
 
-			$manage_components = sprintf(
+			$documentation_link = sprintf(
 				'<a href="%1$s">%2$s</a>',
 				esc_url( 'https://github.com/buddypress/buddypress/blob/master/docs/user/administration/settings/components.md' ),
 				esc_html__( 'Managing Components', 'buddypress' )
-			);
-
-			// Help panel - sidebar links.
-			$screen->set_help_sidebar(
-				'<p><strong>' . esc_html__( 'For more information:', 'buddypress' ) . '</strong></p>' .
-				'<p>' . $manage_components . '</p>' .
-				'<p>' . $bp_forum . '</p>'
 			);
 			break;
 
@@ -749,17 +738,10 @@ function bp_core_add_contextual_help( $screen = '' ) {
 				)
 			);
 
-			$manage_rewrites = sprintf(
+			$documentation_link = sprintf(
 				'<a href="%1$s">%2$s</a>',
 				esc_url( 'https://github.com/buddypress/buddypress/blob/master/docs/user/administration/settings/urls.md' ),
 				esc_html__( 'Managing URLs', 'buddypress' )
-			);
-
-			// Help panel - sidebar links.
-			$screen->set_help_sidebar(
-				'<p><strong>' . esc_html__( 'For more information:', 'buddypress' ) . '</strong></p>' .
-				'<p>' . $manage_rewrites . '</p>' .
-				'<p>' . $bp_forum . '</p>'
 			);
 			break;
 
@@ -775,19 +757,11 @@ function bp_core_add_contextual_help( $screen = '' ) {
 				)
 			);
 
-			$manage_settings = sprintf(
+			$documentation_link = sprintf(
 				'<a href="%1$s">%2$s</a>',
 				esc_url( 'https://github.com/buddypress/buddypress/blob/master/docs/user/administration/settings/options.md' ),
 				esc_html__( 'Managing Settings', 'buddypress' )
 			);
-
-			// Help panel - sidebar links.
-			$screen->set_help_sidebar(
-				'<p><strong>' . esc_html__( 'For more information:', 'buddypress' ) . '</strong></p>' .
-				'<p>' . $manage_settings . '</p>' .
-				'<p>' . $bp_forum . '</p>'
-			);
-
 			break;
 
 		// Profile fields page.
@@ -802,19 +776,11 @@ function bp_core_add_contextual_help( $screen = '' ) {
 				)
 			);
 
-			$manage_profile_fields = sprintf(
+			$documentation_link = sprintf(
 				'<a href="%1$s">%2$s</a>',
 				esc_url( 'https://github.com/buddypress/buddypress/blob/master/docs/user/administration/users/xprofile.md' ),
 				esc_html__( 'Managing Profile Fields', 'buddypress' )
 			);
-
-			// Help panel - sidebar links.
-			$screen->set_help_sidebar(
-				'<p><strong>' . esc_html__( 'For more information:', 'buddypress' ) . '</strong></p>' .
-				'<p>' . $manage_profile_fields . '</p>' .
-				'<p>' . $bp_forum . '</p>'
-			);
-
 			break;
 
 		case 'edit-bp_member_type' :
@@ -827,20 +793,44 @@ function bp_core_add_contextual_help( $screen = '' ) {
 				)
 			);
 
-			$manage_member_types = sprintf(
+			$documentation_link = sprintf(
 				'<a href="%1$s">%2$s</a>',
 				esc_url( 'https://github.com/buddypress/buddypress/blob/master/docs/user/administration/users/member-types.md' ),
 				esc_html__( 'Managing Member Types', 'buddypress' )
 			);
+			break;
 
-			// Help panel - sidebar links.
-			$screen->set_help_sidebar(
-				'<p><strong>' . esc_html__( 'For more information:', 'buddypress' ) . '</strong></p>' .
-				'<p>' . $manage_member_types . '</p>' .
-				'<p>' . $bp_forum . '</p>'
+		case 'edit-bp-email':
+			// Help tab.
+			$screen->add_help_tab(
+				array(
+					'id'      => 'bp-emails-overview',
+					'title'   => __( 'Overview', 'buddypress' ),
+					'content' => bp_core_add_contextual_help_content( 'bp-emails-overview' ),
+				)
 			);
 
+			$documentation_link = sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( 'https://github.com/buddypress/buddypress/blob/master/docs/user/administration/emails/README.md' ),
+				esc_html__( 'Managing BP Emails', 'buddypress' )
+			);
 			break;
+	}
+
+	if ( $documentation_link ) {
+		$bp_forum = sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( 'https://buddypress.org/support/' ),
+			esc_html__( 'Support Forums', 'buddypress' )
+		);
+
+		// Help panel - sidebar links.
+		$screen->set_help_sidebar(
+			'<p><strong>' . esc_html__( 'For more information:', 'buddypress' ) . '</strong></p>' .
+			'<p>' . $documentation_link . '</p>' .
+			'<p>' . $bp_forum . '</p>'
+		);
 	}
 }
 add_action( 'load-settings_page_bp-components', 'bp_core_add_contextual_help' );
@@ -882,6 +872,10 @@ function bp_core_add_contextual_help_content( $tab = '' ) {
 
 		case 'bp-member-types-overview':
 			$retval = __( 'Member Types in BuddyPress provide a powerful way to classify users within your community. By defining various member types, such as "Students", "Teachers", or "Alumni", you can create a more organized and tailored community environment. This feature is especially useful for communities with diverse user groups, allowing customized interactions, content access, and privileges.', 'buddypress' );
+			break;
+
+		case 'bp-emails-overview':
+			$retval = __( 'This screen provides access to all BP Emails. Hovering over a row in the BP Emails list will display action links that allow you to manage the corresponding BP Email.', 'buddypress' );
 			break;
 
 		default:

--- a/src/bp-core/admin/bp-core-admin-functions.php
+++ b/src/bp-core/admin/bp-core-admin-functions.php
@@ -816,6 +816,23 @@ function bp_core_add_contextual_help( $screen = '' ) {
 				esc_html__( 'Managing BP Emails', 'buddypress' )
 			);
 			break;
+
+		case 'bp-email':
+			// Help tab.
+			$screen->add_help_tab(
+				array(
+					'id'      => 'bp-email-overview',
+					'title'   => __( 'Overview', 'buddypress' ),
+					'content' => bp_core_add_contextual_help_content( 'bp-email-overview' ),
+				)
+			);
+
+			$documentation_link = sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( 'https://github.com/buddypress/buddypress/blob/master/docs/user/administration/emails/tokens.md' ),
+				esc_html__( 'BP Email tokens usage', 'buddypress' )
+			);
+			break;
 	}
 
 	if ( $documentation_link ) {
@@ -876,6 +893,14 @@ function bp_core_add_contextual_help_content( $tab = '' ) {
 
 		case 'bp-emails-overview':
 			$retval = __( 'This screen provides access to all BP Emails. Hovering over a row in the BP Emails list will display action links that allow you to manage the corresponding BP Email.', 'buddypress' );
+			break;
+
+		case 'bp-email-overview':
+			$retval = sprintf(
+				/* Translators: %s contains braces within a code tag. */
+				__( 'Phrases wrapped in braces %s are email tokens. Tokens are variable strings that will get replaced with dynamic content when the email gets sent.', 'buddypress' ),
+				'<code>{{ }}</code>'
+			);
 			break;
 
 		default:
@@ -1249,27 +1274,6 @@ function bp_admin_email_maybe_add_translation_notice() {
 	);
 }
 add_action( 'admin_head-edit.php', 'bp_admin_email_maybe_add_translation_notice' );
-
-/**
- * In emails editor, add notice linking to token documentation on Codex.
- *
- * @since 2.5.0
- */
-function bp_admin_email_add_codex_notice() {
-	if ( get_current_screen()->post_type !== bp_get_email_post_type() ) {
-		return;
-	}
-
-	bp_core_add_admin_notice(
-		sprintf(
-			// Translators: %s is the url to the BuddyPress codex page about BP Email tokens.
-			__( 'Phrases wrapped in braces <code>{{ }}</code> are email tokens. <a href="%s">Learn about tokens on the BuddyPress Codex</a>.', 'buddypress' ),
-			esc_url( 'https://codex.buddypress.org/emails/email-tokens/' )
-		),
-		'error'
-	);
-}
-add_action( 'admin_head-post.php', 'bp_admin_email_add_codex_notice' );
 
 /**
  * Display metabox for email taxonomy type.

--- a/src/bp-core/classes/class-bp-admin.php
+++ b/src/bp-core/classes/class-bp-admin.php
@@ -226,7 +226,8 @@ class BP_Admin {
 
 		// Emails
 		add_filter( 'bp_admin_menu_order', array( $this, 'emails_admin_menu_order' ), 20 );
-		add_action( 'load-edit.php', array( $this, 'post_type_load_edit' ), 20 );
+		add_action( 'load-edit.php', array( $this, 'post_type_load_admin_screen' ), 20 );
+		add_action( 'load-post.php', array( $this, 'post_type_load_admin_screen' ), 20 );
 
 		// Official BuddyPress supported Add-ons.
 		add_filter( 'install_plugins_tabs', array( $this, 'addons_tab' ) );
@@ -1290,8 +1291,13 @@ class BP_Admin {
 		}
 	}
 
-	public function post_type_load_edit() {
-		$screen = '';
+	/**
+	 * Adds BP Custom Post Types Admin screen's help tab.
+	 *
+	 * @since 14.0.0
+	 */
+	public function post_type_load_admin_screen() {
+		$screen = null;
 		if ( function_exists( 'get_current_screen' ) ) {
 			$screen = get_current_screen();
 		}

--- a/src/bp-core/classes/class-bp-admin.php
+++ b/src/bp-core/classes/class-bp-admin.php
@@ -226,6 +226,7 @@ class BP_Admin {
 
 		// Emails
 		add_filter( 'bp_admin_menu_order', array( $this, 'emails_admin_menu_order' ), 20 );
+		add_action( 'load-edit.php', array( $this, 'post_type_load_edit' ), 20 );
 
 		// Official BuddyPress supported Add-ons.
 		add_filter( 'install_plugins_tabs', array( $this, 'addons_tab' ) );
@@ -1287,6 +1288,19 @@ class BP_Admin {
 			echo implode( '</li><li>', array_map( 'esc_html', $situations ) );
 			echo '</li></ul>';
 		}
+	}
+
+	public function post_type_load_edit() {
+		$screen = '';
+		if ( function_exists( 'get_current_screen' ) ) {
+			$screen = get_current_screen();
+		}
+
+		if ( ! isset( $screen->post_type ) || bp_get_email_post_type() !== $screen->post_type ) {
+			return;
+		}
+
+		bp_core_add_contextual_help( $screen );
 	}
 
 	/** Helpers ***************************************************************/

--- a/src/bp-core/deprecated/14.0.php
+++ b/src/bp-core/deprecated/14.0.php
@@ -63,3 +63,26 @@ function bp_use_wp_admin_bar() {
 	 */
 	return apply_filters_deprecated( 'bp_use_wp_admin_bar', array( $use_admin_bar ), '14.0.0' );
 }
+
+/**
+ * In emails editor, add notice linking to token documentation on Codex.
+ *
+ * @since 2.5.0
+ * @deprecated 14.0.0
+ */
+function bp_admin_email_add_codex_notice() {
+	_deprecated_function( __FUNCTION__, '14.0.0' );
+
+	if ( get_current_screen()->post_type !== bp_get_email_post_type() ) {
+		return;
+	}
+
+	bp_core_add_admin_notice(
+		sprintf(
+			// Translators: %s is the url to the BuddyPress codex page about BP Email tokens.
+			__( 'Phrases wrapped in braces <code>{{ }}</code> are email tokens. <a href="%s">Learn about tokens on the BuddyPress Codex</a>.', 'buddypress' ),
+			esc_url( 'https://codex.buddypress.org/emails/email-tokens/' )
+		),
+		'error'
+	);
+}


### PR DESCRIPTION
- Improve `bp_core_add_contextual_help()` to avoid code duplication.
- Add an help tab linking to the user documentation page explaining how to manage BP Emails.
- Add an help tab linking to the user documentation page explaining BP Email tokens usage.
- Deprecate `bp_admin_email_add_codex_notice()`.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9159

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
