### PR TITLE
Introduce a filterable function to inform about whether BP is running from `src`

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -139,6 +139,26 @@ function bp_is_running_wp( $version, $compare = '>=' ) {
 	return version_compare( $GLOBALS['wp_version'], $version, $compare );
 }
 
+/**
+ * Informs whether BuddyPress was loaded from the `src` subdirectory (trunk version).
+ *
+ * @since 15.0.0
+ *
+ * @return boolean True if BuddyPress was loaded from the `src` subdirectory, false otherwise.
+ */
+function bp_is_running_from_src_subdirectory() {
+	$is_src = defined( 'BP_SOURCE_SUBDIRECTORY' ) && BP_SOURCE_SUBDIRECTORY === 'src';
+
+	/**
+	 * Filter here to edit the way BuddyPress was loaded.
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param boolean $is_src True if BuddyPress was loaded from the `src` subdirectory, false otherwise.
+	 */
+	return apply_filters( 'bp_is_running_from_src_subdirectory', $is_src );
+}
+
 /** Functions *****************************************************************/
 
 /**
@@ -2766,7 +2786,7 @@ function bp_core_get_minified_asset_suffix() {
 	$ext = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
 	// Ensure the assets can be located when running from /src/.
-	if ( defined( 'BP_SOURCE_SUBDIRECTORY' ) && BP_SOURCE_SUBDIRECTORY === 'src' ) {
+	if ( bp_is_running_from_src_subdirectory() ) {
 		$ext = str_replace( '.min', '', $ext );
 	}
 
@@ -4980,7 +5000,7 @@ function bp_get_deprecated_functions_versions() {
 	 * Unless the `BP_IGNORE_DEPRECATED` constant is used & set to false, the development
 	 * version of BuddyPress do not load deprecated functions.
 	 */
-	if ( defined( 'BP_SOURCE_SUBDIRECTORY' ) && BP_SOURCE_SUBDIRECTORY === 'src' ) {
+	if ( bp_is_running_from_src_subdirectory() ) {
 		return array();
 	}
 

--- a/src/bp-core/bp-core-rest-api.php
+++ b/src/bp-core/bp-core-rest-api.php
@@ -33,9 +33,7 @@ function bp_rest_is_plugin_active() {
  * @return bool Whether to use the REST Endpoints of built BuddyPress.
  */
 function bp_rest_in_buddypress() {
-	$is_src = defined( 'BP_SOURCE_SUBDIRECTORY' ) && BP_SOURCE_SUBDIRECTORY === 'src';
-
-	return ! $is_src && ! bp_rest_is_plugin_active();
+	return ! bp_is_running_from_src_subdirectory() && ! bp_rest_is_plugin_active();
 }
 
 /**

--- a/src/bp-core/bp-core-template-loader.php
+++ b/src/bp-core/bp-core-template-loader.php
@@ -241,7 +241,7 @@ function bp_locate_template( $template_names, $load = false, $require_once = tru
  */
 function bp_locate_template_asset( $filename ) {
 	// Ensure assets can be located when running from /src/.
-	if ( defined( 'BP_SOURCE_SUBDIRECTORY' ) && 'src' === BP_SOURCE_SUBDIRECTORY ) {
+	if ( bp_is_running_from_src_subdirectory() ) {
 		$filename = str_replace( '.min', '', $filename );
 	}
 

--- a/src/bp-templates/bp-legacy/buddypress-functions.php
+++ b/src/bp-templates/bp-legacy/buddypress-functions.php
@@ -406,7 +406,7 @@ class BP_Legacy extends BP_Theme_Compat {
 		$locations = array();
 
 		// Ensure the assets can be located when running from /src/.
-		if ( defined( 'BP_SOURCE_SUBDIRECTORY' ) && BP_SOURCE_SUBDIRECTORY === 'src' ) {
+		if ( bp_is_running_from_src_subdirectory() ) {
 			$file = str_replace( '.min', '', $file );
 		}
 


### PR DESCRIPTION
`bp_is_running_from_src_subdirectory()` informs whether BuddyPress was loaded from the `src` subdirectory (trunk version).

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9224

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
