### PR TITLE
Fixes some WP CLI translation warnings

### DIFF
--- a/src/bp-core/deprecated/2.8.php
+++ b/src/bp-core/deprecated/2.8.php
@@ -143,7 +143,11 @@ function bp_core_admin_php52_plugin_row( $file, $plugin_data ) {
 		// phpcs:ignore WordPress.Security.EscapeOutput
 		$p,
 		esc_html__( 'A BuddyPress update is available, but your system is not compatible.', 'buddypress' ) . ' ' .
-		sprintf( esc_html__( 'See %s for more information.', 'buddypress' ), '<a href="https://codex.buddypress.org/getting-started/buddypress-2-8-will-require-php-5-3/">' . esc_html__( 'the Codex guide', 'buddypress' ) . '</a>' )
+		sprintf(
+			/* translators: %s: the documentation page link giving more information */
+			esc_html__( 'See %s for more information.', 'buddypress' ),
+			'<a href="https://codex.buddypress.org/getting-started/buddypress-2-8-will-require-php-5-3/">' . esc_html__( 'the Codex guide', 'buddypress' ) . '</a>'
+		)
 	);
 
 	echo '</div></td></tr>';

--- a/src/bp-templates/bp-legacy/buddypress/activity/comment.php
+++ b/src/bp-templates/bp-legacy/buddypress/activity/comment.php
@@ -26,8 +26,8 @@ do_action( 'bp_before_activity_comment' ); ?>
 
 	<div class="acomment-meta">
 		<?php
-			/* translators: 1: user profile link, 2: user name, 3: activity permalink, 4: ISO8601 timestamp, 5: activity relative timestamp */
 			printf(
+				/* translators: 1: user profile link, 2: user name, 3: activity permalink, 4: ISO8601 timestamp, 5: activity relative timestamp */
 				esc_html__( '%1$s replied %2$s', 'buddypress' ),
 				'<a href="' . esc_url( bp_get_activity_comment_user_link() ) . '">' . esc_html( bp_get_activity_comment_name() ) . '</a>',
 				'<a href="' . esc_url( bp_get_activity_comment_permalink() ) . '" class="activity-time-since"><span class="time-since" data-livestamp="' . esc_attr( bp_core_get_iso8601_date( bp_get_activity_comment_date_recorded() ) ) . '">' . esc_html( bp_get_activity_comment_date_recorded() ). '</span></a>'

--- a/src/bp-templates/bp-legacy/buddypress/activity/post-form.php
+++ b/src/bp-templates/bp-legacy/buddypress/activity/post-form.php
@@ -29,15 +29,15 @@
 	<p class="activity-greeting">
 		<?php
 		if ( bp_is_group() ) {
-			/* translators: 1: group name. 2: member name. */
 			printf(
+				/* translators: 1: group name. 2: member name. */
 				esc_html__( 'What\'s new in %1$s, %2$s?', 'buddypress' ),
 				esc_html( bp_get_group_name() ),
 				esc_html( bp_get_user_firstname( bp_get_loggedin_user_fullname() ) )
 			);
 		} else {
-			/* translators: %s: member name */
 			printf(
+				/* translators: %s: member name */
 				esc_html__( "What's new, %s?", 'buddypress' ),
 				esc_html( bp_get_user_firstname( bp_get_loggedin_user_fullname() ) )
 			);

--- a/src/bp-templates/bp-legacy/buddypress/members/activate.php
+++ b/src/bp-templates/bp-legacy/buddypress/members/activate.php
@@ -46,8 +46,8 @@
 			<?php else : ?>
 				<p>
 					<?php
-					/* translators: %s: login url */
 					printf(
+						/* translators: %s: login url */
 						esc_html__( 'Your account was activated successfully! You can now %s with the username and password you provided when you signed up.', 'buddypress' ),
 						'<a href="'. esc_url( wp_login_url( bp_get_root_url() ) ) . '">' . esc_html__( 'log in', 'buddypress' ) . '</a>'
 					);

--- a/src/bp-templates/bp-legacy/buddypress/members/single/profile/change-avatar.php
+++ b/src/bp-templates/bp-legacy/buddypress/members/single/profile/change-avatar.php
@@ -25,6 +25,7 @@ do_action( 'bp_before_profile_avatar_upload_content' ); ?>
 	<p>
 		<?php
 		printf(
+			/* Translators: %s is used to output the link to the Gravatar site */
 			esc_html__( 'Your profile photo will be used on your profile and throughout the site. If there is a %s associated with your account email we will use that, or you can upload an image from your computer.', 'buddypress' ),
 			'<a href="http://gravatar.com">Gravatar</a>'
 		);
@@ -94,6 +95,7 @@ do_action( 'bp_before_profile_avatar_upload_content' ); ?>
 	<p>
 		<?php
 		printf(
+			/* Translators: %s is used to output the link to the Gravatar site */
 			esc_html__( 'Your profile photo will be used on your profile and throughout the site. To change your profile photo, please create an account with %s using the same email address as you used to register with this site.', 'buddypress' ),
 			'<a href="https://gravatar.com">Gravatar</a>'
 		);

--- a/src/bp-templates/bp-legacy/buddypress/members/single/settings/general.php
+++ b/src/bp-templates/bp-legacy/buddypress/members/single/settings/general.php
@@ -34,7 +34,12 @@ do_action( 'bp_before_member_settings_template' ); ?>
 	<label for="email"><?php esc_html_e( 'Account Email', 'buddypress' ); ?></label>
 	<input type="email" name="email" id="email" value="<?php echo esc_attr( bp_get_displayed_user_email() ); ?>" class="settings-input" <?php bp_form_field_attributes( 'email' ); ?>/>
 
-	<label for="pass1"><?php printf( esc_html__( 'Change Password %s', 'buddypress' ), '<span>' . esc_html__( '(leave blank for no change)', 'buddypress' ) . '</span>' ); ?></label>
+	<label for="pass1">
+		<?php
+		/* translators: %s: Information about how to keep password unchanged. */
+		printf( esc_html__( 'Change Password %s', 'buddypress' ), '<span>' . esc_html__( '(leave blank for no change)', 'buddypress' ) . '</span>' );
+		?>
+	</label>
 	<input type="password" name="pass1" id="pass1" size="16" value="" class="settings-input small password-entry" <?php bp_form_field_attributes( 'password' ); ?>/>
 	<div id="pass-strength-result"></div>
 	<label for="pass2"><?php esc_html_e( 'Repeat New Password', 'buddypress' );

--- a/src/bp-templates/bp-nouveau/buddypress/members/single/settings/general.php
+++ b/src/bp-templates/bp-nouveau/buddypress/members/single/settings/general.php
@@ -22,7 +22,7 @@ bp_nouveau_member_hook( 'before', 'settings_template' ); ?>
 
 		<label for="pwd">
 			<?php
-			/* translators: %s: email requirement explanations */
+			/* translators: %s: the required text information. */
 			printf( esc_html__( 'Current Password %s', 'buddypress' ), '<span>' . esc_html__( '(required to update email or change current password)', 'buddypress' ) . '</span>' );
 			?>
 		</label>


### PR DESCRIPTION
Fixes some WP CLI translation warnings

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9198

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
