### PR TITLE
Only generate rewrite rules when the BP Query Parser is set to 'rewrites'

### DIFF
--- a/src/bp-core/bp-core-update.php
+++ b/src/bp-core/bp-core-update.php
@@ -976,6 +976,18 @@ function bp_update_to_14_0() {
 			$wpdb->query( "ALTER TABLE {$bp->notifications->table_name} CHANGE is_new is_new tinyint(1) NOT NULL DEFAULT 0" );
 		}
 	}
+
+	/*
+	 * Force permalinks to be refreshed at next page load.
+	 *
+	 * This will make sure configs using BP Classic won't include
+	 * unnecessary rewrite rules.
+	 *
+	 * @see https://buddypress.trac.wordpress.org/ticket/9192
+	 */
+	if ( 'rewrites' !== bp_core_get_query_parser() ) {
+		bp_delete_rewrite_rules();
+	}
 }
 
 /**

--- a/src/bp-core/classes/class-bp-component.php
+++ b/src/bp-core/classes/class-bp-component.php
@@ -1070,7 +1070,7 @@ class BP_Component {
 	 *                            Each argument key needs to match one of `$this->rewrite_ids` keys.
 	 */
 	public function add_rewrite_tags( $rewrite_tags = array() ) {
-		if ( array_filter( $this->rewrite_ids ) ) {
+		if ( 'rewrites' === bp_core_get_query_parser() && array_filter( $this->rewrite_ids ) ) {
 			$chunks = bp_rewrites_get_default_url_chunks();
 
 			foreach ( $this->rewrite_ids as $rewrite_id_key => $rewrite_id_value ) {
@@ -1119,7 +1119,7 @@ class BP_Component {
 	 * }
 	 */
 	public function add_rewrite_rules( $rewrite_rules = array() ) {
-		if ( array_filter( $this->rewrite_ids ) ) {
+		if ( 'rewrites' === bp_core_get_query_parser() && array_filter( $this->rewrite_ids ) ) {
 			$priority = 'top';
 			$chunks   = array_merge( bp_rewrites_get_default_url_chunks(), $rewrite_rules );
 
@@ -1211,7 +1211,7 @@ class BP_Component {
 			$permastructs = array_merge( $directory_permastruct, (array) $permastructs );
 		}
 
-		if ( $permastructs ) {
+		if ( 'rewrites' === bp_core_get_query_parser() && $permastructs ) {
 			foreach ( $permastructs as $name => $params ) {
 				if ( ! $name || ! isset( $params['permastruct'] ) || ! $params['permastruct'] ) {
 					continue;


### PR DESCRIPTION
Make sure the BP Query Parser in use is `'rewrites'` before generating BP Rewrite rules

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9192

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
