### PR TITLE
Avoid a PHP Notice with WP 6.7

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -2645,7 +2645,7 @@ function bp_core_load_buddypress_textdomain() {
 	 */
 	load_plugin_textdomain( $domain );
 }
-add_action( 'bp_core_loaded', 'bp_core_load_buddypress_textdomain' );
+add_action( 'bp_after_setup_theme', 'bp_core_load_buddypress_textdomain' );
 
 /**
  * A JavaScript-free implementation of the search functions in BuddyPress.


### PR DESCRIPTION
Wait until `bp_after_setup_theme` before using the `load_plugin_textdomain()` function as expected by WordPress 6.7.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9240

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
