### PR TITLE
Wrong Profile Image Showing in Credit List

### DIFF
--- a/src/bp-core/classes/class-bp-admin.php
+++ b/src/bp-core/classes/class-bp-admin.php
@@ -1142,7 +1142,7 @@ class BP_Admin {
 			</h3>
 			<ul class="wp-people-group " id="wp-people-group-noteworthy">
 				<li class="wp-person" id="wp-person-shailu25">
-					<a class="web" href="https://profiles.wordpress.org/shailu25/"><img alt="" class="gravatar" src="//gravatar.com/avatar/2d450f193322c17d2138386e45c8ffbf?s=120">
+					<a class="web" href="https://profiles.wordpress.org/shailu25/"><img alt="" class="gravatar" src="//gravatar.com/avatar/898d977196c2e4f5db4aab41edf1f5ad?s=120">
 					Shail Mehta</a>
 				</li>
 				<li class="wp-person" id="wp-person-niftythree">


### PR DESCRIPTION
Another Person's Profile Image Showing With My Name (Its Showing this Profile's Gravatar Instead of my profile photo.)
(https://profiles.wordpress.org/upadalavipul/)

I think @imath Forgot to Change Gravatar URL With Person's Name in this [commit ](Gravatar)

My Profile URL: 
![buddypress](https://github.com/user-attachments/assets/491294a4-da3b-4a4b-b8af-68c6245fe8b8)

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9211


