### PR TITLE
Block user from constantly request activation email resend

### DIFF
--- a/src/bp-members/classes/class-bp-rest-signup-v1-controller.php
+++ b/src/bp-members/classes/class-bp-rest-signup-v1-controller.php
@@ -786,8 +786,6 @@ class BP_REST_Signup_V1_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function signup_resend_activation_email( $request ) {
-		$request->set_param( 'context', 'edit' );
-
 		$signup_id = $request->get_param( 'id' );
 		$send      = \BP_Signup::resend( array( $signup_id ) );
 
@@ -820,6 +818,7 @@ class BP_REST_Signup_V1_Controller extends WP_REST_Controller {
 	 * Check if a given request has access to resend the activation email.
 	 *
 	 * @since 9.0.0
+	 * @since 15.0.0 Return an error when the activation email resend has been blocked temporarily.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return true|WP_Error
@@ -832,9 +831,15 @@ class BP_REST_Signup_V1_Controller extends WP_REST_Controller {
 			$retval = new WP_Error(
 				'bp_rest_invalid_id',
 				__( 'Invalid signup id.', 'buddypress' ),
-				array(
-					'status' => 404,
-				)
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( true === $retval && false === BP_Signup::resend_activation( $signup ) ) {
+			$retval = new WP_Error(
+				'bp_rest_signup_resend_activation_email_fail',
+				__( 'Your account activation email resend has been blocked temporarily due to multiple attempts, please try again later.', 'buddypress' ),
+				array( 'status' => 500 )
 			);
 		}
 

--- a/src/bp-members/classes/class-bp-rest-signup-v1-controller.php
+++ b/src/bp-members/classes/class-bp-rest-signup-v1-controller.php
@@ -786,16 +786,22 @@ class BP_REST_Signup_V1_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function signup_resend_activation_email( $request ) {
-		$signup_id = $request->get_param( 'id' );
-		$send      = \BP_Signup::resend( array( $signup_id ) );
+		$signup = $this->get_signup_object( $request->get_param( 'id' ) );
+		$send   = $signup::resend( $signup->id );
+
+		if ( empty( $send ) ) {
+			return new WP_Error(
+				'bp_rest_signup_resend_activation_email_fail',
+				__( 'There was a problem performing this action. Please try again.', 'buddypress' ),
+				array( 'status' => 500 )
+			);
+		}
 
 		if ( ! empty( $send['errors'] ) ) {
 			return new WP_Error(
 				'bp_rest_signup_resend_activation_email_fail',
 				__( 'Your account has already been activated.', 'buddypress' ),
-				array(
-					'status' => 500,
-				)
+				array( 'status' => 500 )
 			);
 		}
 

--- a/src/bp-members/classes/class-bp-signup.php
+++ b/src/bp-members/classes/class-bp-signup.php
@@ -159,7 +159,7 @@ class BP_Signup {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param integer $signup_id The ID for the signup being queried.
+	 * @param int $signup_id The ID for the signup being queried.
 	 */
 	public function __construct( $signup_id = 0 ) {
 		if ( ! empty( $signup_id ) ) {

--- a/tests/phpunit/testcases/members/class-bp-signup.php
+++ b/tests/phpunit/testcases/members/class-bp-signup.php
@@ -594,7 +594,7 @@ class BP_Tests_BP_Signup extends BP_UnitTestCase {
 
 		bp_core_signup_send_validation_email( 0, $user_email, $activation_key );
 
-		$signup = new BP_Signup( $s1 );
+		$signup = new BP_Signup( $s1->id );
 		$this->assertEquals( 1, $signup->count_sent );
 	}
 

--- a/tests/phpunit/testcases/members/v1-signup-test-controller.php
+++ b/tests/phpunit/testcases/members/v1-signup-test-controller.php
@@ -728,6 +728,8 @@ class BP_Test_REST_Signup_V1_Controller extends WP_Test_REST_Controller_Testcase
 		$request->set_param( 'context', 'edit' );
 		$response = $this->server->dispatch( $request );
 
+		$this->assertEquals( 500, $response->get_status() );
+
 		$error_code = 'bp_rest_signup_resend_activation_email_fail';
 		$error      = $response->as_error();
 		$message    = $error->get_error_message( $error_code );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Here I'm suggesting an approach to block users from constantly request the resending of activation emails. This approach is filterable and flexible. And accounts for both the web version and the REST API.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9137

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
