### PR TITLE
Move the check for the group's `'invite_status'` meta in join action handlers

### DIFF
--- a/src/bp-groups/actions/join.php
+++ b/src/bp-groups/actions/join.php
@@ -18,6 +18,14 @@ function groups_action_join_group() {
 		return;
 	}
 
+	/*
+	 * Ensure that the invite_status key exists, to avoid a group being joinable when its
+	 * creation process was interrupted.
+	 */
+	if ( ! groups_get_groupmeta( bp_get_current_group_id(), 'invite_status' ) ) {
+		return;
+	}
+
 	// Nonce check.
 	if ( ! check_admin_referer( 'groups_join_group' ) ) {
 		return;

--- a/src/bp-groups/bp-groups-functions.php
+++ b/src/bp-groups/bp-groups-functions.php
@@ -664,15 +664,7 @@ function groups_join_group( $group, $user_id = 0 ) {
 
 	$group = bp_get_group( $group );
 
-	/*
-	 * When the group create first step is completed, the group's status has not been defined by the
-	 * group creator yet and defaults to public. As the group status & the invite status are set once
-	 * the group create second step is completed, we need to wait for this step to be achieved to let
-	 * users join the group being created otherwise it would be possible for a user to "pre-join" a
-	 * private/hidden group. Checking if the invite status is set is the only way to make sure this
-	 * second step has been completed. If it's not the case, no need to go further.
-	 */
-	if ( empty( $group->id ) || ! groups_get_groupmeta( $group->id, 'invite_status' ) ) {
+	if ( empty( $group->id ) ) {
 		return false;
 	}
 

--- a/src/bp-templates/bp-legacy/buddypress-functions.php
+++ b/src/bp-templates/bp-legacy/buddypress-functions.php
@@ -1616,6 +1616,15 @@ function bp_legacy_theme_ajax_joinleave_group() {
 				esc_html_e( 'Error joining group', 'buddypress' );
 			}
 
+			/*
+			 * Ensure that the invite_status key exists, to avoid a group
+			 * being joinable when its creation process was interrupted.
+			 */
+			if ( ! groups_get_groupmeta( $group->id, 'invite_status' ) ) {
+				esc_html_e( 'Error joining group', 'buddypress' );
+				break;
+			}
+
 			check_ajax_referer( 'groups_join_group' );
 
 			if ( ! groups_join_group( $group->id ) ) {

--- a/src/bp-templates/bp-nouveau/includes/groups/ajax.php
+++ b/src/bp-templates/bp-nouveau/includes/groups/ajax.php
@@ -168,7 +168,7 @@ function bp_nouveau_ajax_joinleave_group() {
 					'feedback' => $errors['member'],
 					'type'     => 'error',
 				);
-			} elseif ( 'public' !== $group->status ) {
+			} elseif ( 'public' !== $group->status || ! groups_get_groupmeta( $group->id, 'invite_status' ) ) {
 				$response = array(
 					'feedback' => $errors['cannot'],
 					'type'     => 'error',


### PR DESCRIPTION
This PR adds a small adjustment inside Nouveau's Ajax Group's join handler to the [patch](https://buddypress.trac.wordpress.org/attachment/ticket/9241/9241.diff) shared by @boonebgorges directly into the Trac ticket.

Main difference compared to the patch is the fact the `'invite_status'` meta check is done inside a previous conditional statement.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9241

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
