### PR TITLE
Handle the case when a user has an invite to join a public group

### DIFF
--- a/src/bp-groups/bp-groups-template.php
+++ b/src/bp-groups/bp-groups-template.php
@@ -3472,6 +3472,7 @@ function bp_group_join_button( $group = false ) {
 	 * Get the arguments for the Join button group
 	 *
 	 * @since 11.0.0
+	 * @since 14.0.0 Handles the case when a user has an invite to join a public group.
 	 *
 	 * @param BP_Groups_Group $group The group object.
 	 * @return Array The arguments for the Join button group
@@ -3533,26 +3534,50 @@ function bp_group_join_button( $group = false ) {
 					return $button_args;
 
 				case 'public':
-					$url = wp_nonce_url(
-						bp_get_group_url(
-							$group,
-							bp_groups_get_path_chunks( array( 'join' ) )
-						),
-						'groups_join_group'
-					);
 
-					$button_args = array(
-						'id'                => 'join_group',
-						'component'         => 'groups',
-						'must_be_logged_in' => true,
-						'block_self'        => false,
-						'wrapper_class'     => 'group-button ' . $group->status,
-						'wrapper_id'        => 'groupbutton-' . $group->id,
-						'link_href'         => $url,
-						'link_text'         => __( 'Join Group', 'buddypress' ),
-						'link_title'        => __( 'Join Group', 'buddypress' ),
-						'link_class'        => 'group-button join-group',
-					);
+					// Member has outstanding invitation -
+					// show an "Accept Invitation" button.
+					if ( $group->is_invited ) {
+						$url = add_query_arg( 'redirect_to', bp_get_group_url( $group ), bp_get_group_accept_invite_link( $group ) );
+
+						$button_args = array(
+							'id'                => 'accept_invite',
+							'component'         => 'groups',
+							'must_be_logged_in' => true,
+							'block_self'        => false,
+							'wrapper_class'     => 'group-button ' . $group->status,
+							'wrapper_id'        => 'groupbutton-' . $group->id,
+							'link_href'         => $url,
+							'link_text'         => __( 'Accept Invitation', 'buddypress' ),
+							'link_title'        => __( 'Accept Invitation', 'buddypress' ),
+							'link_class'        => 'group-button accept-invite',
+						);
+
+						// Member has no outstanding invitation -
+						// show a "Join Group" button.
+					} else {
+						$url = wp_nonce_url(
+							bp_get_group_url(
+								$group,
+								bp_groups_get_path_chunks( array( 'join' ) )
+							),
+							'groups_join_group'
+						);
+
+						$button_args = array(
+							'id'                => 'join_group',
+							'component'         => 'groups',
+							'must_be_logged_in' => true,
+							'block_self'        => false,
+							'wrapper_class'     => 'group-button ' . $group->status,
+							'wrapper_id'        => 'groupbutton-' . $group->id,
+							'link_href'         => $url,
+							'link_text'         => __( 'Join Group', 'buddypress' ),
+							'link_title'        => __( 'Join Group', 'buddypress' ),
+							'link_class'        => 'group-button join-group',
+						);
+					}
+
 					break;
 
 				case 'private' :
@@ -3573,8 +3598,8 @@ function bp_group_join_button( $group = false ) {
 							'link_class'        => 'group-button accept-invite',
 						);
 
-					// Member has requested membership but request is pending -
-					// show a "Request Sent" button.
+						// Member has requested membership but request is pending -
+						// show a "Request Sent" button.
 					} elseif ( $group->is_pending ) {
 						$button_args = array(
 							'id'                => 'membership_requested',
@@ -3589,8 +3614,8 @@ function bp_group_join_button( $group = false ) {
 							'link_class'        => 'group-button pending membership-requested',
 						);
 
-					// Member has not requested membership yet -
-					// show a "Request Membership" button.
+						// Member has not requested membership yet -
+						// show a "Request Membership" button.
 					} else {
 						$url = wp_nonce_url(
 							bp_get_group_url(

--- a/src/bp-templates/bp-legacy/buddypress-functions.php
+++ b/src/bp-templates/bp-legacy/buddypress-functions.php
@@ -6,7 +6,7 @@
  *
  * @package BuddyPress
  * @subpackage BP_Theme_Compat
- * @version 12.0.0
+ * @version 14.0.0
  */
 
 // Exit if accessed directly.
@@ -1610,7 +1610,7 @@ function bp_legacy_theme_ajax_joinleave_group() {
 	// Client doesn't distinguish between different request types, so we infer from user status.
 	if ( groups_is_user_member( bp_loggedin_user_id(), $group->id ) ) {
 		$request_type = 'leave_group';
-	} elseif ( groups_check_user_has_invite( bp_loggedin_user_id(), $group->id ) && 'joinleave_group' !== $action ) {
+	} elseif ( groups_check_user_has_invite( bp_loggedin_user_id(), $group->id ) ) {
 		$request_type = 'accept_invite';
 	} elseif ( 'private' === $group->status ) {
 		$request_type = 'request_membership';
@@ -1641,10 +1641,6 @@ function bp_legacy_theme_ajax_joinleave_group() {
 		break;
 
 		case 'accept_invite' :
-			if ( ! bp_current_user_can( 'groups_request_membership', array( 'group_id' => $group->id ) ) ) {
-				esc_html_e( 'Error accepting invitation', 'buddypress' );
-			}
-
 			check_ajax_referer( 'groups_accept_invite' );
 
 			if ( ! groups_accept_invite( bp_loggedin_user_id(), $group->id ) ) {
@@ -1664,7 +1660,7 @@ function bp_legacy_theme_ajax_joinleave_group() {
 		case 'request_membership' :
 			check_ajax_referer( 'groups_request_membership' );
 
-			if ( ! groups_send_membership_request( [ 'user_id' => bp_loggedin_user_id(), 'group_id' => $group->id ] ) ) {
+			if ( ! bp_current_user_can( 'groups_request_membership', array( 'group_id' => $group->id ) ) || ! groups_send_membership_request( [ 'user_id' => bp_loggedin_user_id(), 'group_id' => $group->id ] ) ) {
 				esc_html_e( 'Error requesting membership', 'buddypress' );
 			} else {
 				echo '<a id="group-' . esc_attr( $group->id ) . '" class="group-button disabled pending membership-requested" rel="membership-requested" href="' . esc_url( bp_get_group_url( $group ) ) . '">' . esc_html__( 'Request Sent', 'buddypress' ) . '</a>';


### PR DESCRIPTION
- In Groups template: use specific button arguments in case a user has been invited to join a public group (make it different than the Join Group button which fails on BP Legacy).
- In BP Legacy, move the group request capability check into the right case (is currently in the accept invite one).

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9154

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
