### PR TITLE
Avoid PHP errors with BP Default when filtering `'current_theme_supports-buddypress'`

### DIFF
--- a/src/bp-core/bp-core-theme-compatibility.php
+++ b/src/bp-core/bp-core-theme-compatibility.php
@@ -1089,8 +1089,11 @@ add_action( 'bp_init', 'bp_register_buddypress_theme_feature' );
  * @return boolean True if the feature is supported. False otherwise.
  */
 function _bp_filter_current_theme_supports( $supports = false, $args = array(), $feature = null ) {
-	$params             = reset( $args );
-	$is_expected_params = array_filter( array_map( 'is_string', array_keys( $params ) ) );
+	$is_expected_params = array();
+
+	if ( isset( $args[0] ) && is_array( $args[0] ) ) {
+		$is_expected_params = array_filter( array_map( 'is_string', array_keys( $args[0] ) ) );
+	}
 
 	if ( true === $supports && $is_expected_params ) {
 		if ( ! is_array( $feature ) ) {


### PR DESCRIPTION
When first activating the BP Default theme, more than PHP warnings we get a fatal error.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8319

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
