### PR TITLE
Add missing `bp_signups` & `bp_optouts` cache global groups

### DIFF
--- a/src/bp-core/classes/class-bp-core.php
+++ b/src/bp-core/classes/class-bp-core.php
@@ -329,6 +329,7 @@ class BP_Core extends BP_Component {
 				'bp',
 				'bp_pages',
 				'bp_invitations',
+				'bp_optouts',
 			)
 		);
 

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -679,10 +679,13 @@ class BP_Members_Component extends BP_Component {
 	public function setup_cache_groups() {
 
 		// Global groups.
-		wp_cache_add_global_groups( array(
-			'bp_last_activity',
-			'bp_member_member_type',
-		) );
+		wp_cache_add_global_groups(
+			array(
+				'bp_last_activity',
+				'bp_member_member_type',
+				'bp_signups',
+			)
+		);
 
 		parent::setup_cache_groups();
 	}


### PR DESCRIPTION
- Adds `bp_optouts` to the BP Core component global cache group registration.
- Adds `bp_signups` to the BP Members component global cache group registration.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9216

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
