### PR TITLE
Add advanced BP theme supports checks

### DIFF
--- a/src/bp-core/bp-core-theme-compatibility.php
+++ b/src/bp-core/bp-core-theme-compatibility.php
@@ -1068,7 +1068,7 @@ function bp_register_buddypress_theme_feature() {
 		array(
 			'type'        => 'array',
 			'variadic'    => true,
-			'description' => __( 'Whether the Theme supports BuddyPress and possibly BP Modern features', 'buddypress' ),
+			'description' => __( 'Whether the Theme supports BuddyPress and possibly BP Components specific features', 'buddypress' ),
 		)
 	);
 }
@@ -1083,14 +1083,16 @@ add_action( 'bp_init', 'bp_register_buddypress_theme_feature' );
  * @since 14.0.0
  * @access private
  *
- * @param bool   $supports Whether the active theme supports the given feature. Default false.
- * @param array  $args     Array of arguments for the feature.
- * @param string $feature  The theme feature.
+ * @param bool  $supports Whether the active theme supports the given feature. Default false.
+ * @param array $args     Array of arguments for the feature.
+ * @param mixed $feature  The theme feature.
  * @return boolean True if the feature is supported. False otherwise.
  */
 function _bp_filter_current_theme_supports( $supports = false, $args = array(), $feature = null ) {
+	$params             = reset( $args );
+	$is_expected_params = array_filter( array_map( 'is_string', array_keys( $params ) ) );
 
-	if ( true === $supports && $args ) {
+	if ( true === $supports && $is_expected_params ) {
 		$component         = key( $args[0] );
 		$component_feature = $args[0][ $component ];
 
@@ -1113,17 +1115,23 @@ add_filter( 'current_theme_supports-buddypress', '_bp_filter_current_theme_suppo
  *
  * @since 14.0.0
  *
- * @param array
- * @return boolean True if the Theme supports BP component specicif features. False otherwise.
+ * @param array $args An associative array containing **ONE** feature & keyed by the BP Component ID.
+ * @return boolean True if the theme supports the BP feature. False otherwise.
  */
 function bp_current_theme_supports( $args = array() ) {
-	$supports = false;
-
-	if ( $args ) {
-		$supports = current_theme_supports( 'buddypress', $args );
-	} else {
-		$supports = current_theme_supports( 'buddypress' );
+	if ( is_array( $args ) && $args && ( 1 < count( $args ) || is_array( $args[ key( $args ) ] ) ) ) {
+		_doing_it_wrong( __FUNCTION__, esc_html( 'The function only supports checking 1 feature for a specific component at a time for now.', 'buddypress' ), '14.0.0' );
+		return false;
 	}
 
+	$supports = current_theme_supports( 'buddypress', $args );
+
+	/**
+	 * Filter here to edit BP Theme supports.
+	 *
+	 * @since 14.0.0
+	 *
+	 * @param boolean $supports True if the theme supports the BP feature. False otherwise.
+	 */
 	return apply_filters( 'bp_current_theme_supports', $supports, $args );
 }

--- a/src/bp-core/bp-core-theme-compatibility.php
+++ b/src/bp-core/bp-core-theme-compatibility.php
@@ -1093,13 +1093,12 @@ function _bp_filter_current_theme_supports( $supports = false, $args = array(), 
 	$is_expected_params = array_filter( array_map( 'is_string', array_keys( $params ) ) );
 
 	if ( true === $supports && $is_expected_params ) {
-		$component         = key( $args[0] );
-		$component_feature = $args[0][ $component ];
-
 		if ( ! is_array( $feature ) ) {
 			$supports = false;
 		} else {
-			$theme_feature = $feature[0];
+			$component         = key( $args[0] );
+			$component_feature = $args[0][ $component ];
+			$theme_feature     = $feature[0];
 
 			// Check the theme is supporting the component's feature.
 			$supports = isset( $theme_feature[ $component ] ) && in_array( $component_feature, $theme_feature[ $component ], true );

--- a/tests/phpunit/testcases/core/themeCompatibility.php
+++ b/tests/phpunit/testcases/core/themeCompatibility.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @group core
+ * @group core-theme-compatibility
+ */
+class BP_Tests_Theme_Compatibility_Functions extends BP_UnitTestCase {
+
+	/**
+	 * @group bp_current_theme_supports
+	 */
+	public function test_bp_current_theme_doesnot_support() {
+		$this->assertFalse( bp_current_theme_supports() );
+	}
+
+	/**
+	 * @group bp_current_theme_supports
+	 */
+	public function test_bp_current_theme_does_support_buddypress() {
+		add_theme_support( 'buddypress' );
+		$this->assertTrue( bp_current_theme_supports() );
+		remove_theme_support( 'buddypress' );
+	}
+
+	/**
+	 * @group bp_current_theme_supports
+	 */
+	public function test_bp_current_theme_doesnot_support_buddypress_feature() {
+		add_theme_support( 'buddypress' );
+		$this->assertFalse( bp_current_theme_supports( array( 'activity' => 'feature' ) ) );
+		remove_theme_support( 'buddypress' );
+	}
+
+	/**
+	 * @group bp_current_theme_supports
+	 */
+	public function test_bp_current_theme_does_support_buddypress_feature() {
+		add_theme_support(
+			'buddypress',
+			array(
+				'activity' => array( 'feature1', 'feature2' ),
+			)
+		);
+		$this->assertTrue( bp_current_theme_supports( array( 'activity' => 'feature1' ) ) );
+		$this->assertFalse( bp_current_theme_supports( array( 'activity' => 'feature3' ) ) );
+		$this->assertFalse( bp_current_theme_supports( array( 'notifications' => '' ) ) );
+		$this->assertTrue( bp_current_theme_supports() );
+
+		remove_theme_support( 'buddypress' );
+	}
+}

--- a/tests/phpunit/testcases/core/themeCompatibility.php
+++ b/tests/phpunit/testcases/core/themeCompatibility.php
@@ -2,49 +2,57 @@
 /**
  * @group core
  * @group core-theme-compatibility
+ * @group bp_current_theme_supports
  */
 class BP_Tests_Theme_Compatibility_Functions extends BP_UnitTestCase {
 
-	/**
-	 * @group bp_current_theme_supports
-	 */
 	public function test_bp_current_theme_doesnot_support() {
 		$this->assertFalse( bp_current_theme_supports() );
 	}
 
-	/**
-	 * @group bp_current_theme_supports
-	 */
 	public function test_bp_current_theme_does_support_buddypress() {
 		add_theme_support( 'buddypress' );
 		$this->assertTrue( bp_current_theme_supports() );
-		remove_theme_support( 'buddypress' );
 	}
 
-	/**
-	 * @group bp_current_theme_supports
-	 */
 	public function test_bp_current_theme_doesnot_support_buddypress_feature() {
 		add_theme_support( 'buddypress' );
 		$this->assertFalse( bp_current_theme_supports( array( 'activity' => 'feature' ) ) );
-		remove_theme_support( 'buddypress' );
 	}
 
-	/**
-	 * @group bp_current_theme_supports
-	 */
 	public function test_bp_current_theme_does_support_buddypress_feature() {
 		add_theme_support(
 			'buddypress',
 			array(
-				'activity' => array( 'feature1', 'feature2' ),
+				'activity'      => array( 'feature1', 'feature2' ),
 			)
 		);
 		$this->assertTrue( bp_current_theme_supports( array( 'activity' => 'feature1' ) ) );
 		$this->assertFalse( bp_current_theme_supports( array( 'activity' => 'feature3' ) ) );
 		$this->assertFalse( bp_current_theme_supports( array( 'notifications' => '' ) ) );
 		$this->assertTrue( bp_current_theme_supports() );
+	}
 
-		remove_theme_support( 'buddypress' );
+	/**
+	 * @expectedIncorrectUsage bp_current_theme_supports
+	 */
+	public function test_bp_current_theme_support_incorrect_usage() {
+		add_theme_support(
+			'buddypress',
+			array(
+				'activity'      => array( 'feature1', 'feature2' ),
+				'notifications' => array( 'feature3' ),
+			)
+		);
+
+		$this->assertFalse( bp_current_theme_supports( array( 'activity' => array( 'feature1', 'feature2' ) ) ) );
+		$this->assertFalse(
+			bp_current_theme_supports(
+				array(
+					'activity'      => 'feature1',
+					'notifications' => 'feature3',
+				)
+			)
+		);
 	}
 }


### PR DESCRIPTION
This PR is extending the WP theme supports API to be able to check Standalone themes opted in for BP Modern features such as the Activity Block Editor.

Usage in theme:
```php
add_theme_support(
	'buddypress',
	array(
		'activity' => array( 'block-editor' ),
		'messages' => array( 'pagination' ),
	)
);
```

Usage in BuddyPress:
```php
if ( bp_current_theme_supports( array( 'activity' => 'block-editor' ) ) ) {}
```

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8319

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
