### PR TITLE
Patch/9207

### DIFF
--- a/blueprint.json
+++ b/blueprint.json
@@ -5,14 +5,21 @@
 		"php": "8.2",
 		"wp": "latest"
 	},
-	"phpExtensionBundles": [
-		"kitchen-sink"
-	],
+	"login": true,
+	"siteOptions": {
+		"blogname": "BuddyPress stable Playground"
+	},
 	"steps": [
 		{
-			"step": "login",
-			"username": "admin",
-			"password": "password"
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "buddypress"
+			}
+		},
+		{
+			"step": "activateTheme",
+			"themeFolderName": "twentytwentyfour"
 		}
 	]
 }

--- a/src/bp-core/bp-core-catchuri.php
+++ b/src/bp-core/bp-core-catchuri.php
@@ -37,7 +37,13 @@ function bp_core_set_ajax_uri_globals() {
 		return;
 	}
 
-	bp_reset_query( bp_get_referer_path(), $GLOBALS['wp_query'] );
+	$referer = bp_get_referer_path();
+	if ( ! $referer && isset( $_REQUEST['canonicalUrl'] ) ) {
+		$canonical_url = esc_url_raw( wp_unslash( $_REQUEST['canonicalUrl'] ) );
+		$referer       = wp_validate_redirect( wp_parse_url( $canonical_url, PHP_URL_PATH ) );
+	}
+
+	bp_reset_query( $referer, $GLOBALS['wp_query'] );
 }
 
 /**

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -1666,7 +1666,8 @@ function bp_core_setup_message() {
 	// Get BuddyPress.
 	$bp = buddypress();
 
-	if ( empty( $bp->template_message ) && isset( $_COOKIE['bp-message'] ) ) {
+	// For a mysterious reason WP Playground seems to add a 'deleted' value to `$_COOKIE['bp-message']` when not set.
+	if ( empty( $bp->template_message ) && isset( $_COOKIE['bp-message'] ) && 'deleted' !== $_COOKIE['bp-message'] ) {
 		$bp->template_message = stripslashes( $_COOKIE['bp-message'] );
 	}
 

--- a/src/bp-templates/bp-legacy/buddypress-functions.php
+++ b/src/bp-templates/bp-legacy/buddypress-functions.php
@@ -324,6 +324,7 @@ class BP_Legacy extends BP_Theme_Compat {
 
 			// Settings.
 			'store_filter_settings' => $store_filter_settings,
+			'canonical_url'         => bp_get_canonical_url(),
 		) );
 		wp_localize_script( $asset['handle'], 'BP_DTheme', $params );
 

--- a/src/bp-templates/bp-legacy/js/buddypress.js
+++ b/src/bp-templates/bp-legacy/js/buddypress.js
@@ -1,6 +1,6 @@
 /* jshint undef: false, unused:false */
 /* @version 1.7.0 */
-/* @version 10.0.0 */
+/* @version 15.0.0 */
 // AJAX Functions
 var jq = jQuery;
 
@@ -175,13 +175,14 @@ jq( function() {
 
 		post_data = jq.extend( {
 			action: 'post_update',
-			'cookie': bp_get_cookies(),
+			cookie: bp_get_cookies(),
 			'_wpnonce_post_update': jq('#_wpnonce_post_update').val(),
-			'content': content,
-			'object': object,
+			content: content,
+			object: object,
 			'item_id': item_id,
-			'since': last_date_recorded,
-			'_bp_as_nonce': jq('#_bp_as_nonce').val() || ''
+			since: last_date_recorded,
+			'_bp_as_nonce': jq('#_bp_as_nonce').val() || '',
+			canonicalUrl: BP_DTheme.canonical_url
 		}, inputs );
 
 		jq.post( ajaxurl, post_data, function( response ) {
@@ -315,9 +316,10 @@ jq( function() {
 
 			jq.post( ajaxurl, {
 				action: 'activity_mark_' + type,
-				'cookie': bp_get_cookies(),
-				'id': parent_id,
-				nonce: nonce
+				cookie: bp_get_cookies(),
+				id: parent_id,
+				nonce: nonce,
+				canonicalUrl: BP_DTheme.canonical_url
 			},
 			function(response) {
 				target.removeClass('loading');
@@ -376,9 +378,10 @@ jq( function() {
 
 			jq.post( ajaxurl, {
 				action: 'delete_activity',
-				'cookie': bp_get_cookies(),
-				'id': id,
-				'_wpnonce': nonce
+				cookie: bp_get_cookies(),
+				id: id,
+				'_wpnonce': nonce,
+				canonicalUrl: BP_DTheme.canonical_url
 			},
 			function(response) {
 
@@ -407,9 +410,10 @@ jq( function() {
 
 			jq.post( ajaxurl, {
 				action: 'bp_spam_activity',
-				'cookie': encodeURIComponent( document.cookie ),
-				'id': li.attr( 'id' ).substr( 9, li.attr( 'id' ).length ),
-				'_wpnonce': target.attr( 'href' ).split( '_wpnonce=' )[1]
+				cookie: encodeURIComponent( document.cookie ),
+				id: li.attr( 'id' ).substr( 9, li.attr( 'id' ).length ),
+				'_wpnonce': target.attr( 'href' ).split( '_wpnonce=' )[1],
+				canonicalUrl: BP_DTheme.canonical_url
 			},
 
 			function(response) {
@@ -449,10 +453,11 @@ jq( function() {
 
 			load_more_args = {
 				action: 'activity_get_older_updates',
-				'cookie': bp_get_cookies(),
-				'page': oldest_page,
+				cookie: bp_get_cookies(),
+				page: oldest_page,
 				'offset_lower': offsetLower,
-				'exclude_just_posted': just_posted.join(',')
+				'exclude_just_posted': just_posted.join(','),
+				canonicalUrl: BP_DTheme.canonical_url
 			};
 
 			load_more_search = bp_get_querystring('s');
@@ -518,7 +523,8 @@ jq( function() {
 
 		jq.post( ajaxurl, {
 			action: 'get_single_activity_content',
-			'activity_id': a_id
+			'activity_id': a_id,
+			canonicalUrl: BP_DTheme.canonical_url
 		},
 		function(response) {
 			jq(a_inner).slideUp(300).html(response).slideDown(300);
@@ -624,11 +630,12 @@ jq( function() {
 
 			ajaxdata = {
 				action: 'new_activity_comment',
-				'cookie': bp_get_cookies(),
+				cookie: bp_get_cookies(),
 				'_wpnonce_new_activity_comment': jq('#_wpnonce_new_activity_comment' + '_' + form_id[2] ).val(),
 				'comment_id': comment_id,
 				'form_id': form_id[2],
-				'content': content.val()
+				content: content.val(),
+				canonicalUrl: BP_DTheme.canonical_url
 			};
 
 			// Akismet
@@ -708,9 +715,10 @@ jq( function() {
 
 			jq.post( ajaxurl, {
 				action: 'delete_activity_comment',
-				'cookie': bp_get_cookies(),
+				cookie: bp_get_cookies(),
 				'_wpnonce': nonce,
-				'id': comment_id
+				id: comment_id,
+				canonicalUrl: BP_DTheme.canonical_url
 			},
 			function(response) {
 				/* Check for errors and append if found. */
@@ -766,9 +774,10 @@ jq( function() {
 
 			jq.post( ajaxurl, {
 				action: 'bp_spam_activity_comment',
-				'cookie': encodeURIComponent( document.cookie ),
+				cookie: encodeURIComponent( document.cookie ),
 				'_wpnonce': link_href.split( '_wpnonce=' )[1],
-				'id': link_href.split( 'cid=' )[1].split( '&' )[0]
+				id: link_href.split( 'cid=' )[1].split( '&' )[0],
+				canonicalUrl: BP_DTheme.canonical_url
 			},
 
 			function ( response ) {
@@ -1090,10 +1099,11 @@ jq( function() {
 		jq.post( ajaxurl, {
 			action: 'groups_invite_user',
 			'friend_action': friend_action,
-			'cookie': bp_get_cookies(),
+			cookie: bp_get_cookies(),
 			'_wpnonce': jq('#_wpnonce_invite_uninvite_user').val(),
 			'friend_id': friend_id,
-			'group_id': jq('#group_id').val()
+			'group_id': jq('#group_id').val(),
+			canonicalUrl: BP_DTheme.canonical_url
 		},
 		function(response)
 		{
@@ -1137,10 +1147,11 @@ jq( function() {
 		jq.post( ajaxurl, {
 			action: 'groups_invite_user',
 			'friend_action': 'uninvite',
-			'cookie': bp_get_cookies(),
+			cookie: bp_get_cookies(),
 			'_wpnonce': jq('#_wpnonce_invite_uninvite_user').val(),
 			'friend_id': friend_id,
-			'group_id': jq('#group_id').val()
+			'group_id': jq('#group_id').val(),
+			canonicalUrl: BP_DTheme.canonical_url
 		},
 		function()
 		{
@@ -1224,9 +1235,10 @@ jq( function() {
 
 		jq.post( ajaxurl, {
 			action: action,
-			'cookie': bp_get_cookies(),
-			'id': id,
-			'_wpnonce': nonce
+			cookie: bp_get_cookies(),
+			id: id,
+			'_wpnonce': nonce,
+			canonicalUrl: BP_DTheme.canonical_url
 		},
 		function(response) {
 			button.removeClass('loading');
@@ -1266,9 +1278,10 @@ jq( function() {
 
 		jq.post( ajaxurl, {
 			action: 'addremove_friend',
-			'cookie': bp_get_cookies(),
-			'fid': fid,
-			'_wpnonce': nonce
+			cookie: bp_get_cookies(),
+			fid: fid,
+			'_wpnonce': nonce,
+			canonicalUrl: BP_DTheme.canonical_url
 		},
 		function(response)
 		{
@@ -1328,9 +1341,10 @@ jq( function() {
 
 		jq.post( ajaxurl, {
 			action: 'joinleave_group',
-			'cookie': bp_get_cookies(),
-			'gid': gid,
-			'_wpnonce': nonce
+			cookie: bp_get_cookies(),
+			gid: gid,
+			'_wpnonce': nonce,
+			canonicalUrl: BP_DTheme.canonical_url
 		},
 		function(response)
 		{
@@ -1447,13 +1461,14 @@ jq( function() {
 
 			jq.post( ajaxurl, {
 				action: 'messages_send_reply',
-				'cookie': bp_get_cookies(),
+				cookie: bp_get_cookies(),
 				'_wpnonce': jq('#send_message_nonce').val(),
 
-				'content': jq('#message_content').val(),
+				content: jq('#message_content').val(),
 				'send_to': jq('#send_to').val(),
-				'subject': jq('#subject').val(),
-				'thread_id': jq('#thread_id').val()
+				subject: jq('#subject').val(),
+				'thread_id': jq('#thread_id').val(),
+				canonicalUrl: BP_DTheme.canonical_url
 			},
 			function(response)
 			{
@@ -1537,8 +1552,9 @@ jq( function() {
 			action: 'messages_star',
 			'message_id': link.data('message-id'),
 			'star_status': link.data('star-status'),
-			'nonce': link.data('star-nonce'),
-			'bulk': link.data('star-bulk')
+			nonce: link.data('star-nonce'),
+			bulk: link.data('star-bulk'),
+			canonicalUrl: BP_DTheme.canonical_url
 		},
 		function(response) {
 			if ( 1 === parseInt( response, 10 ) ) {
@@ -1659,7 +1675,8 @@ jq( function() {
 		jq.post( ajaxurl, {
 			action: 'messages_close_notice',
 			'notice_id': jq('.notice').attr('rel').substr( 2, jq('.notice').attr('rel').length ),
-			nonce: jq( '#close-notice-nonce' ).val()
+			nonce: jq( '#close-notice-nonce' ).val(),
+			canonicalUrl: BP_DTheme.canonical_url
 		},
 		function(response) {
 			jq('#close-notice').removeClass('loading');
@@ -1917,14 +1934,15 @@ function bp_filter_request( object, filter, scope, target, search_terms, page, e
 
 	bp_ajax_request = jq.post( ajaxurl, {
 		action: object + '_filter',
-		'cookie': cookie,
-		'object': object,
-		'filter': filter,
-		'search_terms': search_terms,
-		'scope': scope,
-		'page': page,
-		'extras': extras,
-		'template': template
+		cookie: cookie,
+		object: object,
+		filter: filter,
+		search_terms: search_terms,
+		scope: scope,
+		page: page,
+		extras: extras,
+		template: template,
+		canonicalUrl: BP_DTheme.canonical_url
 	},
 	function(response)
 	{
@@ -1981,10 +1999,11 @@ function bp_activity_request(scope, filter) {
 
 	bp_ajax_request = jq.post( ajaxurl, {
 		action: 'activity_widget_filter',
-		'cookie': cookie,
+		cookie: cookie,
 		'_wpnonce_activity_filter': jq('#_wpnonce_activity_filter').val(),
-		'scope': scope,
-		'filter': filter
+		scope: scope,
+		filter: filter,
+		canonicalUrl: BP_DTheme.canonical_url
 	},
 	function(response)
 	{

--- a/src/bp-templates/bp-nouveau/buddypress-functions.php
+++ b/src/bp-templates/bp-nouveau/buddypress-functions.php
@@ -125,7 +125,7 @@ class BP_Nouveau extends BP_Theme_Compat {
 				0
 			);
 
-			// When BP Classic is activated, regular themes need this filter. 
+			// When BP Classic is activated, regular themes need this filter.
 			if ( bp_is_classic() ) {
 				// Set the BP Uri for the Ajax customizer preview.
 				add_filter( 'bp_uri', array( $this, 'customizer_set_uri' ), 10, 1 );
@@ -502,6 +502,7 @@ class BP_Nouveau extends BP_Theme_Compat {
 	public function localize_scripts() {
 		$params = array(
 			'ajaxurl'           => bp_core_ajax_url(),
+			'canonical_url'     => bp_get_canonical_url(),
 			'confirm'           => __( 'Are you sure?', 'buddypress' ),
 
 			/* translators: %s: number of activity comments */

--- a/src/bp-templates/bp-nouveau/js/buddypress-activity-post-form.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-activity-post-form.js
@@ -1,6 +1,6 @@
 /* global BP_Nouveau, _, Backbone */
 /* @since 3.0.0 */
-/* @version 8.0.0 */
+/* @version 15.0.0 */
 window.wp = window.wp || {};
 window.bp = window.bp || {};
 

--- a/src/bp-templates/bp-nouveau/js/buddypress-activity-post-form.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-activity-post-form.js
@@ -727,6 +727,7 @@ window.bp = window.bp || {};
 			this.model.set( meta, { silent: true } );
 
 			var data = {
+				canonicalUrl: BP_Nouveau.canonical_url,
 				'_wpnonce_post_update': BP_Nouveau.activity.params.post_nonce
 			};
 

--- a/src/bp-templates/bp-nouveau/js/buddypress-group-invites.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-group-invites.js
@@ -1,6 +1,6 @@
 /* global wp, BP_Nouveau, _, Backbone */
 /* @since 3.0.0 */
-/* @version 8.0.0 */
+/* @version 15.0.0 */
 window.wp = window.wp || {};
 window.bp = window.bp || {};
 
@@ -243,7 +243,12 @@ window.bp = window.bp || {};
 		model: bp.Models.User,
 
 		initialize : function() {
-			this.options = { page: 1, total_page: 0, group_id: BP_Nouveau.group_invites.group_id };
+			this.options = {
+				page: 1,
+				total_page: 0,
+				group_id: BP_Nouveau.group_invites.group_id,
+				canonicalUrl: BP_Nouveau.canonical_url
+			};
 		},
 
 		sync: function( method, model, options ) {

--- a/src/bp-templates/bp-nouveau/js/buddypress-messages.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-messages.js
@@ -1,7 +1,7 @@
 /* global wp, BP_Nouveau, _, Backbone, tinymce, tinyMCE */
 /* jshint devel: true */
 /* @since 3.0.0 */
-/* @version 11.2.0 */
+/* @version 15.0.0 */
 window.wp = window.wp || {};
 window.bp = window.bp || {};
 
@@ -259,7 +259,10 @@ window.bp = window.bp || {};
 			var sent = bp.ajax.post(
 				'messages_send_message',
 				_.extend(
-					{ nonce: BP_Nouveau.messages.nonces.send },
+					{
+						nonce: BP_Nouveau.messages.nonces.send,
+						canonicalUrl: BP_Nouveau.canonical_url
+					},
 					this.attributes
 				)
 			);
@@ -291,7 +294,8 @@ window.bp = window.bp || {};
 				_.pick( this.attributes, ['id', 'message_id'] ),
 				{
 					action : 'messages_thread_read',
-					nonce  : BP_Nouveau.nonces.messages
+					nonce  : BP_Nouveau.nonces.messages,
+					canonicalUrl: BP_Nouveau.canonical_url
 				}
 			);
 
@@ -329,7 +333,8 @@ window.bp = window.bp || {};
 
 			if ( 'read' === method ) {
 				options.data = _.extend( options.data, {
-					action: 'messages_get_user_message_threads'
+					action: 'messages_get_user_message_threads',
+					canonicalUrl: BP_Nouveau.canonical_url
 				} );
 
 				return bp.ajax.send( options );
@@ -390,8 +395,9 @@ window.bp = window.bp || {};
 
 			options.data = _.extend( options.data, {
 				action: 'messages_' + action,
-				nonce : BP_Nouveau.nonces.messages,
-				id    : ids
+				nonce: BP_Nouveau.nonces.messages,
+				id: ids,
+				canonicalUrl: BP_Nouveau.canonical_url
 			} );
 
 			return bp.ajax.send( options );
@@ -412,7 +418,8 @@ window.bp = window.bp || {};
 
 			if ( 'read' === method ) {
 				options.data = _.extend( options.data, {
-					action: 'messages_get_thread_messages'
+					action: 'messages_get_thread_messages',
+					canonicalUrl: BP_Nouveau.canonical_url
 				} );
 
 				return bp.ajax.send( options );
@@ -421,7 +428,8 @@ window.bp = window.bp || {};
 			if ( 'create' === method ) {
 				options.data = _.extend( options.data, {
 					action : 'messages_send_reply',
-					nonce  : BP_Nouveau.messages.nonces.send
+					nonce  : BP_Nouveau.messages.nonces.send,
+					canonicalUrl: BP_Nouveau.canonical_url
 				}, model || {} );
 
 				return bp.ajax.send( options );

--- a/src/bp-templates/bp-nouveau/js/buddypress-nouveau.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-nouveau.js
@@ -195,7 +195,7 @@ window.bp = window.bp || {};
 			}
 
 			// Extend posted data with stored data and object nonce.
-			var postData = $.extend( {}, bp.Nouveau.getStorage( 'bp-' + object ), { nonce: BP_Nouveau.nonces[object] }, post_data );
+			var postData = $.extend( {}, bp.Nouveau.getStorage( 'bp-' + object ), { nonce: BP_Nouveau.nonces[object], canonicalUrl: BP_Nouveau.canonical_url }, post_data );
 
 			if ( undefined !== BP_Nouveau.customizer_settings ) {
 				postData.customized = BP_Nouveau.customizer_settings;

--- a/src/bp-templates/bp-nouveau/js/buddypress-nouveau.js
+++ b/src/bp-templates/bp-nouveau/js/buddypress-nouveau.js
@@ -2,7 +2,7 @@
 /* jshint devel: true */
 /* jshint browser: true */
 /* @since 3.0.0 */
-/* @version 10.0.0 */
+/* @version 15.0.0 */
 window.wp = window.wp || {};
 window.bp = window.bp || {};
 

--- a/src/bp-xprofile/bp-xprofile-functions.php
+++ b/src/bp-xprofile/bp-xprofile-functions.php
@@ -1477,6 +1477,7 @@ function bp_xprofile_get_wp_user_keys() {
  * Returns the signup field IDs.
  *
  * @since 8.0.0
+ * @since 15.0.0 The SQL request was adapted to support WP Playground's SQLite DB.
  *
  * @global wpdb $wpdb WordPress database object.
  *
@@ -1489,12 +1490,22 @@ function bp_xprofile_get_signup_field_ids() {
 		global $wpdb;
 		$bp = buddypress();
 
-		$signup_field_ids = $wpdb->get_col( "SELECT object_id FROM {$bp->profile->table_name_meta} WHERE object_type = 'field' AND meta_key = 'signup_position' ORDER BY CONVERT(meta_value, SIGNED) ASC" );
+		// WP Playground's SQLite DB does not support CONVERT AS SIGNED.
+		$results          = $wpdb->get_results( "SELECT object_id, meta_value FROM {$bp->profile->table_name_meta} WHERE object_type = 'field' AND meta_key = 'signup_position'" );
+		$signup_field_ids = array();
+
+		foreach ( $results as $result ) {
+			$index                      = (int) $result->meta_value;
+			$signup_field_ids[ $index ] = (int) $result->object_id;
+		}
+
+		// Sort.
+		ksort( $signup_field_ids );
 
 		wp_cache_set( 'signup_fields', $signup_field_ids, 'bp_xprofile' );
 	}
 
-	return array_map( 'intval', $signup_field_ids );
+	return array_values( $signup_field_ids );
 }
 
 /**

--- a/src/bp-xprofile/classes/class-bp-xprofile-group.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-group.php
@@ -352,10 +352,12 @@ class BP_XProfile_Group {
 			}
 		}
 
+		$signup_fields_order = bp_xprofile_get_signup_field_ids();
+
 		// Pull field objects from the cache.
 		$fields = array();
 		foreach ( $field_ids as $field_id ) {
-			if ( true === $r['signup_fields_only'] && ! in_array( $field_id, bp_xprofile_get_signup_field_ids(), true ) ) {
+			if ( true === $r['signup_fields_only'] && ! in_array( $field_id, $signup_fields_order, true ) ) {
 				continue;
 			}
 

--- a/src/bp-xprofile/classes/class-bp-xprofile-group.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-group.php
@@ -352,12 +352,10 @@ class BP_XProfile_Group {
 			}
 		}
 
-		$signup_fields_order = bp_xprofile_get_signup_field_ids();
-
 		// Pull field objects from the cache.
 		$fields = array();
 		foreach ( $field_ids as $field_id ) {
-			if ( true === $r['signup_fields_only'] && ! in_array( $field_id, $signup_fields_order, true ) ) {
+			if ( true === $r['signup_fields_only'] && ! in_array( $field_id, bp_xprofile_get_signup_field_ids(), true ) ) {
 				continue;
 			}
 

--- a/tests/blueprints/14-0-0-RC1.json
+++ b/tests/blueprints/14-0-0-RC1.json
@@ -5,21 +5,21 @@
 		"php": "8.2",
 		"wp": "latest"
 	},
-	"phpExtensionBundles": [
-		"kitchen-sink"
-	],
+	"login": true,
+	"siteOptions": {
+		"blogname": "BuddyPress 14.0.0-RC1 Playground"
+	},
 	"steps": [
 		{
-			"step": "login",
-			"username": "admin",
-			"password": "password"
-		},
-		{
 			"step": "installPlugin",
-			"pluginZipFile": {
+			"pluginData": {
 				"resource": "url",
 				"url": "https://downloads.wordpress.org/plugin/buddypress.14.0.0-RC1.zip"
 			}
+		},
+		{
+			"step": "activateTheme",
+			"themeFolderName": "twentytwentyfour"
 		}
 	]
 }

--- a/tests/blueprints/14-0-0-beta1.json
+++ b/tests/blueprints/14-0-0-beta1.json
@@ -1,24 +1,25 @@
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "\/wp-admin\/admin.php?page=bp-components",
 	"preferredVersions": {
 		"php": "8.2",
 		"wp": "latest"
 	},
-	"phpExtensionBundles": [
-		"kitchen-sink"
-	],
+	"login": true,
+	"siteOptions": {
+		"blogname": "BuddyPress 14.0.0-beta1 Playground"
+	},
 	"steps": [
 		{
-			"step": "login",
-			"username": "admin",
-			"password": "password"
-		},
-		{
 			"step": "installPlugin",
-			"pluginZipFile": {
+			"pluginData": {
 				"resource": "url",
 				"url": "https://downloads.wordpress.org/plugin/buddypress.14.0.0-beta1.zip"
 			}
+		},
+		{
+			"step": "activateTheme",
+			"themeFolderName": "twentytwentyfour"
 		}
 	]
 }

--- a/tests/blueprints/14-0-0-beta2.json
+++ b/tests/blueprints/14-0-0-beta2.json
@@ -1,24 +1,25 @@
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "\/wp-admin\/admin.php?page=bp-components",
 	"preferredVersions": {
 		"php": "8.2",
 		"wp": "latest"
 	},
-	"phpExtensionBundles": [
-		"kitchen-sink"
-	],
+	"login": true,
+	"siteOptions": {
+		"blogname": "BuddyPress 14.0.0-beta2 Playground"
+	},
 	"steps": [
 		{
-			"step": "login",
-			"username": "admin",
-			"password": "password"
-		},
-		{
 			"step": "installPlugin",
-			"pluginZipFile": {
+			"pluginData": {
 				"resource": "url",
 				"url": "https://downloads.wordpress.org/plugin/buddypress.14.0.0-beta2.zip"
 			}
+		},
+		{
+			"step": "activateTheme",
+			"themeFolderName": "twentytwentyfour"
 		}
 	]
 }

--- a/tests/phpunit/testcases/xprofile/functions.php
+++ b/tests/phpunit/testcases/xprofile/functions.php
@@ -1420,4 +1420,47 @@ Bar!';
 		$this->assertEquals( 'barfoo', $updated_u->first_name );
 		$this->assertEquals( '', $updated_u->last_name );
 	}
+
+	/**
+	 * @ticket BP9207
+	 */
+	public function test_bp_xprofile_get_signup_field_ids() {
+		add_filter( 'bp_get_signup_allowed', '__return_true' );
+		$signup_test_group = self::factory()->xprofile_group->create();
+
+		$third = self::factory()->xprofile_field->create(
+			array(
+				'field_group_id' => $signup_test_group,
+				'type'           => 'textbox',
+				'name'           => 'thirdPosition'
+			)
+		);
+
+		$first = self::factory()->xprofile_field->create(
+			array(
+				'field_group_id' => $signup_test_group,
+				'type'           => 'textbox',
+				'name'           => 'firstPosition'
+			)
+		);
+
+		$tenth = self::factory()->xprofile_field->create(
+			array(
+				'field_group_id' => $signup_test_group,
+				'type'           => 'textbox',
+				'name'           => 'tenthPosition'
+			)
+		);
+
+		// Set order.
+		bp_xprofile_update_field_meta( $first, 'signup_position', 1 );
+		bp_xprofile_update_field_meta( 1, 'signup_position', 2 );
+		bp_xprofile_update_field_meta( $third, 'signup_position', 3 );
+		bp_xprofile_update_field_meta( $tenth, 'signup_position', 10 );
+
+		$this->assertSame( bp_xprofile_get_signup_field_ids(), array( $first, 1, $third, $tenth ) );
+
+		xprofile_delete_field_group( $signup_test_group );
+		remove_filter( 'bp_get_signup_allowed', '__return_true' );
+	}
 }


### PR DESCRIPTION
To fix WP Playground issues, I suggest to:

- Send the current canonical URL into Ajax request vars. `wp_get_referer()` is not set which explains why BP URI globals are not set into Ajax context by WP Playground.
- Ignore `$_COOKIE['bp-message']` if its value is set to `deleted`. It looks like the cookie is not deleted but its value is set to `deleted` once it's removed by BuddyPress.
- About the ` SIGNED` conversion or casting SQL issue, it looks like it's a SQLlite issue that will be hard to cope with: see https://wordpress.org/support/topic/wordpress-meta-query-not-working/ I used a workaround to get rid of it for now.

> [!IMPORTANT]
> I'll need to run `grunt commit` before SVN committing this PR.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9207

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
