### PR TITLE
Start Documenting  BP REST API v2

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -12,3 +12,4 @@ If you’re new to Add-on development, start by reading the [introduction](./int
 2. [BuddyPress Components](./components/README.md)
 3. [BuddyPress Theme Compatibility](./theme-compat/README.md)
 4. [BuddyPress execution contexts](./execution-contexts/README.md)
+5. [BuddyPress REST API (v2)](./execution-contexts/rest-api/README.md)

--- a/docs/developer/execution-contexts/README.md
+++ b/docs/developer/execution-contexts/README.md
@@ -4,5 +4,5 @@
 
 1. Theme/front-end
 2. [Ajax](./ajax.md)
-3. REST API
+3. [REST API](./rest-api/README.md)
 4. Administration

--- a/docs/developer/execution-contexts/rest-api/README.md
+++ b/docs/developer/execution-contexts/rest-api/README.md
@@ -1,0 +1,69 @@
+# BuddyPress REST API (v2)
+
+Just like the WordPress REST API does it for content data types the BP REST API provides API endpoints for BuddyPress community actions data types that allow developers to interact with sites remotely by sending and receiving [JSON](https://en.wikipedia.org/wiki/JSON) (JavaScript Object Notation) objects. JSON is an open standard data format that is lightweight and human-readable, and looks like Objects do in JavaScript; hence the name.
+
+When you send content to or make a request to the API, the response will be returned in JSON. This enables developers to create, read and update BuddyPress user generated content from client-side JavaScript or from external applications, even those written in languages beyond PHP.
+
+## Why use the BP REST API?
+
+The BP REST API makes it easier than ever to use BuddyPress in new and exciting ways, such as creating Single Page Applications on top of BuddyPress. You could create a Template Pack to provide an entirely new front-end experience for BuddyPress, create brand new & interactive community features, or great BuddyPress blocks for the Block Editor.
+
+The BP REST API can also serve as a strong replacement for the WordPress admin-ajax API. By using the BP REST API, you can more easily structure the way you want to get data into and out of BuddyPress. AJAX calls can be greatly simplified by using the BP REST API, enabling you to improve the performance of your custom features.
+
+## About authentification
+
+**Cookie authentication** is the standard authentication method included with WordPress, the **BP REST API use it**.
+
+### The REST API Nonce
+
+The WordPress REST API includes a technique called [nonces](https://developer.wordpress.org/apis/security/nonces/) to avoid [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) issues. This prevents other sites from forcing you to perform actions without explicitly intending to do so. This requires slightly special handling for the API.
+
+The API uses nonces with the action set to `wp_rest`. To generate it and pass it to your script you can use the `wp_add_inline_script()` function.
+
+```php
+<?php
+// Generating the nonce.
+function example_enqueue_script() {
+	wp_enqueue_script( 'my-script-handle', 'url-to/my-script.js' );
+
+	//Setting your script's data.
+	$script_data = array(
+		'nonce' => wp_create_nonce( 'wp_rest' ),
+	);
+
+	// Pass the nonce to your script.
+	wp_add_inline_script(
+		'my-script-handle',
+		sprintf( 'const %1$s = %2$s;', 'bpRestApi', wp_json_encode( $script_data ) ),
+		'before'
+	);
+}
+add_action( 'bp_enqueue_community_scripts', 'example_enqueue_script' );
+```
+
+### Sending the nonce
+
+For developers making their own requests, the nonce will need to be passed with each request. The recommended way to send the nonce value is in the request headers. Below is an example using the JavaScript Fetch API.
+
+```js
+// Set headers.
+const requestHeaders = new Headers( {
+	'X-WP-Nonce': bpRestApi.nonce,
+} );
+
+// Send & handle the request.
+fetch( '/wp-json/buddypress/v2/components', {
+	method: 'GET',
+	headers: requestHeaders,
+} ).then( ( response ) => {
+	return response.json();
+} ).then( ( data ) => {
+	 console.log( data )
+} );
+```
+
+## Next Steps
+
+Familiarize yourself with the [key technical concepts](https://developer.wordpress.org/rest-api/key-concepts/) behind how the REST API functions.
+
+For a comprehensive overview of the resources and routes available by default, review the [API reference](./reference.md).

--- a/docs/developer/execution-contexts/rest-api/README.md
+++ b/docs/developer/execution-contexts/rest-api/README.md
@@ -48,10 +48,11 @@ add_action( 'bp_enqueue_community_scripts', 'example_enqueue_script' );
 
 For developers making their own requests, the nonce will need to be passed with each request. The recommended way to send the nonce value is in the request headers. Below is an example using the JavaScript Fetch API.
 
-```js
+```javascript
 // Set headers.
 const requestHeaders = new Headers( {
 	'X-WP-Nonce': bpRestApi.nonce,
+	'Content-Type': 'application/json',
 } );
 
 // Send & handle the request.
@@ -61,7 +62,7 @@ fetch( '/wp-json/buddypress/v2/components', {
 } ).then( ( response ) => {
 	return response.json();
 } ).then( ( data ) => {
-	 console.log( data )
+	 console.log( data );
 } );
 ```
 

--- a/docs/developer/execution-contexts/rest-api/README.md
+++ b/docs/developer/execution-contexts/rest-api/README.md
@@ -1,5 +1,8 @@
 # BuddyPress REST API (v2)
 
+> [!IMPORTANT]
+> This is the documentation for the BP REST API **v2**. This version was introduced in BuddyPress 15.0.0. The BP REST API v1 is deprecated as of BuddyPress 15.0.0. If you still need to use v1, you can download and activate the archived [BP REST plugin](https://github.com/buddypress/BP-REST) and refer to this [documentation](https://developer.buddypress.org/bp-rest-api/). We strongly advise you to update your code to support **v2** as soon as you can.
+
 Just like the WordPress REST API does it for content data types the BP REST API provides API endpoints for BuddyPress community actions data types that allow developers to interact with sites remotely by sending and receiving [JSON](https://en.wikipedia.org/wiki/JSON) (JavaScript Object Notation) objects. JSON is an open standard data format that is lightweight and human-readable, and looks like Objects do in JavaScript; hence the name.
 
 When you send content to or make a request to the API, the response will be returned in JSON. This enables developers to create, read and update BuddyPress user generated content from client-side JavaScript or from external applications, even those written in languages beyond PHP.

--- a/docs/developer/execution-contexts/rest-api/README.md
+++ b/docs/developer/execution-contexts/rest-api/README.md
@@ -1,7 +1,7 @@
 # BuddyPress REST API (v2)
 
 > [!IMPORTANT]
-> This is the documentation for the BP REST API **v2**. This version was introduced in BuddyPress 15.0.0. The BP REST API v1 is deprecated as of BuddyPress 15.0.0. If you still need to use v1, you can download and activate the archived [BP REST plugin](https://github.com/buddypress/BP-REST) and refer to this [documentation](https://developer.buddypress.org/bp-rest-api/). We strongly advise you to update your code to support **v2** as soon as you can.
+> This is the documentation for the BP REST API **v2**. This version was introduced in BuddyPress 15.0.0. The BP REST API v1 is deprecated as of BuddyPress 15.0.0. If you still need to use v1, you can download and activate the archived [BuddyPress RESTful API plugin](https://github.com/buddypress/BP-REST) and refer to this [documentation](https://developer.buddypress.org/bp-rest-api/). We strongly advise you to update your code to support **v2** as soon as you can.
 
 Just like the WordPress REST API does it for content data types the BP REST API provides API endpoints for BuddyPress community actions data types that allow developers to interact with sites remotely by sending and receiving [JSON](https://en.wikipedia.org/wiki/JSON) (JavaScript Object Notation) objects. JSON is an open standard data format that is lightweight and human-readable, and looks like Objects do in JavaScript; hence the name.
 

--- a/docs/developer/execution-contexts/rest-api/components.md
+++ b/docs/developer/execution-contexts/rest-api/components.md
@@ -79,7 +79,7 @@ fetch( '/wp-json/buddypress/v2/components?context=edit&status=active', {
 fetch( '/wp-json/buddypress/v2/components', {
 	method: 'PUT',
 	headers: requestHeaders,
-    body: JSON.stringify( { name: 'groups', action: 'activate' } ),
+	body: JSON.stringify( { name: 'groups', action: 'activate' } ),
 } ).then( ( response ) => {
 	return response.json();
 } ).then( ( data ) => {

--- a/docs/developer/execution-contexts/rest-api/components.md
+++ b/docs/developer/execution-contexts/rest-api/components.md
@@ -1,0 +1,93 @@
+# Components
+
+BuddyPress chose a modular approach using components to organize its features. Two components are loaded by default (eg: BuddyPress Core and Community Members) while the majority are optionals. BuddyPress comes with 8 built-in optional components (Account Settings, Activity Streams, Extended Profiles, Friend connections, Notifications, Private messaging, User groups and Site Tracking).
+
+> [!IMPORTANT]
+> Note: It’s important to note there can be more optional components regarding the BuddyPress plugins installed on the website : these plugins can use the BP Component API to incorpore the lists of active or inactive BuddyPress components.
+
+## Schema
+
+The schema defines all the fields that exist for BuddyPress components.
+
+| Property | Description |
+| --- | --- |
+| `name` | Key name of the component.  <br />JSON data type: _string_. <br />Context: `view`, `edit`. |
+| `is_active` | Whether the component is active or not.  <br />JSON data type: _boolean_. <br /><br />Default: `false`. Context: `view`, `edit`. |
+| `status` | Whether the component is active or inactive. <br />JSON data type: _string_. <br />Context: `view`, `edit`.  <br />One of: `active`, `inactive`. |
+| `title` | Title of the component. <br />JSON data type: _string_. <br />Context: `view`, `edit`. |
+| `description` | Description of the component. <br />JSON data type: _string_. <br />Context: `view`, `edit`. |
+| `features` | Information about active features for the component. <br />JSON data type: _object_ \| _null_. <br />Default: `null`. <br />Context: `view`, `edit`. |
+
+## List the BuddyPress components
+
+### Arguments
+
+| Name | Description |
+| --- | --- |
+| `context` | Scope under which the request is made; determines fields present in response.  <br />JSON data type: _string_. <br />Default: `view`. <br />One of: `view`, `edit`. |
+| `page` | Current page of the collection.  <br />JSON data type: _integer_. <br />Default: `1`. |
+| `per_page` | Maximum number of components to be returned in result set. <br />JSON data type: _integer_. <br />Default: `10`. |
+| `search` | Limit results to those matching a string. <br />JSON data type: _string_. |
+| `status` | Limit result set to components with a specific status. <br />JSON data type: _string_. <br />Default: `all`. <br />One of: `all, active, inactive`. |
+| `type` | Information about active features for the component. <br />JSON data type: _string_. <br />Default: `all`. <br />One of: `all, optional, retired, required`. |
+
+### Definition
+
+`GET /buddypress/v2/components`
+
+### Example of use
+
+> [!WARNING]
+> The `requestHeaders` object needs to be set according to the WordPress REST API nonce. Read more about the [REST API authentification](./README.md#about-authentification).
+
+
+```javascript
+fetch( '/wp-json/buddypress/v2/components?context=edit&status=active', {
+	method: 'GET',
+	headers: requestHeaders,
+} ).then( ( response ) => {
+	return response.json();
+} ).then( ( data ) => {
+	 console.table( data );
+} );
+```
+
+### JSON Response
+
+- An array of objects representing the matching components on success.
+- An object containg the error code, data and message on failure.
+
+## Activate or Deactivate a BuddyPress component
+
+### Arguments
+
+| Name | Description |
+| --- | --- |
+| `name` | Key name of the component. **Required**. <br />JSON data type: _string_. |
+| `action` | Whether to activate or deactivate the component. **Required**. <br />JSON data type: _string_. <br />One of: `activate`, `deactivate`. |
+
+### Definition
+
+`PUT /buddypress/v2/components`
+
+### Example of use
+
+> [!WARNING]
+> The `requestHeaders` needs to be set according to the WordPress REST API nonce. Read more about the [REST API authentification](./README.md#about-authentification).
+
+```javascript
+fetch( '/wp-json/buddypress/v2/components', {
+	method: 'PUT',
+	headers: requestHeaders,
+    body: JSON.stringify( { name: 'groups', action: 'activate' } ),
+} ).then( ( response ) => {
+	return response.json();
+} ).then( ( data ) => {
+	 console.log( data );
+} );
+```
+
+### JSON Response
+
+- An object representing the updated component on success.
+- An object containg the error code, data and message on failure.

--- a/docs/developer/execution-contexts/rest-api/components.md
+++ b/docs/developer/execution-contexts/rest-api/components.md
@@ -1,4 +1,4 @@
-# Components
+# Components REST API routes
 
 BuddyPress chose a modular approach using components to organize its features. Two components are loaded by default (eg: BuddyPress Core and Community Members) while the majority are optionals. BuddyPress comes with 8 built-in optional components (Account Settings, Activity Streams, Extended Profiles, Friend connections, Notifications, Private messaging, User groups and Site Tracking).
 
@@ -12,7 +12,7 @@ The schema defines all the fields that exist for BuddyPress components.
 | Property | Description |
 | --- | --- |
 | `name` | Key name of the component.  <br />JSON data type: _string_. <br />Context: `view`, `edit`. |
-| `is_active` | Whether the component is active or not.  <br />JSON data type: _boolean_. <br /><br />Default: `false`. Context: `view`, `edit`. |
+| `is_active` | Whether the component is active or not.  <br />JSON data type: _boolean_. <br />Default: `false`. <br />Context: `view`, `edit`. |
 | `status` | Whether the component is active or inactive. <br />JSON data type: _string_. <br />Context: `view`, `edit`.  <br />One of: `active`, `inactive`. |
 | `title` | Title of the component. <br />JSON data type: _string_. <br />Context: `view`, `edit`. |
 | `description` | Description of the component. <br />JSON data type: _string_. <br />Context: `view`, `edit`. |

--- a/docs/developer/execution-contexts/rest-api/components.md
+++ b/docs/developer/execution-contexts/rest-api/components.md
@@ -1,9 +1,9 @@
 # Components REST API routes
 
-BuddyPress chose a modular approach using components to organize its features. Two components are loaded by default (eg: BuddyPress Core and Community Members) while the majority are optionals. BuddyPress comes with 8 built-in optional components (Account Settings, Activity Streams, Extended Profiles, Friend connections, Notifications, Private messaging, User groups and Site Tracking).
+BuddyPress chose a modular approach using components to organize its features. Two components are loaded by default (eg: BuddyPress Core and Community Members) while the majority are optional. BuddyPress comes with 8 built-in optional components (Account Settings, Activity Streams, Extended Profiles, Friend connections, Notifications, Private messaging, User groups and Site Tracking).
 
 > [!IMPORTANT]
-> Note: It’s important to note there can be more optional components regarding the BuddyPress plugins installed on the website : these plugins can use the BP Component API to incorpore the lists of active or inactive BuddyPress components.
+> It’s important to note there can be more than one optional component from BuddyPress plugins installed on the website: these plugins can use the BuddyPress Component API to incorporate the lists of active or inactive components.
 
 ## Schema
 

--- a/docs/developer/execution-contexts/rest-api/members.md
+++ b/docs/developer/execution-contexts/rest-api/members.md
@@ -200,7 +200,7 @@ fetch( '/wp-json/buddypress/v2/members/2', {
 | Name | Description |
 | --- | --- |
 | `id` | Unique identifier for the user. **Required**. <br />JSON data type: _integer_. |
-| `force` | Required to be true, as members do not support trashing. <br />JSON data type: _boolean_. <br />Default: `false`. |
+| `force` | Required to be true, as members do not support trashing. **Required**. <br />JSON data type: _boolean_. <br />Default: `false`. |
 | `reassign` | Reassign the deleted member’s posts and links to this user ID. **Required**. <br />JSON data type: _integer_. |
 
 ### Definition
@@ -312,7 +312,7 @@ fetch( '/wp-json/buddypress/v2/members/me', {
 
 | Name | Description |
 | --- | --- |
-| `force` | Required to be true, as members do not support trashing. <br />JSON data type: _boolean_. <br />Default: `false`. |
+| `force` | Required to be true, as members do not support trashing. **Required**. <br />JSON data type: _boolean_. <br />Default: `false`. |
 | `reassign` | Reassign the deleted member’s posts and links to this user ID. **Required**. <br />JSON data type: _integer_. |
 
 ### Definition

--- a/docs/developer/execution-contexts/rest-api/members.md
+++ b/docs/developer/execution-contexts/rest-api/members.md
@@ -1,0 +1,353 @@
+# Members REST API routes
+
+The BuddyPress Members REST controller extends the WordPress Users one to include specific BuddyPress data such as profile fields data[^1] and use the `BP_User_Query` instead of the `WP_User_Query` to fetch the members.
+
+## Schema
+
+The schema defines all the fields that exist for a member object.
+
+| Property | Description |
+| --- | --- |
+| `id` | Unique identifier for the member. <br />JSON data type: _integer_. <br />Read only. <br />Context: `embed`, `view`, `edit`. |
+| `name`  | Display name for the member. <br />JSON data type: _string_. <br />Context: `embed`, `view`, `edit`. |
+| `mention_name` | The name used for that user in @-mentions. <br />JSON data type: _string_. <br />Context: `embed`, `view`, `edit`. |
+| `link` | Profile URL of the member. <br />JSON data type: _string_, format: _URI_. <br />Read only. <br />Context: `embed`, `view`, `edit`. |
+| `user_login` | An alphanumeric identifier for the member. <br />JSON data type: _string_. <br />Context: `embed`, `view`, `edit`. |
+| `member_types` | Member types associated with the member. See this [documentation page](https://github.com/buddypress/buddypress/blob/master/docs/user/administration/users/member-types.md) for more information. <br />JSON data type: _array_. <br />Read only. <br />Context: `embed`, `view`, `edit`. |
+| `registered_date` | Registration date for the member. <br />JSON data type: _string_ \| _null_, format: _date-time_. <br />Read only. <br />Context: `edit`. |
+| `registered_date_gmt` | The date the member was registered, as GMT. <br />JSON data type: _string_ \| _null_, format: _date-time_. <br />Read only. <br />Context: `edit`. |
+| `registered_since` | Elapsed time since the member registered. <br />JSON data type: _string_. <br />Read only. <br />Context: `view`, `edit`. |
+| `password` | Password for the member (never included). <br />JSON data type: _string_. <br />Context: none. |
+| `roles` | Roles assigned to the member. <br />JSON data type: _array_. <br />Context: `edit`. |
+| `capabilities` | All capabilities assigned to the member. <br />JSON data type: _object_. <br />Read only. <br />Context: `edit`. |
+| `capabilities` | Any extra capabilities assigned to the user. <br />JSON data type: _object_. <br />Read only. <br />Context: `edit`. |
+| `xprofile`[^2] | Member xProfile groups and its fields. <br />JSON data type: _array_. <br />Read only. <br />Context: `view`, `edit`. |
+| `friendship_status`[^3] | Whether the logged in user has a friendship relationship with the fetched user. <br />JSON data type: _boolean_. <br />Read only. <br />Context: `view`, `edit`. |
+| `friendship_status_slug`[^3] | Slug of the friendship relationship status the logged in user has with the fetched user. <br />JSON data type: _string_. <br />Read only. <br />One of: `is_friend`, `not_friends`, `pending`, `awaiting_response`. <br />Context: `view`, `edit`. |
+| `total_friend_count`[^3] | Total number of friends for the member. <br />JSON data type: _integer_. <br />Read only. <br />Context: `view`, `edit`. |
+| `last_activity` | Last date the member was active on the site. <br />JSON data type: _object_ (properties: `timediff`, `date` and `date_gmt`). <br />Read only. <br />Context: `view`, `edit`. |
+| `latest_update`[^4] | The content of the latest activity posted by the member. <br />JSON data type: _object_ (properties: `id`, `raw` and `rendered`). <br />Read only. <br />Context: `view`, `edit`. |
+| `avatar_urls`[^5] | Avatar URLs for the member (Full & Thumb sizes). <br />JSON data type: _object_ (properties: `full`, and `thumb`). <br />Read only. <br />Context: `embed`, `view`, `edit`. |
+
+## List Members
+
+### Arguments
+
+| Name | Description |
+| --- | --- |
+| `context` | Scope under which the request is made; determines fields present in response. <br />JSON data type: _string_. <br/>Default: `view`. <br/>One of: `view`, `embed`, `edit`. |
+| `page` | Current page of the collection. <br />JSON data type: _integer_. <br />Default: `1`. |
+| `per_page` | Maximum number of members to be returned in result set. <br />JSON data type: _integer_. <br />Default: `10`. |
+| `search` | Limit results to those matching a string. <br />JSON data type: _string_. |
+| `exclude` | Ensure result set excludes specific IDs. <br />JSON data type: _array_. <br />Default: `[]`. |
+| `include` | Ensure result set includes specific IDs. <br />JSON data type: _array_. <br />Default: `[]`. |
+| `type` | Shorthand for certain orderby/order combinations. <br />JSON data type: _string_. <br />Default: `newest`. <br/>One of: `active`, `newest`, `alphabetical`, `random`, `online`, `popular`. |
+| `user_id` | Limit results to friends of a user. <br />JSON data type: _integer_. <br />Default: `0`. |
+| `user_ids` | Pass IDs of users to limit result set. <br />JSON data type: _array_. <br />Default: `[]`. |
+| `populate_extras` | Whether to fetch extra BP data about the returned members. <br />JSON data type: _boolean_. <br />Default: `false`. |
+| `member_type` | Limit results set to certain type(s). See this [documentation page](https://github.com/buddypress/buddypress/blob/master/docs/user/administration/users/member-types.md) for more information.<br />JSON data type: _array_. <br />Default: `[]`. |
+| `xprofile` | Limit results set to a certain xProfile field. <br />JSON data type: _array_. <br />Default: `[]`. |
+
+### Definition
+
+`GET /buddypress/v2/members`
+
+### Example of use
+
+> [!WARNING]
+> The `requestHeaders` object needs to be set according to the WordPress REST API nonce. Read more about the [REST API authentification](./README.md#about-authentification).
+
+```javascript
+fetch( '/wp-json/buddypress/v2/members?context=view&type=active', {
+	method: 'GET',
+	headers: requestHeaders,
+} ).then( ( response ) => {
+	return response.json();
+} ).then( ( data ) => {
+	 console.table( data );
+} );
+```
+
+### JSON Response
+
+- An array of objects representing the matching members on success.
+- An object containg the error code, data and message on failure.
+
+## Create a member
+
+Only users having the `create_users` WordPress capability can create a new member.
+
+### Arguments
+
+| Name | Description |
+| --- | --- |
+| `user_login` | An alphanumeric identifier for the member. **Required**. <br />JSON data type: _string_. |
+| `password` | Password for the member. **Required**. <br />JSON data type: _string_. |
+| `email` | The email address for the member. **Required**. <br />JSON data type: _string_. |
+| `name` | Display name for the member. <br />JSON data type: _string_. |
+| `roles` | Roles assigned to the member. <br />JSON data type: _array_. |
+| `member_type` | A comma separated list of Member Types to set for the member. See this [documentation page](https://github.com/buddypress/buddypress/blob/master/docs/user/administration/users/member-types.md) for more information. <br />JSON data type: _string_. |
+
+### Definition
+
+`POST /buddypress/v2/members`
+
+### Example of use
+
+> [!WARNING]
+> The `requestHeaders` object needs to be set according to the WordPress REST API nonce. Read more about the [REST API authentification](./README.md#about-authentification).
+
+```javascript
+fetch( '/wp-json/buddypress/v2/members', {
+	method: 'POST',
+	headers: requestHeaders,
+	body: JSON.stringify(
+		{
+			'user_login': 'bapuu',
+			password: 'neverUseWe@kPassW0rd!',
+			email: 'bapuu@buddypress.org',
+			name: 'Bapuu',
+		}
+	),
+} ).then( ( response ) => {
+	return response.json();
+} ).then( ( data ) => {
+	 console.log( data );
+} );
+```
+
+### JSON Response
+
+- An object representing the created member on success.
+- An object containg the error code, data and message on failure.
+
+## Retrieve a specific member
+
+### Arguments
+
+| Name | Description |
+| --- | --- |
+| `id` | Unique identifier for the member. **Required**. <br />JSON data type: _integer_. |
+| `context` | Scope under which the request is made; determines fields present in response. <br />JSON data type: _string_. <br /> Default: `view`. <br /> One of: `view, embed, edit`. |
+| `populate_extras` | Whether to fetch extra BP data about the returned member. <br />JSON data type: _boolean_.<br /> Default: `false`. |
+
+### Definition
+
+`GET /buddypress/v2/members/<id>`
+
+### Example of use
+
+> [!WARNING]
+> The `requestHeaders` object needs to be set according to the WordPress REST API nonce. Read more about the [REST API authentification](./README.md#about-authentification).
+
+```javascript
+fetch( '/wp-json/buddypress/v2/members/2?populate_extras=true', {
+	method: 'GET',
+	headers: requestHeaders,
+} ).then( ( response ) => {
+	return response.json();
+} ).then( ( data ) => {
+	 console.log( data );
+} );
+```
+
+### JSON Response
+
+- An object representing the member on success.
+- An object containg the error code, data and message on failure.
+
+## Update a specific member
+
+### Arguments
+
+| Name | Description |
+| --- | --- |
+| `id` | Unique identifier for the user. **Required**. <br />JSON data type: _integer_. |
+| `name` | Display name for the member. <br />JSON data type: _string_. |
+| `roles` | Roles assigned to the member. <br />JSON data type: _array_. |
+| `member_type` | A comma separated list of Member Types to set for the member. See this [documentation page](https://github.com/buddypress/buddypress/blob/master/docs/user/administration/users/member-types.md) for more information. <br />JSON data type: _string_. |
+
+### Definition
+
+`PUT /buddypress/v2/members/<id>`
+
+### Example of use
+
+> [!WARNING]
+> The `requestHeaders` object needs to be set according to the WordPress REST API nonce. Read more about the [REST API authentification](./README.md#about-authentification).
+
+```javascript
+fetch( '/wp-json/buddypress/v2/members/2', {
+	method: 'PUT',
+	headers: requestHeaders,
+	body: JSON.stringify( { name: 'Bapuu The BP Wapuu' } ),
+} ).then( ( response ) => {
+	return response.json();
+} ).then( ( data ) => {
+	 console.log( data );
+} );
+```
+
+### JSON Response
+
+- An object representing the updated member on success.
+- An object containg the error code, data and message on failure.
+
+## Delete a specific member
+
+### Arguments
+
+| Name | Description |
+| --- | --- |
+| `id` | Unique identifier for the user. **Required**. <br />JSON data type: _integer_. |
+| `force` | Required to be true, as members do not support trashing. <br />JSON data type: _boolean_. <br />Default: `false`. |
+| `reassign` | Reassign the deleted member’s posts and links to this user ID. **Required**. <br />JSON data type: _integer_. |
+
+### Definition
+
+`DELETE /buddypress/v2/members/<id>`
+
+### Example of use
+
+> [!WARNING]
+> The `requestHeaders` object needs to be set according to the WordPress REST API nonce. Read more about the [REST API authentification](./README.md#about-authentification).
+
+```javascript
+fetch( '/wp-json/buddypress/v2/members/2', {
+	method: 'DELETE',
+	headers: requestHeaders,
+	body: JSON.stringify(
+		{
+			force: true,
+			reassign: 1,
+		}
+	),
+} ).then( ( response ) => {
+	return response.json();
+} ).then( ( data ) => {
+	 console.log( data );
+} );
+```
+
+### JSON Response
+
+- An object informing about the `deleted` status and the `previous` member on success.
+- An object containg the error code, data and message on failure.
+
+## Retrieve the logged in member
+
+### Arguments
+
+| Name | Description |
+| --- | --- |
+| `context` | Scope under which the request is made; determines fields present in response. <br />JSON data type: _string_. <br /> Default: `view`. <br /> One of: `view, embed, edit`. |
+| `populate_extras` | Whether to fetch extra BP data about the returned member. <br />JSON data type: _boolean_.<br /> Default: `false`. |
+
+### Definition
+
+`GET /buddypress/v2/members/me`
+
+### Example of use
+
+> [!WARNING]
+> The `requestHeaders` object needs to be set according to the WordPress REST API nonce. Read more about the [REST API authentification](./README.md#about-authentification).
+
+```javascript
+fetch( '/wp-json/buddypress/v2/members/me', {
+	method: 'GET',
+	headers: requestHeaders,
+} ).then( ( response ) => {
+	return response.json();
+} ).then( ( data ) => {
+	 console.log( data );
+} );
+```
+
+### JSON Response
+
+- An object representing the member on success.
+- An object containg the error code, data and message on failure.
+
+## Update the logged in member
+
+To update roles, the logged in member must have the_ `promote_user` capability.
+
+### Arguments
+
+| Name | Description |
+| --- | --- |
+| `name` | Display name for the member. <br />JSON data type: _string_. |
+| `roles` | Roles assigned to the member. <br />JSON data type: _array_. |
+| `member_type` | A comma separated list of Member Types to set for the member. See this [documentation page](https://github.com/buddypress/buddypress/blob/master/docs/user/administration/users/member-types.md) for more information. <br />JSON data type: _string_. |
+
+### Definition
+
+`PUT /buddypress/v2/members/me`
+
+### Example of use
+
+> [!WARNING]
+> The `requestHeaders` object needs to be set according to the WordPress REST API nonce. Read more about the [REST API authentification](./README.md#about-authentification).
+
+```javascript
+fetch( '/wp-json/buddypress/v2/members/me', {
+	method: 'PUT',
+	headers: requestHeaders,
+	body: JSON.stringify( { name: 'Admin Istrator' } ),
+} ).then( ( response ) => {
+	return response.json();
+} ).then( ( data ) => {
+	 console.log( data );
+} );
+```
+
+### JSON Response
+
+- An object representing the updated member on success.
+- An object containg the error code, data and message on failure.
+
+## Delete the logged in member
+
+### Arguments
+
+| Name | Description |
+| --- | --- |
+| `force` | Required to be true, as members do not support trashing. <br />JSON data type: _boolean_. <br />Default: `false`. |
+| `reassign` | Reassign the deleted member’s posts and links to this user ID. **Required**. <br />JSON data type: _integer_. |
+
+### Definition
+
+`DELETE /buddypress/v2/members/me`
+
+### Example of use
+
+> [!WARNING]
+> The `requestHeaders` object needs to be set according to the WordPress REST API nonce. Read more about the [REST API authentification](./README.md#about-authentification).
+
+```javascript
+fetch( '/wp-json/buddypress/v2/members/me', {
+	method: 'DELETE',
+	headers: requestHeaders,
+	body: JSON.stringify(
+		{
+			force: true,
+			reassign: 1,
+		}
+	),
+} ).then( ( response ) => {
+	return response.json();
+} ).then( ( data ) => {
+	 console.log( data );
+} );
+```
+
+### JSON Response
+
+- An object informing about the `deleted` status and the `previous` member on success.
+- An object containg the error code, data and message on failure.
+
+[^1]: the eXtended Profiles component needs to be active on the website to make these profile fields available into Members REST requests.
+[^2]: data is only fetched if the eXtended Profiles component is active.
+[^3]: data is only fetched if the Friends component is active.
+[^4]: data is only fetched if the Activity component is active.
+[^5]: This property is only available if the WordPress discussion settings allow avatars.

--- a/docs/developer/execution-contexts/rest-api/reference.md
+++ b/docs/developer/execution-contexts/rest-api/reference.md
@@ -1,0 +1,34 @@
+# Reference
+
+Just like the WordPress REST API, the BP REST API is organized around [REST](https://en.wikipedia.org/wiki/Representational_state_transfer), and is designed to have predictable, resource-oriented URLs and to use HTTP response codes to indicate API errors. The API uses built-in HTTP features, like HTTP authentication and HTTP verbs, which can be understood by off-the-shelf HTTP clients, and supports cross-origin resource sharing to allow you to interact securely with the API from a client-side web application.
+
+The BP REST API uses JSON exclusively as the request and response format, including error responses.
+
+The BP REST API provides public data accessible to any client anonymously, as well as private data only available after [authentication](./README.md#about-authentification). Once authenticated the BP REST API supports most BuddyPress community actions, allowing you to enhance your plugins with more responsive management tools, or build complex single-page applications.
+
+This API reference provides information on the specific endpoints available through the API, their parameters, and their response data format.
+
+## Developer Endpoint Reference
+
+| Resource | Base Route |
+| --- | --- |
+| Components | `/buddypress/v2/components` |
+| Members | `/buddypress/v2/members` |
+| Member Profile Photo | `/buddypress/v2/members/<user_id>/avatar` |
+| Member Profile Cover | `/buddypress/v2/members/<user_id>/cover` |
+| Member Registration | `/buddypress/v2/signup` |
+| Activity | `/buddypress/v2/activity` |
+| Extended Profile Groups | `/buddypress/v2/xprofile/groups` |
+| Extended Profile Field | `/buddypress/v2/xprofile/fields` |
+| Extended Profile Data | `/buddypress/v2/xprofile/<field_id>/data/<user_id>` |
+| Friends | `/buddypress/v2/friends` |
+| User Groups | `/buddypress/v2/groups` |
+| Group Profile Photo | `/buddypress/v2/groups/<group_id>/avatar` |
+| Group Profile Cover | `/buddypress/v2/groups/<group_id>/cover` |
+| Group Membership | `/buddypress/v2/groups/<group_id>/members` |
+| Group Membership Requests | `/buddypress/v2/groups/<group_id>/membership-request` |
+| Group Invites | `/buddypress/v2/groups/<group_id>/invites` |
+| Private Messaging | `/buddypress/v2/messages` |
+| Screen Notifications | `/buddypress/v2/notifications` |
+| User Blogs | `/buddypress/v2/blogs` |
+| Blog Profile Photo | `/buddypress/v2/blogs/<id>/avatar` |

--- a/docs/developer/execution-contexts/rest-api/reference.md
+++ b/docs/developer/execution-contexts/rest-api/reference.md
@@ -12,7 +12,7 @@ This API reference provides information on the specific endpoints available thro
 
 | Resource | Base Route |
 | --- | --- |
-| Components | `/buddypress/v2/components` |
+| [Components](./components.md) | `/buddypress/v2/components` |
 | Members | `/buddypress/v2/members` |
 | Member Profile Photo | `/buddypress/v2/members/<user_id>/avatar` |
 | Member Profile Cover | `/buddypress/v2/members/<user_id>/cover` |

--- a/docs/developer/execution-contexts/rest-api/reference.md
+++ b/docs/developer/execution-contexts/rest-api/reference.md
@@ -1,4 +1,4 @@
-# Reference
+# BP REST API Reference
 
 Just like the WordPress REST API, the BP REST API is organized around [REST](https://en.wikipedia.org/wiki/Representational_state_transfer), and is designed to have predictable, resource-oriented URLs and to use HTTP response codes to indicate API errors. The API uses built-in HTTP features, like HTTP authentication and HTTP verbs, which can be understood by off-the-shelf HTTP clients, and supports cross-origin resource sharing to allow you to interact securely with the API from a client-side web application.
 

--- a/docs/developer/execution-contexts/rest-api/reference.md
+++ b/docs/developer/execution-contexts/rest-api/reference.md
@@ -13,7 +13,7 @@ This API reference provides information on the specific endpoints available thro
 | Resource | Base Route |
 | --- | --- |
 | [Components](./components.md) | `/buddypress/v2/components` |
-| Members | `/buddypress/v2/members` |
+| [Members](./members.md) | `/buddypress/v2/members` |
 | Member Profile Photo | `/buddypress/v2/members/<user_id>/avatar` |
 | Member Profile Cover | `/buddypress/v2/members/<user_id>/cover` |
 | Member Registration | `/buddypress/v2/signup` |

--- a/docs/developer/manifest.json
+++ b/docs/developer/manifest.json
@@ -72,6 +72,30 @@
 		"parent": null
 	},
 	{
+		"title": "BuddyPress REST API",
+		"slug": "bp-rest-api",
+		"markdown_source": "../developer/execution-contexts/rest-api/README.md",
+		"parent": null
+	},
+	{
+		"title": "BP REST API Reference",
+		"slug": "bp-rest-api-reference",
+		"markdown_source": "../developer/execution-contexts/rest-api/reference.md",
+		"parent": "bp-rest-api"
+	},
+	{
+		"title": "Components REST API routes",
+		"slug": "bp-rest-api-components",
+		"markdown_source": "../developer/execution-contexts/rest-api/components.md",
+		"parent": "bp-rest-api-reference"
+	},
+	{
+		"title": "Members REST API routes",
+		"slug": "bp-rest-api-members",
+		"markdown_source": "../developer/execution-contexts/rest-api/members.md",
+		"parent": "bp-rest-api-reference"
+	},
+	{
 		"title": "BuddyPress Functions",
 		"slug": "bp-functions",
 		"markdown_source": "../developer/functions/README.md",

--- a/src/bp-core/classes/class-bp-core-components-rest-controller.php
+++ b/src/bp-core/classes/class-bp-core-components-rest-controller.php
@@ -431,7 +431,7 @@ class BP_Core_Components_REST_Controller extends WP_REST_Controller {
 			'is_active'   => $status['bool'],
 			'title'       => $data['title'],
 			'description' => $data['description'],
-			'features'    => array(),
+			'features'    => null,
 		);
 
 		// Set component's features.
@@ -475,7 +475,7 @@ class BP_Core_Components_REST_Controller extends WP_REST_Controller {
 					);
 					break;
 				default:
-					$features = array();
+					$features = null;
 					break;
 			}
 
@@ -552,10 +552,11 @@ class BP_Core_Components_REST_Controller extends WP_REST_Controller {
 						'type'        => 'string',
 					),
 					'features'    => array(
-						'description' => __( 'Information about active features for the component.', 'buddypress' ),
-						'type'        => 'array',
 						'context'     => array( 'view', 'edit' ),
-						'default'     => array(),
+						'description' => __( 'Information about active features for the component.', 'buddypress' ),
+						'type'        => array( 'object', 'null' ),
+						'properties'  => array(),
+						'default'     => null,
 					),
 				),
 			);

--- a/src/bp-members/classes/class-bp-members-rest-controller.php
+++ b/src/bp-members/classes/class-bp-members-rest-controller.php
@@ -1118,7 +1118,6 @@ class BP_Members_REST_Controller extends WP_REST_Users_Controller {
 								'format'      => 'date-time',
 							),
 						),
-						'format'      => 'date-time',
 						'context'     => array( 'view', 'edit' ),
 						'readonly'    => true,
 					),


### PR DESCRIPTION
Adds the following page to developer doc:
- Introduction about the BP REST API
- Reference: list of REST API Routes
- Components routes
- Members routes

Working on these docs made me suggesting improvements about Components and Members REST controllers, @renatonascalves could you have a look at these?

See https://github.com/buddypress/bp-documentation/issues/298

Ticket: https://buddypress.trac.wordpress.org/ticket/9145

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
