### PR TITLE
Fix: Made strings translatable in 2.8.php file

### DIFF
--- a/src/bp-core/deprecated/2.8.php
+++ b/src/bp-core/deprecated/2.8.php
@@ -143,7 +143,7 @@ function bp_core_admin_php52_plugin_row( $file, $plugin_data ) {
 		// phpcs:ignore WordPress.Security.EscapeOutput
 		$p,
 		esc_html__( 'A BuddyPress update is available, but your system is not compatible.', 'buddypress' ) . ' ' .
-		sprintf( esc_html__( 'See %s for more information.', 'buddypress' ), '<a href="https://codex.buddypress.org/getting-started/buddypress-2-8-will-require-php-5-3/">' . esc_html( 'the Codex guide', 'buddypress' ) . '</a>' )
+		sprintf( esc_html__( 'See %s for more information.', 'buddypress' ), '<a href="https://codex.buddypress.org/getting-started/buddypress-2-8-will-require-php-5-3/">' . esc_html__( 'the Codex guide', 'buddypress' ) . '</a>' )
 	);
 
 	echo '</div></td></tr>';
@@ -207,7 +207,7 @@ function bp_core_admin_php53_admin_notice() {
 			&nbsp;
 			<?php
 			/* translators: %s: the url to a codex page */
-			printf( esc_html_x( 'See %s for more information.', 'deprecated string', 'buddypress' ), '<a href="https://codex.buddypress.org/getting-started/buddypress-2-8-will-require-php-5-3/">' . esc_html( 'the Codex guide', 'buddypress' ) . '</a>' );
+			printf( esc_html_x( 'See %s for more information.', 'deprecated string', 'buddypress' ), '<a href="https://codex.buddypress.org/getting-started/buddypress-2-8-will-require-php-5-3/">' . esc_html__( 'the Codex guide', 'buddypress' ) . '</a>' );
 			?>
 		</p>
 		<?php wp_nonce_field( "bp-dismissible-notice-$notice_id", "bp-dismissible-nonce-$notice_id" ); ?>


### PR DESCRIPTION
Fix: Made strings translatable in 2.8.php file

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9177