### PR TITLE
Bring back custom translation files for BuddyPress!

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -2493,11 +2493,15 @@ function bp_is_get_request() {
  * @param  string $locale The current locale for the WordPress site.
  * @return string Absolut path to the translation file to use.
  */
-function bp_load_custom_translation_file( $file, $domain, $locale ) {
+function bp_load_custom_translation_file( $file, $domain, $locale = '' ) {
 	$bp_domain = 'buddypress';
 
 	if ( $domain !== $bp_domain ) {
 		return $file;
+	}
+
+	if ( ! $locale ) {
+		$locale = determine_locale();
 	}
 
 	/**

--- a/src/bp-core/deprecated/14.0.php
+++ b/src/bp-core/deprecated/14.0.php
@@ -84,3 +84,17 @@ function bp_admin_email_add_codex_notice() {
 		'error'
 	);
 }
+
+/**
+ * Load the buddypress translation file for current language.
+ *
+ * @since 1.0.2
+ * @deprecated 14.0.0
+ *
+ * @return bool
+ */
+function bp_core_load_buddypress_textdomain() {
+	_deprecated_function( __FUNCTION__, '14.0.0' );
+
+	return false;
+}


### PR DESCRIPTION
Use the `'load_translation_file'` filter to check custom file locations for the `buddypress` text domain.

**NB**: this filter was introduced by WordPress in version 6.5.

If there's a `buddypress-xx_XX.mo` (where xx_XX is the locale code) file into one of the following directories, it will be used to replace the default one (WordPress.org Plugin Directory / GlotPress):

1. `/wp-content/languages/plugins/buddypress` (added in 14.0.0)
2. `/wp-content/languages/buddypress`
3. `/wp-content/languages`

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9187

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
