### PR TITLE
Docblock: Update incorrect instances of `void`

### DIFF
--- a/src/bp-activity/screens/friends.php
+++ b/src/bp-activity/screens/friends.php
@@ -11,8 +11,6 @@
  * Load the 'My Friends' activity page.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function bp_activity_screen_friends() {
 	if ( ! bp_is_active( 'friends' ) ) {

--- a/src/bp-activity/screens/groups.php
+++ b/src/bp-activity/screens/groups.php
@@ -11,8 +11,6 @@
  * Load the 'My Groups' activity page.
  *
  * @since 1.2.0
- *
- * @return void
  */
 function bp_activity_screen_groups() {
 	if ( ! bp_is_active( 'groups' ) ) {

--- a/src/bp-activity/screens/mentions.php
+++ b/src/bp-activity/screens/mentions.php
@@ -41,8 +41,6 @@ function bp_activity_screen_mentions() {
  * Reset the logged-in user's new mentions data when he visits his mentions screen.
  *
  * @since 1.5.0
- *
- * @return void
  */
 function bp_activity_reset_my_new_mentions() {
 	if ( ! bp_is_my_profile() ) {

--- a/src/bp-activity/screens/permalink.php
+++ b/src/bp-activity/screens/permalink.php
@@ -95,8 +95,6 @@ add_action( 'bp_actions', 'bp_activity_action_permalink_router' );
  * Load the page for a single activity item.
  *
  * @since 1.2.0
- *
- * @return void
  */
 function bp_activity_screen_single_activity_permalink() {
 	// No displayed user or not viewing activity component.

--- a/src/bp-blogs/screens/create.php
+++ b/src/bp-blogs/screens/create.php
@@ -11,8 +11,6 @@
  * Load the "Create a Blog" screen.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function bp_blogs_screen_create_a_blog() {
 

--- a/src/bp-blogs/screens/my-blogs.php
+++ b/src/bp-blogs/screens/my-blogs.php
@@ -11,8 +11,6 @@
  * Load the "My Blogs" screen.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function bp_blogs_screen_my_blogs() {
 	if ( ! is_multisite() ) {

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -825,7 +825,7 @@ function bp_core_get_directory_pages() {
  *                              and replace with new ones. Otherwise existing page mappings
  *                              are kept, and the gaps filled in with new pages. Default: 'keep'.
  * @param boolean $return_pages Whether to return the page mapping or not.
- * @return void|array
+ * @return array|null
  */
 function bp_core_add_page_mappings( $components, $existing = 'keep', $return_pages = false ) {
 

--- a/src/bp-core/classes/class-bp-core-login-widget.php
+++ b/src/bp-core/classes/class-bp-core-login-widget.php
@@ -55,7 +55,6 @@ class BP_Core_Login_Widget {
 	 *
 	 * @param array $new_instance The new instance options.
 	 * @param array $old_instance The old instance options.
-	 * @return array $instance The parsed options to be saved.
 	 */
 	public function update( $new_instance, $old_instance ) {
 		_deprecated_function( __METHOD__, '12.0.0' );
@@ -68,7 +67,6 @@ class BP_Core_Login_Widget {
 	 * @deprecated 12.0.0
 	 *
 	 * @param array $instance Settings for this widget.
-	 * @return void
 	 */
 	public function form( $instance = array() ) {
 		_deprecated_function( __METHOD__, '12.0.0' );

--- a/src/bp-core/classes/class-bp-optouts-list-table.php
+++ b/src/bp-core/classes/class-bp-optouts-list-table.php
@@ -242,7 +242,6 @@ class BP_Optouts_List_Table extends WP_Users_List_Table {
 	 * @param string    $style    Styles for the row.
 	 * @param string    $role     Role to be assigned to user.
 	 * @param int       $numposts Number of posts.
-	 * @return void
 	 */
 	public function single_row( $optout = null, $style = '', $role = '', $numposts = 0 ) {
 		if ( '' === $style ) {

--- a/src/bp-groups/actions/create.php
+++ b/src/bp-groups/actions/create.php
@@ -11,8 +11,6 @@
  * Catch and process group creation form submissions.
  *
  * @since 1.2.0
- *
- * @return void
  */
 function groups_action_create_group() {
 

--- a/src/bp-groups/actions/join.php
+++ b/src/bp-groups/actions/join.php
@@ -11,8 +11,6 @@
  * Catch and process "Join Group" button clicks.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function groups_action_join_group() {
 

--- a/src/bp-groups/actions/leave-group.php
+++ b/src/bp-groups/actions/leave-group.php
@@ -17,8 +17,6 @@
  * another function handles this. See {@link bp_legacy_theme_ajax_joinleave_group()}.
  *
  * @since 1.2.4
- *
- * @return void
  */
 function groups_action_leave_group() {
 	if ( ! bp_is_single_item() || ! bp_is_groups_component() || ! bp_is_current_action( 'leave-group' ) ) {

--- a/src/bp-groups/bp-groups-template.php
+++ b/src/bp-groups/bp-groups-template.php
@@ -7,8 +7,6 @@
  * @since 1.5.0
  */
 
-use Mantle\Support\Stringable;
-
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 

--- a/src/bp-groups/bp-groups-template.php
+++ b/src/bp-groups/bp-groups-template.php
@@ -7,6 +7,8 @@
  * @since 1.5.0
  */
 
+use Mantle\Support\Stringable;
+
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
@@ -4220,7 +4222,7 @@ function bp_group_member_name() {
 	 *
 	 * @global BP_Core_Members_Template $members_template The Members template loop class.
 	 *
-	 * @return mixed|void
+	 * @return string|null
 	 */
 	function bp_get_group_member_name() {
 		global $members_template;
@@ -4250,7 +4252,7 @@ function bp_group_member_url() {
 	 *
 	 * @global BP_Core_Members_Template $members_template The Members template loop class.
 	 *
-	 * @return mixed|void
+	 * @return string
 	 */
 	function bp_get_group_member_url() {
 		global $members_template;
@@ -4260,7 +4262,7 @@ function bp_group_member_url() {
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param string $value URL for the current user.
+		 * @param string $group_member_url URL for the current user.
 		 */
 		return apply_filters( 'bp_get_group_member_url', bp_members_get_user_url( $members_template->member->user_id ) );
 	}
@@ -4281,7 +4283,7 @@ function bp_group_member_link() {
 	 *
 	 * @global BP_Core_Members_Template $members_template The Members template loop class.
 	 *
-	 * @return mixed|void
+	 * @return string
 	 */
 	function bp_get_group_member_link() {
 		global $members_template;
@@ -4291,7 +4293,7 @@ function bp_group_member_link() {
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param string $value HTML link for the current user.
+		 * @param string $group_member_link HTML link for the current user.
 		 */
 		return apply_filters( 'bp_get_group_member_link', '<a href="' . esc_url( bp_members_get_user_url( $members_template->member->user_id ) ) . '">' . esc_html( $members_template->member->display_name ) . '</a>' );
 	}
@@ -4311,7 +4313,7 @@ function bp_group_member_domain() {
 	 *
 	 * @global BP_Core_Members_Template $members_template The Members template loop class.
 	 *
-	 * @return mixed|void
+	 * @return string
 	 */
 	function bp_get_group_member_domain() {
 		global $members_template;
@@ -4321,7 +4323,7 @@ function bp_group_member_domain() {
 		 *
 		 * @since 1.2.0
 		 *
-		 * @param string $value Domain for the current user.
+		 * @param string $group_member_domain Domain for the current user.
 		 */
 		return apply_filters( 'bp_get_group_member_domain', bp_members_get_user_url( $members_template->member->user_id ) );
 	}
@@ -4341,7 +4343,7 @@ function bp_group_member_is_friend() {
 	 *
 	 * @global BP_Core_Members_Template $members_template The Members template loop class.
 	 *
-	 * @return mixed|void
+	 * @return string
 	 */
 	function bp_get_group_member_is_friend() {
 		global $members_template;
@@ -4539,7 +4541,7 @@ function bp_group_pag_id() {
 	/**
 	 * @since 1.0.0
 	 *
-	 * @return mixed|void
+	 * @return string
 	 */
 	function bp_get_group_pag_id() {
 
@@ -4548,7 +4550,7 @@ function bp_group_pag_id() {
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param string $value Value to use for the pag id.
+		 * @param string $pag_id Value to use for the pag id.
 		 */
 		return apply_filters( 'bp_get_group_pag_id', 'pag' );
 	}
@@ -4567,11 +4569,11 @@ function bp_group_member_pagination() {
 	/**
 	 * Returns the group members list pagination links.
 	 *
-	 *  @since 1.0.0
+	 * @since 1.0.0
 	 *
 	 * @global BP_Core_Members_Template $members_template The Members template loop class.
 	 *
-	 * @return mixed|void
+	 * @return string|null
 	 */
 	function bp_get_group_member_pagination() {
 		global $members_template;
@@ -4601,7 +4603,7 @@ function bp_group_member_pagination_count() {
 	 *
 	 * @global BP_Core_Members_Template $members_template The Members template loop class.
 	 *
-	 * @return mixed|void
+	 * @return string
 	 */
 	function bp_get_group_member_pagination_count() {
 		global $members_template;
@@ -4623,7 +4625,7 @@ function bp_group_member_pagination_count() {
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param string $value    "Viewing x-y of z members" text.
+		 * @param string $message  "Viewing x-y of z members" text.
 		 * @param string $from_num Total amount for the low value in the range.
 		 * @param string $to_num   Total amount for the high value in the range.
 		 * @param string $total    Total amount of members found.
@@ -6154,8 +6156,13 @@ function bp_group_requests_pagination_count() {
  *
  * @since 1.1.0
  *
- * @param string $args
- * @return bool|mixed|void
+ * @param string|array $args {
+ *    @type int $group_id ID of the group. Defaults to current group.
+ *    @type int $user_id  ID of the user. Defaults to logged-in user.
+ *    @type int $per_page Number of records to return per page. Default: 10.
+ *    @type int $page     Page of results to return. Default: 1.
+ * }
+ * @return bool
  */
 function bp_group_has_invites( $args = '' ) {
 	global $invites_template, $group_id;
@@ -6195,7 +6202,7 @@ function bp_group_has_invites( $args = '' ) {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param bool                      $value            Whether there are requests to display.
+	 * @param bool                      $invites          Whether there are invites to display.
 	 * @param BP_Groups_Invite_Template $invites_template Object holding the invites query results.
 	 */
 	return apply_filters( 'bp_group_has_invites', $invites_template->has_invites(), $invites_template );
@@ -6233,7 +6240,7 @@ function bp_group_invite_item_id() {
 	/**
 	 * @since 1.1.0
 	 *
-	 * @return mixed|void
+	 * @return string
 	 */
 	function bp_get_group_invite_item_id() {
 		global $invites_template;
@@ -6243,7 +6250,7 @@ function bp_group_invite_item_id() {
 		 *
 		 * @since 1.1.0
 		 *
-		 * @param string $value Group invite item ID.
+		 * @param string $group_invite_item_id Group invite item ID.
 		 */
 		return apply_filters( 'bp_get_group_invite_item_id', 'uid-' . $invites_template->invite->user->id );
 	}
@@ -6259,7 +6266,7 @@ function bp_group_invite_user_avatar() {
 	/**
 	 * @since 1.1.0
 	 *
-	 * @return mixed|void
+	 * @return string|null
 	 */
 	function bp_get_group_invite_user_avatar() {
 		global $invites_template;
@@ -6269,7 +6276,7 @@ function bp_group_invite_user_avatar() {
 		 *
 		 * @since 1.1.0
 		 *
-		 * @param string $value Group invite user avatar.
+		 * @param string $invite_user_avatar Group invite user avatar.
 		 */
 		return apply_filters( 'bp_get_group_invite_user_avatar', $invites_template->invite->user->avatar_thumb );
 	}
@@ -6285,7 +6292,7 @@ function bp_group_invite_user_link() {
 	/**
 	 * @since 1.1.0
 	 *
-	 * @return mixed|void
+	 * @return string
 	 */
 	function bp_get_group_invite_user_link() {
 		global $invites_template;
@@ -6295,9 +6302,9 @@ function bp_group_invite_user_link() {
 		 *
 		 * @since 1.1.0
 		 *
-		 * @param string $value Group invite user link.
+		 * @param string $user_link Group invite user link.
 		 */
-		return apply_filters( 'bp_get_group_invite_user_link', bp_core_get_userlink( $invites_template->invite->user->id ) );
+		return apply_filters( 'bp_get_group_invite_user_link', (string) bp_core_get_userlink( $invites_template->invite->user->id ) );
 	}
 
 /**
@@ -6310,7 +6317,7 @@ function bp_group_invite_user_last_active() {
 	/**
 	 * @since 1.1.0
 	 *
-	 * @return mixed|void
+	 * @return string|null
 	 */
 	function bp_get_group_invite_user_last_active() {
 		global $invites_template;
@@ -6320,7 +6327,7 @@ function bp_group_invite_user_last_active() {
 		 *
 		 * @since 1.1.0
 		 *
-		 * @param string $value Group invite user's last active time.
+		 * @param string $user_last_active Group invite user's last active time.
 		 */
 		return apply_filters( 'bp_get_group_invite_user_last_active', $invites_template->invite->user->last_active );
 	}

--- a/src/bp-groups/classes/class-bp-groups-group-members-template.php
+++ b/src/bp-groups/classes/class-bp-groups-group-members-template.php
@@ -60,7 +60,7 @@ class BP_Groups_Group_Members_Template {
 
 	/**
 	 * @since 1.0.0
-	 * @var array|string|void
+	 * @var array|string|null
 	 */
 	public $pag_links;
 

--- a/src/bp-groups/classes/class-bp-groups-membership-requests-template.php
+++ b/src/bp-groups/classes/class-bp-groups-membership-requests-template.php
@@ -60,7 +60,7 @@ class BP_Groups_Membership_Requests_Template {
 
 	/**
 	 * @since 1.0.0
-	 * @var array|string|void
+	 * @var array|string|null
 	 */
 	public $pag_links;
 

--- a/src/bp-groups/screens/single/activity-permalink.php
+++ b/src/bp-groups/screens/single/activity-permalink.php
@@ -14,8 +14,6 @@
  * Handle the display of a single group activity item.
  *
  * @since 1.2.0
- *
- * @return void
  */
 function groups_screen_group_activity_permalink() {
 	if ( ! bp_is_groups_component() || ! bp_is_active( 'activity' ) || ( bp_is_active( 'activity' ) && ! bp_is_current_action( bp_get_activity_slug() ) ) || ! bp_action_variable( 0 ) ) {

--- a/src/bp-groups/screens/single/activity.php
+++ b/src/bp-groups/screens/single/activity.php
@@ -11,8 +11,6 @@
  * Handle the loading of a single group's activity.
  *
  * @since 2.4.0
- *
- * @return void
  */
 function groups_screen_group_activity() {
 

--- a/src/bp-groups/screens/single/admin/delete-group.php
+++ b/src/bp-groups/screens/single/admin/delete-group.php
@@ -11,8 +11,6 @@
  * Handle the display of the Delete Group page.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function groups_screen_group_admin_delete_group() {
 

--- a/src/bp-groups/screens/single/admin/edit-details.php
+++ b/src/bp-groups/screens/single/admin/edit-details.php
@@ -11,8 +11,6 @@
  * Handle the display of a group's admin/edit-details page.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function groups_screen_group_admin_edit_details() {
 

--- a/src/bp-groups/screens/single/admin/group-avatar.php
+++ b/src/bp-groups/screens/single/admin/group-avatar.php
@@ -11,8 +11,6 @@
  * Handle the display of a group's Change Avatar page.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function groups_screen_group_admin_avatar() {
 

--- a/src/bp-groups/screens/single/admin/group-cover-image.php
+++ b/src/bp-groups/screens/single/admin/group-cover-image.php
@@ -11,8 +11,6 @@
  * Handle the display of a group's Change cover image page.
  *
  * @since 2.4.0
- *
- * @return void
  */
 function groups_screen_group_admin_cover_image() {
 	if ( 'group-cover-image' != bp_get_group_current_admin_tab() ) {

--- a/src/bp-groups/screens/single/admin/group-settings.php
+++ b/src/bp-groups/screens/single/admin/group-settings.php
@@ -11,8 +11,6 @@
  * Handle the display of a group's admin/group-settings page.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function groups_screen_group_admin_settings() {
 

--- a/src/bp-groups/screens/single/admin/manage-members.php
+++ b/src/bp-groups/screens/single/admin/manage-members.php
@@ -11,8 +11,6 @@
  * This function handles actions related to member management on the group admin.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function groups_screen_group_admin_manage_members() {
 

--- a/src/bp-groups/screens/single/admin/membership-requests.php
+++ b/src/bp-groups/screens/single/admin/membership-requests.php
@@ -11,8 +11,6 @@
  * Handle the display of Admin > Membership Requests.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function groups_screen_group_admin_requests() {
 	$bp = buddypress();

--- a/src/bp-groups/screens/single/home.php
+++ b/src/bp-groups/screens/single/home.php
@@ -11,8 +11,6 @@
  * Handle the loading of a single group's page.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function groups_screen_group_home() {
 

--- a/src/bp-groups/screens/single/members.php
+++ b/src/bp-groups/screens/single/members.php
@@ -11,8 +11,6 @@
  * Handle the display of a group's Members page.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function groups_screen_group_members() {
 

--- a/src/bp-groups/screens/single/request-membership.php
+++ b/src/bp-groups/screens/single/request-membership.php
@@ -11,8 +11,6 @@
  * Handle the display of a group's Request Membership page.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function groups_screen_group_request_membership() {
 

--- a/src/bp-groups/screens/single/send-invites.php
+++ b/src/bp-groups/screens/single/send-invites.php
@@ -11,8 +11,6 @@
  * Handle the display of a group's Send Invites page.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function groups_screen_group_invite() {
 
@@ -76,8 +74,6 @@ function groups_screen_group_invite() {
  * Remove Invite removes the invitation via AJAX.
  *
  * @since 2.0.0
- *
- * @return void
  */
 function groups_remove_group_invite() {
 	if ( ! bp_is_group_invites() ) {

--- a/src/bp-groups/screens/user/invites.php
+++ b/src/bp-groups/screens/user/invites.php
@@ -11,8 +11,6 @@
  * Handle the loading of a user's Groups > Invites page.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function groups_screen_group_invites() {
 	$group_id = (int) bp_action_variable( 1 );

--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -413,7 +413,7 @@ function bp_core_get_user_email( $user_id ) {
  *                        Default: false.
  * @param bool $just_link Disable full name and HTML and just return the URL
  *                        text. Default false.
- * @return string|bool The link text based on passed parameters, or false on
+ * @return string|false The link text based on passed parameters, or false on
  *                     no match.
  */
 function bp_core_get_userlink( $user_id, $no_anchor = false, $just_link = false ) {
@@ -1948,12 +1948,14 @@ function bp_core_signup_user( $user_login, $user_password, $user_email, $usermet
  * @param string $user_name   user_login of requesting user.
  * @param string $user_email  Email address of requesting user.
  * @param string $usermeta    Miscellaneous metadata for the user.
- * @return bool
+ * @return bool|null
  */
 function bp_core_signup_blog( $blog_domain, $blog_path, $blog_title, $user_name, $user_email, $usermeta ) {
 	if ( ! is_multisite() || ! function_exists( 'wpmu_signup_blog' ) ) {
 		return false;
 	}
+
+	wpmu_signup_blog( $blog_domain, $blog_path, $blog_title, $user_name, $user_email, $usermeta );
 
 	/**
 	 * Filters the result of wpmu_signup_blog().
@@ -1963,9 +1965,9 @@ function bp_core_signup_blog( $blog_domain, $blog_path, $blog_title, $user_name,
 	 *
 	 * @since 1.2.2
 	 *
-	 * @param void $value
+	 * @param null $value Null value.
 	 */
-	return apply_filters( 'bp_core_signup_blog', wpmu_signup_blog( $blog_domain, $blog_path, $blog_title, $user_name, $user_email, $usermeta ) );
+	return apply_filters( 'bp_core_signup_blog', null );
 }
 
 /**

--- a/src/bp-members/classes/class-bp-core-members-widget.php
+++ b/src/bp-members/classes/class-bp-core-members-widget.php
@@ -65,7 +65,6 @@ class BP_Core_Members_Widget {
 	 *
 	 * @param array $new_instance The new instance options.
 	 * @param array $old_instance The old instance options.
-	 * @return array $instance The parsed options to be saved.
 	 */
 	public function update( $new_instance, $old_instance ) {
 		_deprecated_function( __METHOD__, '12.0.0' );
@@ -78,7 +77,6 @@ class BP_Core_Members_Widget {
 	 * @deprecated 12.0.0
 	 *
 	 * @param array $instance Widget instance settings.
-	 * @return void
 	 */
 	public function form( $instance ) {
 		_deprecated_function( __METHOD__, '12.0.0' );
@@ -91,7 +89,6 @@ class BP_Core_Members_Widget {
 	 * @deprecated 12.0.0
 	 *
 	 * @param array $instance Widget instance settings.
-	 * @return array
 	 */
 	public function parse_settings( $instance = array() ) {
 		_deprecated_function( __METHOD__, '12.0.0' );

--- a/src/bp-members/classes/class-bp-core-recently-active-widget.php
+++ b/src/bp-members/classes/class-bp-core-recently-active-widget.php
@@ -55,7 +55,6 @@ class BP_Core_Recently_Active_Widget extends WP_Widget {
 	 *
 	 * @param array $new_instance The new instance options.
 	 * @param array $old_instance The old instance options.
-	 * @return array $instance The parsed options to be saved.
 	 */
 	public function update( $new_instance, $old_instance ) {
 		_deprecated_function( __METHOD__, '12.0.0' );
@@ -68,7 +67,6 @@ class BP_Core_Recently_Active_Widget extends WP_Widget {
 	 * @deprecated 12.0.0
 	 *
 	 * @param array $instance Widget instance settings.
-	 * @return void
 	 */
 	public function form( $instance ) {
 		_deprecated_function( __METHOD__, '12.0.0' );
@@ -81,7 +79,6 @@ class BP_Core_Recently_Active_Widget extends WP_Widget {
 	 * @deprecated 12.0.0
 	 *
 	 * @param array $instance Widget instance settings.
-	 * @return array
 	 */
 	public function parse_settings( $instance = array() ) {
 		_deprecated_function( __METHOD__, '12.0.0' );

--- a/src/bp-members/classes/class-bp-core-whos-online-widget.php
+++ b/src/bp-members/classes/class-bp-core-whos-online-widget.php
@@ -56,7 +56,6 @@ class BP_Core_Whos_Online_Widget extends WP_Widget {
 	 *
 	 * @param array $new_instance The new instance options.
 	 * @param array $old_instance The old instance options.
-	 * @return array $instance The parsed options to be saved.
 	 */
 	public function update( $new_instance, $old_instance ) {
 		_deprecated_function( __METHOD__, '12.0.0' );
@@ -69,7 +68,6 @@ class BP_Core_Whos_Online_Widget extends WP_Widget {
 	 * @deprecated 12.0.0
 	 *
 	 * @param array $instance Widget instance settings.
-	 * @return void
 	 */
 	public function form( $instance ) {
 		_deprecated_function( __METHOD__, '12.0.0' );
@@ -82,7 +80,6 @@ class BP_Core_Whos_Online_Widget extends WP_Widget {
 	 * @deprecated 12.0.0
 	 *
 	 * @param array $instance Widget instance settings.
-	 * @return array
 	 */
 	public function parse_settings( $instance = array() ) {
 		_deprecated_function( __METHOD__, '12.0.0' );

--- a/src/bp-members/classes/class-bp-members-invitations-list-table.php
+++ b/src/bp-members/classes/class-bp-members-invitations-list-table.php
@@ -311,7 +311,6 @@ class BP_Members_Invitations_List_Table extends WP_Users_List_Table {
 	 * @param string        $style    Styles for the row.
 	 * @param string        $role     Role to be assigned to user.
 	 * @param int           $numposts Number of posts.
-	 * @return void
 	 */
 	public function single_row( $invite = null, $style = '', $role = '', $numposts = 0 ) {
 		if ( '' === $style ) {

--- a/src/bp-members/classes/class-bp-members-list-table.php
+++ b/src/bp-members/classes/class-bp-members-list-table.php
@@ -272,7 +272,6 @@ class BP_Members_List_Table extends WP_Users_List_Table {
 	 * @param string      $style         Styles for the row.
 	 * @param string      $role          Role to be assigned to user.
 	 * @param int         $numposts      Numper of posts.
-	 * @return void
 	 */
 	public function single_row( $signup_object = null, $style = '', $role = '', $numposts = 0 ) {
 		if ( '' === $style ) {

--- a/src/bp-members/screens/activate.php
+++ b/src/bp-members/screens/activate.php
@@ -11,8 +11,6 @@
  * Handle the loading of the Activate screen.
  *
  * @since 1.1.0
- *
- * @return void
  */
 function bp_core_screen_activation() {
 
@@ -45,9 +43,6 @@ function bp_core_screen_activation() {
 		// Redirect away from the activation page.
 		bp_core_redirect( $redirect_to );
 	}
-
-	// Get BuddyPress.
-	$bp = buddypress();
 
 	/**
 	 * Filters the template to load for the Member activation page screen.
@@ -90,7 +85,6 @@ function bp_members_action_activate_account() {
 		return;
 	}
 
-	$bp       = buddypress();
 	$redirect = bp_get_activation_page();
 
 	/**
@@ -130,6 +124,5 @@ function bp_members_action_activate_account() {
 
 	bp_core_add_message( __( 'Your account is now active!', 'buddypress' ) );
 	bp_core_redirect( add_query_arg( 'activated', '1', $redirect ) );
-
 }
 add_action( 'bp_actions', 'bp_members_action_activate_account' );

--- a/src/bp-members/screens/change-avatar.php
+++ b/src/bp-members/screens/change-avatar.php
@@ -11,8 +11,6 @@
  * Handle the display of the profile Change Avatar page by loading the correct template file.
  *
  * @since 6.0.0
- *
- * @return void
  */
 function bp_members_screen_change_avatar() {
 	// Bail if not the correct screen.

--- a/src/bp-messages/screens/compose.php
+++ b/src/bp-messages/screens/compose.php
@@ -11,8 +11,6 @@
  * Load the Messages > Compose screen.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function messages_screen_compose() {
 

--- a/src/bp-messages/screens/inbox.php
+++ b/src/bp-messages/screens/inbox.php
@@ -11,8 +11,6 @@
  * Load the Messages > Inbox screen.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function messages_screen_inbox() {
 

--- a/src/bp-messages/screens/notices.php
+++ b/src/bp-messages/screens/notices.php
@@ -11,8 +11,6 @@
  * Load the Messages > Notices screen.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function messages_screen_notices() {
 

--- a/src/bp-messages/screens/sentbox.php
+++ b/src/bp-messages/screens/sentbox.php
@@ -11,8 +11,6 @@
  * Load the Messages > Sent screen.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function messages_screen_sentbox() {
 

--- a/src/bp-messages/screens/view.php
+++ b/src/bp-messages/screens/view.php
@@ -11,8 +11,6 @@
  * Load an individual conversation screen.
  *
  * @since 1.0.0
- *
- * @return void.
  */
 function messages_screen_conversation() {
 

--- a/src/bp-notifications/actions/bulk-manage.php
+++ b/src/bp-notifications/actions/bulk-manage.php
@@ -11,14 +11,12 @@
  * Handles bulk management (mark as read/unread, delete) of notifications.
  *
  * @since 2.2.0
- *
- * @return false|void
  */
 function bp_notifications_action_bulk_manage() {
 
 	// Bail if not the read or unread screen.
 	if ( ! bp_is_notifications_component() || ! ( bp_is_current_action( 'read' ) || bp_is_current_action( 'unread' ) ) ) {
-		return false;
+		return;
 	}
 
 	// Get the action.
@@ -28,13 +26,13 @@ function bp_notifications_action_bulk_manage() {
 
 	// Bail if no action or no IDs.
 	if ( ( ! in_array( $action, array( 'delete', 'read', 'unread' ), true ) ) || empty( $notifications ) || empty( $nonce ) ) {
-		return false;
+		return;
 	}
 
 	// Check the nonce.
 	if ( ! wp_verify_nonce( $nonce, 'notifications_bulk_nonce' ) ) {
 		bp_core_add_message( __( 'There was a problem managing your notifications.', 'buddypress' ), 'error' );
-		return false;
+		return;
 	}
 
 	$notifications = wp_parse_id_list( $notifications );

--- a/src/bp-notifications/screens/read.php
+++ b/src/bp-notifications/screens/read.php
@@ -40,8 +40,6 @@ function bp_notifications_screen_read() {
  * Handle marking single notifications as unread.
  *
  * @since 1.9.0
- *
- * @return void
  */
 function bp_notifications_action_mark_unread() {
 

--- a/src/bp-notifications/screens/unread.php
+++ b/src/bp-notifications/screens/unread.php
@@ -40,8 +40,6 @@ function bp_notifications_screen_unread() {
  * Handle marking single notifications as read.
  *
  * @since 1.9.0
- *
- * @return void
  */
 function bp_notifications_action_mark_read() {
 

--- a/src/bp-settings/actions/notifications.php
+++ b/src/bp-settings/actions/notifications.php
@@ -11,8 +11,6 @@
  * Handles the changing and saving of user notification settings.
  *
  * @since 1.6.0
- *
- * @return bool|void
  */
 function bp_settings_action_notifications() {
 	if ( ! bp_is_post_request() ) {
@@ -26,7 +24,7 @@ function bp_settings_action_notifications() {
 
 	// Bail if not in settings.
 	if ( ! bp_is_settings_component() || ! bp_is_current_action( 'notifications' ) ) {
-		return false;
+		return;
 	}
 
 	// 404 if there are any additional action variables attached

--- a/src/bp-settings/screens/capabilities.php
+++ b/src/bp-settings/screens/capabilities.php
@@ -11,8 +11,6 @@
  * Show the capabilities settings template.
  *
  * @since 1.6.0
- *
- * @return void
  */
 function bp_settings_screen_capabilities() {
 

--- a/src/bp-settings/screens/data.php
+++ b/src/bp-settings/screens/data.php
@@ -11,8 +11,6 @@
  * Show the data settings template.
  *
  * @since 4.0.0
- *
- * @return void
  */
 function bp_settings_screen_data() {
 

--- a/src/bp-settings/screens/delete-account.php
+++ b/src/bp-settings/screens/delete-account.php
@@ -11,8 +11,6 @@
  * Show the delete-account settings template.
  *
  * @since 1.5.0
- *
- * @return void
  */
 function bp_settings_screen_delete_account() {
 

--- a/src/bp-settings/screens/general.php
+++ b/src/bp-settings/screens/general.php
@@ -11,8 +11,6 @@
  * Show the general settings template.
  *
  * @since 1.5.0
- *
- * @return void
  */
 function bp_settings_screen_general() {
 
@@ -32,7 +30,6 @@ function bp_settings_screen_general() {
 		apply_filters( 'bp_settings_screen_general_settings', 'members/single/settings/general' ),
 		'members/single/index',
 	);
-
 
 	bp_core_load_template( $templates );
 }

--- a/src/bp-settings/screens/notifications.php
+++ b/src/bp-settings/screens/notifications.php
@@ -11,8 +11,6 @@
  * Show the notifications settings template.
  *
  * @since 1.5.0
- *
- * @return void
  */
 function bp_settings_screen_notification() {
 

--- a/src/bp-templates/bp-legacy/buddypress-functions.php
+++ b/src/bp-templates/bp-legacy/buddypress-functions.php
@@ -1136,8 +1136,6 @@ function bp_legacy_theme_new_activity_comment() {
  * Deletes an Activity item received via a POST request.
  *
  * @since 1.2.0
- *
- * @return mixed String on error, void on success.
  */
 function bp_legacy_theme_delete_activity() {
 	if ( ! bp_is_post_request() ) {
@@ -1178,8 +1176,6 @@ function bp_legacy_theme_delete_activity() {
  * Deletes an Activity comment received via a POST request.
  *
  * @since 1.2.0
- *
- * @return mixed String on error, void on success.
  */
 function bp_legacy_theme_delete_activity_comment() {
 	if ( ! bp_is_post_request() ) {
@@ -1220,8 +1216,6 @@ function bp_legacy_theme_delete_activity_comment() {
  * AJAX spam an activity item or comment.
  *
  * @since 1.6.0
- *
- * @return mixed String on error, void on success.
  */
 function bp_legacy_theme_spam_activity() {
 	$bp = buddypress();
@@ -1541,8 +1535,6 @@ function bp_legacy_theme_ajax_addremove_friend() {
  * Accept a user friendship request via a POST request.
  *
  * @since 1.2.0
- *
- * @return mixed String on error, void on success.
  */
 function bp_legacy_theme_ajax_accept_friendship() {
 	if ( ! bp_is_post_request() ) {
@@ -1551,8 +1543,9 @@ function bp_legacy_theme_ajax_accept_friendship() {
 
 	check_admin_referer( 'friends_accept_friendship' );
 
-	if ( ! friends_accept_friendship( (int) $_POST['id'] ) )
+	if ( ! friends_accept_friendship( (int) $_POST['id'] ) ) {
 		echo "-1<div id='message' class='error'><p>" . esc_html__( 'There was a problem accepting that request. Please try again.', 'buddypress' ) . '</p></div>';
+	}
 
 	exit;
 }
@@ -1561,8 +1554,6 @@ function bp_legacy_theme_ajax_accept_friendship() {
  * Reject a user friendship request via a POST request.
  *
  * @since 1.2.0
- *
- * @return mixed String on error, void on success.
  */
 function bp_legacy_theme_ajax_reject_friendship() {
 	if ( ! bp_is_post_request() ) {
@@ -1571,8 +1562,9 @@ function bp_legacy_theme_ajax_reject_friendship() {
 
 	check_admin_referer( 'friends_reject_friendship' );
 
-	if ( ! friends_reject_friendship( (int) $_POST['id'] ) )
+	if ( ! friends_reject_friendship( (int) $_POST['id'] ) ) {
 		echo "-1<div id='message' class='error'><p>" . esc_html__( 'There was a problem rejecting that request. Please try again.', 'buddypress' ) . '</p></div>';
+	}
 
 	exit;
 }
@@ -1701,8 +1693,6 @@ function bp_legacy_theme_ajax_joinleave_group() {
  * Close and keep closed site wide notices from an admin in the sidebar, via a POST request.
  *
  * @since 1.2.0
- *
- * @return mixed String on error, void on success.
  */
 function bp_legacy_theme_ajax_close_notice() {
 	if ( ! bp_is_post_request() ) {
@@ -1792,8 +1782,6 @@ function bp_legacy_theme_ajax_messages_send_reply() {
  *
  * @since 1.2.0
  * @deprecated 2.2.0
- *
- * @return mixed String on error, void on success.
  */
 function bp_legacy_theme_ajax_message_markunread() {
 	die( '-1' );
@@ -1806,8 +1794,6 @@ function bp_legacy_theme_ajax_message_markunread() {
  *
  * @since 1.2.0
  * @deprecated 2.2.0
- *
- * @return mixed String on error, void on success.
  */
 function bp_legacy_theme_ajax_message_markread() {
 	die( '-1' );
@@ -1820,8 +1806,6 @@ function bp_legacy_theme_ajax_message_markread() {
  *
  * @since 1.2.0
  * @deprecated 2.2.0
- *
- * @return string|null HTML
  */
 function bp_legacy_theme_ajax_messages_delete() {
 	die( '-1' );

--- a/src/bp-xprofile/bp-xprofile-functions.php
+++ b/src/bp-xprofile/bp-xprofile-functions.php
@@ -762,7 +762,7 @@ add_action( 'bp_parse_query', 'xprofile_override_user_fullnames', 100 );
  * When search_terms are passed to BP_User_Query, search against xprofile fields.
  *
  * @since 2.0.0
- * 
+ *
  * @global wpdb $wpdb WordPress database object.
  *
  * @param array         $sql   Clauses in the user_id SQL query.
@@ -962,7 +962,7 @@ add_action( 'delete_user', 'xprofile_remove_data_on_delete_user' );
  * Delete a piece of xprofile metadata.
  *
  * @since 1.5.0
- * 
+ *
  * @global wpdb $wpdb WordPress database object.
  *
  * @param int         $object_id   ID of the object the metadata belongs to.
@@ -1145,7 +1145,7 @@ function bp_xprofile_update_fielddata_meta( $field_data_id, $meta_key, $meta_val
  * Return the field ID for the Full Name xprofile field.
  *
  * @since 2.0.0
- * 
+ *
  * @global wpdb $wpdb WordPress database object.
  *
  * @return int Field ID.
@@ -1385,11 +1385,12 @@ function bp_xprofile_get_fields_by_visibility_levels( $user_id, $levels = array(
 /**
  * Formats datebox field values passed through a POST request.
  *
+ * This function only changes the global $_POST that should contain
+ * the datebox data.
+ *
  * @since 2.8.0
  *
  * @param int $field_id The id of the current field being looped through.
- * @return void This function only changes the global $_POST that should contain
- *              the datebox data.
  */
 function bp_xprofile_maybe_format_datebox_post_data( $field_id ) {
 	if ( ! isset( $_POST[ 'field_' . $field_id ] ) ) {
@@ -1476,7 +1477,7 @@ function bp_xprofile_get_wp_user_keys() {
  * Returns the signup field IDs.
  *
  * @since 8.0.0
- * 
+ *
  * @global wpdb $wpdb WordPress database object.
  *
  * @return int[] The signup field IDs.

--- a/src/bp-xprofile/classes/class-bp-xprofile-field-type.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-field-type.php
@@ -294,7 +294,6 @@ abstract class BP_XProfile_Field_Type {
 	 * @since 2.0.0
 	 *
 	 * @param array $raw_properties Optional key/value array of permitted attributes that you want to add.
-	 * @return void
 	 */
 	abstract public function edit_field_html( array $raw_properties = array() );
 
@@ -306,7 +305,6 @@ abstract class BP_XProfile_Field_Type {
 	 * @since 2.0.0
 	 *
 	 * @param array $raw_properties Optional key/value array of permitted attributes that you want to add.
-	 * @return void
 	 */
 	abstract public function admin_field_html( array $raw_properties = array() );
 

--- a/src/bp-xprofile/classes/class-bp-xprofile-field.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-field.php
@@ -1580,8 +1580,6 @@ class BP_XProfile_Field {
 	 * Private method used to output field Member Type metabox.
 	 *
 	 * @since 2.4.0
-	 *
-	 * @return void If default field or if the field does not support the feature.
 	 */
 	private function member_type_metabox() {
 
@@ -1635,8 +1633,6 @@ class BP_XProfile_Field {
 	 * Private method used to output field visibility metaboxes.
 	 *
 	 * @since 2.3.0
-	 *
-	 * @return void If default field or if the field does not support the feature.
 	 */
 	private function visibility_metabox() {
 
@@ -1684,8 +1680,6 @@ class BP_XProfile_Field {
 	 * Output the metabox for setting if field is required or not.
 	 *
 	 * @since 2.3.0
-	 *
-	 * @return void If default field or if the field does not support the feature.
 	 */
 	private function required_metabox() {
 
@@ -1711,8 +1705,6 @@ class BP_XProfile_Field {
 	 * Private method used to output autolink metabox.
 	 *
 	 * @since 2.5.0
-	 *
-	 * @return void If the field does not support the feature.
 	 */
 	private function autolink_metabox() {
 
@@ -1746,8 +1738,6 @@ class BP_XProfile_Field {
 	 * Output the metabox for setting what type of field this is.
 	 *
 	 * @since 2.3.0
-	 *
-	 * @return void If default field.
 	 */
 	private function type_metabox() {
 
@@ -1789,8 +1779,6 @@ class BP_XProfile_Field {
 	 * Output the metabox for setting the field's position into the signup form.
 	 *
 	 * @since 8.0.0
-	 *
-	 * @return void If default field or if the field does not support the feature.
 	 */
 	private function signup_position_metabox() {
 		// Field types not supporting the feature cannot be added to signups form.
@@ -1829,8 +1817,6 @@ class BP_XProfile_Field {
 	 * Output hidden fields used by default field.
 	 *
 	 * @since 2.3.0
-	 *
-	 * @return void If not default field.
 	 */
 	private function default_field_hidden_inputs() {
 

--- a/src/bp-xprofile/screens/edit.php
+++ b/src/bp-xprofile/screens/edit.php
@@ -12,8 +12,6 @@
  * Also checks to make sure this can only be accessed for the logged in users profile.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function xprofile_screen_edit_profile() {
 

--- a/src/bp-xprofile/screens/settings-profile.php
+++ b/src/bp-xprofile/screens/settings-profile.php
@@ -11,8 +11,6 @@
  * Show the xprofile settings template.
  *
  * @since 2.0.0
- *
- * @return void
  */
 function bp_xprofile_screen_settings() {
 
@@ -41,8 +39,6 @@ function bp_xprofile_screen_settings() {
  * Handles the saving of xprofile field visibilities.
  *
  * @since 1.9.0
- *
- * @return void
  */
 function bp_xprofile_action_settings() {
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Happy to elaborate it further, but a quick read on https://wiki.php.net/rfc/void_return_type 
 and https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#1-functions-class-methods might be enough to understand the reason of the incorrect usage.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9164

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
