### PR TITLE
Use better hooks to notify group members they were promoted

### DIFF
--- a/src/bp-groups/bp-groups-notifications.php
+++ b/src/bp-groups/bp-groups-notifications.php
@@ -300,7 +300,7 @@ function groups_notification_promoted_member( $user_id = 0, $group_id = 0 ) {
 	);
 	bp_send_email( 'groups-member-promoted', (int) $user_id, $args );
 }
-add_action( 'groups_promoted_member', 'groups_notification_promoted_member', 10, 2 );
+add_action( 'group_member_promoted', 'groups_notification_promoted_member', 10, 2 );
 
 /**
  * Notify a member they have been invited to a group.
@@ -1055,7 +1055,7 @@ function bp_groups_delete_promotion_notifications( $user_id = 0, $group_id = 0 )
 		bp_notifications_delete_notifications_by_item_id( $user_id, $group_id, buddypress()->groups->id, 'member_promoted_to_mod' );
 	}
 }
-add_action( 'groups_demoted_member', 'bp_groups_delete_promotion_notifications', 10, 2 );
+add_action( 'group_member_demoted', 'bp_groups_delete_promotion_notifications', 10, 2 );
 
 /**
  * Mark notifications read when a member accepts a group invitation.

--- a/src/bp-groups/screens/single/admin/manage-members.php
+++ b/src/bp-groups/screens/single/admin/manage-members.php
@@ -48,14 +48,15 @@ function groups_screen_group_admin_manage_members() {
 			}
 
 			/**
-			 * Fires before the redirect after a group member has been promoted.
+			 * Fires before the redirect.
 			 *
 			 * @since 1.0.0
+			 * @deprecated 14.0.0
 			 *
 			 * @param int $user_id ID of the user being promoted.
-			 * @param int $id      ID of the group user is promoted within.
+			 * @param int $id      ID of the group is promoted within.
 			 */
-			do_action( 'groups_promoted_member', $user_id, $bp->groups->current_group->id );
+			do_action_deprecated( 'groups_promoted_member', array( $user_id, $bp->groups->current_group->id ), '14.0.0', 'group_member_promoted' );
 
 			bp_core_redirect( $redirect );
 		}
@@ -86,11 +87,12 @@ function groups_screen_group_admin_manage_members() {
 			 * Fires before the redirect after a group member has been demoted.
 			 *
 			 * @since 1.0.0
+			 * @deprecated 14.0.0
 			 *
 			 * @param int $user_id ID of the user being demoted.
-			 * @param int $id      ID of the group user is demoted within.
+			 * @param int $id      ID of the group is demoted within.
 			 */
-			do_action( 'groups_demoted_member', $user_id, $bp->groups->current_group->id );
+			do_action_deprecated( 'groups_demoted_member', array( $user_id, $bp->groups->current_group->id ), '14.0.0', 'group_member_demoted' );
 
 			bp_core_redirect( $redirect );
 		}
@@ -114,11 +116,12 @@ function groups_screen_group_admin_manage_members() {
 			 * Fires before the redirect after a group member has been banned.
 			 *
 			 * @since 1.0.0
+			 * @deprecated 14.0.0
 			 *
 			 * @param int $user_id ID of the user being banned.
 			 * @param int $id      ID of the group user is banned from.
 			 */
-			do_action( 'groups_banned_member', $user_id, $bp->groups->current_group->id );
+			do_action_deprecated( 'groups_banned_member', array( $user_id, $bp->groups->current_group->id ), '14.0.0', 'group_member_banned' );
 
 			bp_core_redirect( $redirect );
 		}
@@ -142,11 +145,12 @@ function groups_screen_group_admin_manage_members() {
 			 * Fires before the redirect after a group member has been unbanned.
 			 *
 			 * @since 1.0.0
+			 * @deprecated 14.0.0
 			 *
 			 * @param int $user_id ID of the user being unbanned.
 			 * @param int $id      ID of the group user is unbanned from.
 			 */
-			do_action( 'groups_unbanned_member', $user_id, $bp->groups->current_group->id );
+			do_action_deprecated( 'groups_unbanned_member', array( $user_id, $bp->groups->current_group->id ), '14.0.0', 'group_member_unbanned' );
 
 			bp_core_redirect( $redirect );
 		}
@@ -170,11 +174,12 @@ function groups_screen_group_admin_manage_members() {
 			 * Fires before the redirect after a group member has been removed.
 			 *
 			 * @since 1.2.6
+			 * @deprecated 14.0.0
 			 *
 			 * @param int $user_id ID of the user being removed.
 			 * @param int $id      ID of the group the user is removed from.
 			 */
-			do_action( 'groups_removed_member', $user_id, $bp->groups->current_group->id );
+			do_action_deprecated( 'groups_removed_member', array( $user_id, $bp->groups->current_group->id ), '14.0.0', 'group_member_removed' );
 
 			bp_core_redirect( $redirect );
 		}

--- a/tests/phpunit/testcases/groups/notifications.php
+++ b/tests/phpunit/testcases/groups/notifications.php
@@ -181,7 +181,7 @@ class BP_Tests_Groups_Notifications extends BP_UnitTestCase {
 		$this->assertEquals( array( $n ), wp_list_pluck( $notifications, 'id' ) );
 
 		// fire the hook
-		do_action( 'groups_demoted_member', $u, $g );
+		do_action( 'group_member_demoted', $u, $g );
 
 		$notifications = BP_Notifications_Notification::get( array(
 			'user_id' => $u,
@@ -205,7 +205,7 @@ class BP_Tests_Groups_Notifications extends BP_UnitTestCase {
 		$this->assertEquals( array( $n ), wp_list_pluck( $notifications, 'id' ) );
 
 		// fire the hook
-		do_action( 'groups_demoted_member', $u, $g );
+		do_action( 'group_member_demoted', $u, $g );
 
 		$notifications = BP_Notifications_Notification::get( array(
 			'user_id' => $u,


### PR DESCRIPTION
Hi @needle

Just checked, I believe we actually need to update BuddyPress and the BP REST API.

- BuddyPress: it shouldn't use the current hooks as there can be situations where the hook is fired although the requested action failed.
- BuddyPress `groups_$action_member()` function should be usable outside of the Web version using the BP REST API for instance. It's not currently the case and I suspect it to be the reason why we were directly using `BP_Groups_Member->$action()`
- The BP REST API should absolutely use `groups_$action_member()` functions to be sure cache is cleared or group activities are deleted when it's needed. It's currently not the case. I'll soon submit a PR to the BP REST API GH repo.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9158

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
