### PR TITLE
Restore `bp_core_load_buddypress_textdomain()`

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -2602,6 +2602,32 @@ function bp_load_custom_script_translation_file( $file, $handle, $domain ) {
 add_filter( 'load_script_translation_file', 'bp_load_custom_script_translation_file', 10, 3 );
 
 /**
+ * Load the buddypress translation file for current language.
+ *
+ * @since 1.0.2
+ *
+ * @return void
+ */
+function bp_core_load_buddypress_textdomain() {
+	$domain = 'buddypress';
+
+	/*
+	 * In most cases, WordPress already loaded BuddyPress textdomain
+	 * thanks to the `_load_textdomain_just_in_time()` function.
+	 */
+	if ( is_textdomain_loaded( $domain ) ) {
+		return;
+	}
+
+	/*
+	 * We only need to keep loading BuddyPress textdomain to allow
+	 * the usage of custom `en_US` translation files.
+	 */
+	load_plugin_textdomain( $domain );
+}
+add_action( 'bp_core_loaded', 'bp_core_load_buddypress_textdomain' );
+
+/**
  * A JavaScript-free implementation of the search functions in BuddyPress.
  *
  * @since 1.0.1

--- a/src/bp-core/deprecated/14.0.php
+++ b/src/bp-core/deprecated/14.0.php
@@ -86,20 +86,6 @@ function bp_admin_email_add_codex_notice() {
 }
 
 /**
- * Load the buddypress translation file for current language.
- *
- * @since 1.0.2
- * @deprecated 14.0.0
- *
- * @return bool
- */
-function bp_core_load_buddypress_textdomain() {
-	_deprecated_function( __FUNCTION__, '14.0.0' );
-
-	return false;
-}
-
-/**
  * Handle save/update of screen options for the Activity component admin screen.
  *
  * @since 1.6.0


### PR DESCRIPTION
If we don't need `bp_core_load_buddypress_textdomain()` for the regular translation usage, when an advanced user is using a custom `en_US` language file for BuddyPress, we absolutely need it to load this specific file.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9187

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
