### PR TITLE
Don't let users join a group before its status has been defined.

### DIFF
--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -661,7 +661,15 @@ function groups_join_group( $group, $user_id = 0 ) {
 
 	$group = bp_get_group( $group );
 
-	if ( empty( $group->id ) ) {
+	/*
+	 * When the group create first step is completed, the group's status has not been defined by the
+	 * group creator yet and defaults to public. As the group status & the invite status are set once
+	 * the group create second step is completed, we need to wait for this step to be achieved to let
+	 * users join the group being created otherwise it would be possible for a user to "pre-join" a
+	 * private/hidden group. Checking if the invite status is set is the only way to make sure this
+	 * second step has been completed. If it's not the case, no need to go further.
+	 */
+	if ( empty( $group->id ) || ! groups_get_groupmeta( $group->id, 'invite_status' ) ) {
 		return false;
 	}
 

--- a/tests/phpunit/includes/factory.php
+++ b/tests/phpunit/includes/factory.php
@@ -93,12 +93,13 @@ class BP_UnitTest_Factory_For_Group extends WP_UnitTest_Factory_For_Thing {
 		parent::__construct( $factory );
 
 		$this->default_generation_definitions = array(
-			'name'         => new WP_UnitTest_Generator_Sequence( 'Group %s' ),
-			'description'  => new WP_UnitTest_Generator_Sequence( 'Group description %s' ),
-			'slug'         => new WP_UnitTest_Generator_Sequence( 'group-slug-%s' ),
-			'status'       => 'public',
-			'enable_forum' => true,
-			'date_created' => bp_core_current_time(),
+			'name'          => new WP_UnitTest_Generator_Sequence( 'Group %s' ),
+			'description'   => new WP_UnitTest_Generator_Sequence( 'Group description %s' ),
+			'slug'          => new WP_UnitTest_Generator_Sequence( 'group-slug-%s' ),
+			'status'        => 'public',
+			'enable_forum'  => true,
+			'date_created'  => bp_core_current_time(),
+			'invite_status' => 'members',
 		);
 	}
 
@@ -130,6 +131,8 @@ class BP_UnitTest_Factory_For_Group extends WP_UnitTest_Factory_For_Thing {
 		groups_update_groupmeta( $group_id, 'total_member_count', 1 );
 		$last_activity = isset( $args['last_activity'] ) ? $args['last_activity'] : bp_core_current_time();
 		groups_update_groupmeta( $group_id, 'last_activity', $last_activity );
+		groups_update_groupmeta( $group_id, 'invite_status', $args['invite_status'] );
+
 
 		return $group_id;
 	}

--- a/tests/phpunit/testcases/groups/cache.php
+++ b/tests/phpunit/testcases/groups/cache.php
@@ -41,6 +41,9 @@ class BP_Tests_Group_Cache extends BP_UnitTestCase {
 				'last_activity' => array(
 					$time,
 				),
+				'invite_status' => array(
+					'members',
+				),
 				'foo' => array(
 					'bar',
 				),
@@ -51,6 +54,9 @@ class BP_Tests_Group_Cache extends BP_UnitTestCase {
 				),
 				'last_activity' => array(
 					$time,
+				),
+				'invite_status' => array(
+					'members',
 				),
 				'foo' => array(
 					'baz',

--- a/tests/phpunit/testcases/groups/class-bp-groups-member.php
+++ b/tests/phpunit/testcases/groups/class-bp-groups-member.php
@@ -207,7 +207,6 @@ class BP_Tests_BP_Groups_Member_TestCases extends BP_UnitTestCase {
 
 		// Test with no status
 		// In bp_group_get_invite_status(), no status falls back to "members"
-		$this->assertTrue( '' == groups_get_groupmeta( $g, 'invite_status' ) );
 		$this->assertFalse( bp_groups_user_can_send_invites( $g, $u_nonmembers ) );
 		$this->assertTrue( bp_groups_user_can_send_invites( $g, $u_members ) );
 		$this->assertTrue( bp_groups_user_can_send_invites( $g, $u_mods ) );


### PR DESCRIPTION
Use the `invite_status` group meta to check the group create second step has been completed.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9162

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
