### PR TITLE
`customizer_set_uri` can cause notice in PHP 8.1

### DIFF
--- a/src/bp-templates/bp-nouveau/buddypress-functions.php
+++ b/src/bp-templates/bp-nouveau/buddypress-functions.php
@@ -696,7 +696,7 @@ class BP_Nouveau extends BP_Theme_Compat {
 	 * @deprecated 12.0.0
 	 *
 	 * @param  string $path The BP Uri.
-	 * @return string       The BP Uri.
+	 * @return string
 	 */
 	public function customizer_set_uri( $path ) {
 		_deprecated_function( __METHOD__, '12.0.0' );
@@ -707,18 +707,18 @@ class BP_Nouveau extends BP_Theme_Compat {
 
 		$uri = wp_parse_url( $path );
 
-		if ( false === strpos( $uri['path'], 'customize.php' ) ) {
+		if ( ! str_contains( $uri['path'], 'customize.php' ) || empty( $uri['query'] ) ) {
 			return $path;
-		} else {
-			$vars = bp_parse_args(
-				$uri['query'],
-				array(),
-				'customizer_set_uri'
-			);
+		}
 
-			if ( ! empty( $vars['url'] ) ) {
-				$path = str_replace( get_site_url(), '', urldecode( $vars['url'] ) );
-			}
+		$vars = bp_parse_args(
+			$uri['query'],
+			array(),
+			'customizer_set_uri'
+		);
+
+		if ( ! empty( $vars['url'] ) ) {
+			$path = str_replace( get_site_url(), '', urldecode( $vars['url'] ) );
 		}
 
 		return $path;

--- a/src/bp-templates/bp-nouveau/buddypress-functions.php
+++ b/src/bp-templates/bp-nouveau/buddypress-functions.php
@@ -120,6 +120,12 @@ class BP_Nouveau extends BP_Theme_Compat {
 				},
 				0
 			);
+
+			// When BP Classic is activated, regular themes need this filter. 
+			if ( function_exists( 'bp_classic' ) ) {
+				// Set the BP Uri for the Ajax customizer preview.
+				add_filter( 'bp_uri', array( $this, 'customizer_set_uri' ), 10, 1 );
+			}
 		} elseif ( wp_using_themes() && ! isset( $_GET['bp_customizer'] ) ) {
 			remove_action( 'customize_register', 'bp_customize_register', 20 );
 		}
@@ -693,13 +699,12 @@ class BP_Nouveau extends BP_Theme_Compat {
 	 * Set the BP Uri for the customizer in case of Ajax requests.
 	 *
 	 * @since 3.0.0
-	 * @deprecated 12.0.0
+	 * @since 12.0.0 Only fired for regular themes when BP Classic is activated.
 	 *
 	 * @param  string $path The BP Uri.
 	 * @return string
 	 */
 	public function customizer_set_uri( $path ) {
-		_deprecated_function( __METHOD__, '12.0.0' );
 
 		if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
 			return $path;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://buddypress.trac.wordpress.org/ticket/8920

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
