### PR TITLE
Deprecate `bp-api-request` properly

### DIFF
--- a/src/bp-core/bp-core-rest-api.php
+++ b/src/bp-core/bp-core-rest-api.php
@@ -392,33 +392,3 @@ function bp_rest_api_v1_dispatch_error( $result, $server, $request ) {
 	);
 }
 add_filter( 'rest_pre_dispatch', 'bp_rest_api_v1_dispatch_error', 10, 3 );
-
-/**
- * Register the jQuery.ajax wrapper for BP REST API requests.
- *
- * @since 5.0.0
- * @deprecated 10.0.0
- */
-function bp_rest_api_register_request_script() {
-	if ( ! bp_rest_api_is_available() ) {
-		return;
-	}
-
-	wp_register_script(
-		'bp-api-request',
-		sprintf( '%1$sbp-core/js/bp-api-request%2$s.js', buddypress()->plugin_url, bp_core_get_minified_asset_suffix() ),
-		array( 'jquery', 'wp-api-request' ),
-		bp_get_version(),
-		true
-	);
-
-	wp_localize_script(
-		'bp-api-request',
-		'bpApiSettings',
-		array(
-			'unexpectedError'   => __( 'An unexpected error occurred. Please try again.', 'buddypress' ),
-			'deprecatedWarning' => __( 'The bp.apiRequest function is deprecated since BuddyPress 10.0.0, please use wp.apiRequest instead.', 'buddypress' ),
-		)
-	);
-}
-add_action( 'bp_init', 'bp_rest_api_register_request_script' );

--- a/src/bp-core/deprecated/10.0.php
+++ b/src/bp-core/deprecated/10.0.php
@@ -58,3 +58,34 @@ function bp_delete_site_hook() {
 
 	return $wp_hook;
 }
+
+/**
+ * Register the jQuery.ajax wrapper for BP REST API requests.
+ *
+ * @since 5.0.0
+ * @deprecated 10.0.0
+ */
+function bp_rest_api_register_request_script() {
+	_deprecated_function( __FUNCTION__, '10.0.0' );
+
+	if ( ! bp_rest_api_is_available() ) {
+		return;
+	}
+
+	wp_register_script(
+		'bp-api-request',
+		sprintf( '%1$sbp-core/js/bp-api-request%2$s.js', buddypress()->plugin_url, bp_core_get_minified_asset_suffix() ),
+		array( 'jquery', 'wp-api-request' ),
+		bp_get_version(),
+		true
+	);
+
+	wp_localize_script(
+		'bp-api-request',
+		'bpApiSettings',
+		array(
+			'unexpectedError'   => __( 'An unexpected error occurred. Please try again.', 'buddypress' ),
+			'deprecatedWarning' => __( 'The bp.apiRequest function is deprecated since BuddyPress 10.0.0, please use wp.apiRequest instead.', 'buddypress' ),
+		)
+	);
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9145

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
