### PR TITLE
Improve inline comments for `BP_Members_Invitations_Component`

### DIFF
--- a/src/bp-members/classes/class-bp-members-invitations-component.php
+++ b/src/bp-members/classes/class-bp-members-invitations-component.php
@@ -9,9 +9,25 @@
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * BuddyPress Invitations Component Class.
+ *
+ * Invitations are actually a deactivable feature of the Members component. To make sure this feature
+ * page slugs can be customized using the BP Rewrites API, it was decided to extend the `BP_Component`
+ * class to benefit from the improvements added to it during 12.0.0 into the "rewrite" area.
+ * @see `BP_Component::register_nav()`.
+ *
+ * @since 12.0.0
+ */
 class BP_Members_Invitations_Component extends BP_Component {
 
-	function __construct() {
+	/**
+	 * Start the invitations feature creation process.
+	 *
+	 * @since 12.0.0
+	 */
+	public function __construct() {
 		parent::start(
 			'members_invitations',
 			__( 'Members Invitations', 'buddypress' ),


### PR DESCRIPTION
Adds 2 PHP doc blocks + the missing `public` keyword to the constructor. 

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9220

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
