### PR TITLE
Introduce 2 new filterable functions to get register/activate root slugs

### DIFF
--- a/src/bp-members/bp-members-template.php
+++ b/src/bp-members/bp-members-template.php
@@ -243,6 +243,26 @@ function bp_signup_slug() {
 	}
 
 /**
+ * Returns the registration page root slug.
+ *
+ * This function is used to set the BP Signup rewrite rule and permastruct.
+ *
+ * @since 15.0.0
+ *
+ * @return string The registration page root slug.
+ */
+function bp_get_signup_root_slug() {
+	/**
+	 * Filter here to edit the registration page root slug.
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param string $register_root_slug The registration page root slug.
+	 */
+	return apply_filters( 'bp_members_register_root_slug', bp_get_signup_slug() );
+}
+
+/**
  * Output the activation slug.
  *
  * @since 1.5.0
@@ -274,6 +294,26 @@ function bp_activate_slug() {
 		 */
 		return apply_filters( 'bp_get_activate_slug', $slug );
 	}
+
+/**
+ * Returns the registration page root slug.
+ *
+ * This function is used to set the BP Signup rewrite rule and permastruct.
+ *
+ * @since 15.0.0
+ *
+ * @return string The registration page root slug.
+ */
+function bp_get_activate_root_slug() {
+	/**
+	 * Filter here to edit the activation page root slug.
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param string $activate_root_slug The activation page root slug.
+	 */
+	return apply_filters( 'bp_members_activate_root_slug', bp_get_activate_slug() );
+}
 
 /**
  * Output the members invitation pane slug.

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -227,8 +227,8 @@ class BP_Members_Component extends BP_Component {
 		$bp = buddypress();
 
 		// Set-up Extra permastructs for the register and activate pages.
-		$this->register_permastruct = bp_get_signup_slug() . '/%' . $this->rewrite_ids['member_register'] . '%';
-		$this->activate_permastruct = bp_get_activate_slug() . '/%' . $this->rewrite_ids['member_activate'] . '%';
+		$this->register_permastruct = bp_get_signup_root_slug() . '/%' . $this->rewrite_ids['member_register'] . '%';
+		$this->activate_permastruct = bp_get_activate_root_slug() . '/%' . $this->rewrite_ids['member_activate'] . '%';
 
 		// Init the User's ID to use to build the Nav for.
 		$user_id = bp_loggedin_user_id();
@@ -725,17 +725,17 @@ class BP_Members_Component extends BP_Component {
 				'query' => 'index.php?' . $this->rewrite_ids['directory'] . '=1&' . $this->rewrite_ids['directory_type'] . '=$matches[1]',
 			),
 			'member_activate'     => array(
-				'regex' => bp_get_activate_slug() . '/?$',
+				'regex' => bp_get_activate_root_slug() . '/?$',
 				'order' => 40,
 				'query' => 'index.php?' . $this->rewrite_ids['member_activate'] . '=1',
 			),
 			'member_activate_key' => array(
-				'regex' => bp_get_activate_slug() . '/([^/]+)/?$',
+				'regex' => bp_get_activate_root_slug() . '/([^/]+)/?$',
 				'order' => 30,
 				'query' => 'index.php?' . $this->rewrite_ids['member_activate'] . '=1&' . $this->rewrite_ids['member_activate_key'] . '=$matches[1]',
 			),
 			'member_register'     => array(
-				'regex' => bp_get_signup_slug() . '/?$',
+				'regex' => bp_get_signup_root_slug() . '/?$',
 				'order' => 20,
 				'query' => 'index.php?' . $this->rewrite_ids['member_register'] . '=1',
 			),

--- a/tests/phpunit/testcases/routing/members.php
+++ b/tests/phpunit/testcases/routing/members.php
@@ -121,4 +121,76 @@ class BP_Tests_Routing_Members extends BP_UnitTestCase {
 
 		$this->assertSame( get_current_user_id(), bp_displayed_user_id() );
 	}
+
+	public function filter_root_slug( $root_slug ) {
+		return 'community/' . $root_slug;
+	}
+
+	/**
+	 * @ticket BP9063
+	 */
+	public function test_members_registration_page_filtered() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		add_filter( 'bp_members_register_root_slug', array( $this, 'filter_root_slug' ) );
+		bp_delete_rewrite_rules();
+
+		// Regenerate rewrite rules.
+		$this->go_to( home_url() );
+		$bp_registration_url = bp_get_signup_page();
+
+		remove_filter( 'bp_members_register_root_slug', array( $this, 'filter_root_slug' ) );
+
+		$this->go_to( $bp_registration_url );
+
+		$this->assertTrue( false !== strpos( $bp_registration_url, 'community' ) );
+		$this->assertTrue( bp_is_register_page() );
+	}
+
+	/**
+	 * @ticket BP9063
+	 */
+	public function test_members_registration_page() {
+		$this->set_permalink_structure( '/%postname%/' );
+		$bp_registration_url = bp_get_signup_page();
+
+		$this->go_to( $bp_registration_url );
+
+		$this->assertTrue( false === strpos( $bp_registration_url, 'community' ) );
+		$this->assertTrue( bp_is_register_page() );
+	}
+
+	/**
+	 * @ticket BP9063
+	 */
+	public function test_members_activation_page_filtered() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		add_filter( 'bp_members_activate_root_slug', array( $this, 'filter_root_slug' ) );
+		bp_delete_rewrite_rules();
+
+		// Regenerate rewrite rules.
+		$this->go_to( home_url() );
+		$bp_activation_url = bp_get_activation_page();
+
+		remove_filter( 'bp_members_activate_root_slug', array( $this, 'filter_root_slug' ) );
+
+		$this->go_to( $bp_activation_url );
+
+		$this->assertTrue( false !== strpos( $bp_activation_url, 'community' ) );
+		$this->assertTrue( bp_is_activation_page() );
+	}
+
+	/**
+	 * @ticket BP9063
+	 */
+	public function test_members_activation_page() {
+		$this->set_permalink_structure( '/%postname%/' );
+		$bp_activation_url = bp_get_activation_page();
+
+		$this->go_to( $bp_activation_url );
+
+		$this->assertTrue( false === strpos( $bp_activation_url, 'community' ) );
+		$this->assertTrue( bp_is_activation_page() );
+	}
 }


### PR DESCRIPTION
Introduce 2 new filterable functions to get register/activate root slugs. These 2 functions are used to set rewrite rules and permastructs. Using the filter it is now possible to prepend a `custom-slug/` to the generated rewrite rules and permastruct.

This was the only missing thing to be able to prepend a `custom-slug/` to all directory/specific page root slugs.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9063

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
