### PR TITLE
Avoid WP's notice about using translatable strings too early

### DIFF
--- a/docs/developer/components/build-component.md
+++ b/docs/developer/components/build-component.md
@@ -47,8 +47,8 @@ class BP_Custom_Component extends BP_Component {
 			// Your component ID.
 			'custom',
 
-			// Your component Name.
-			__( 'Custom component', 'custom-text-domain' ),
+			// The raw name for your component. Do not use translatable strings here.
+			'Custom component',
 
 			/*
 			 * The path from where additional files should be included.

--- a/src/bp-activity/classes/class-bp-activity-component.php
+++ b/src/bp-activity/classes/class-bp-activity-component.php
@@ -28,7 +28,7 @@ class BP_Activity_Component extends BP_Component {
 	public function __construct() {
 		parent::start(
 			'activity',
-			__( 'Activity Streams', 'buddypress' ),
+			'Activity Streams',
 			buddypress()->plugin_dir,
 			array(
 				'adminbar_myaccount_order' => 10,

--- a/src/bp-blogs/classes/class-bp-blogs-component.php
+++ b/src/bp-blogs/classes/class-bp-blogs-component.php
@@ -30,7 +30,7 @@ class BP_Blogs_Component extends BP_Component {
 	public function __construct() {
 		parent::start(
 			'blogs',
-			__( 'Site Directory', 'buddypress' ),
+			'Site Directory',
 			buddypress()->plugin_dir,
 			array(
 				'adminbar_myaccount_order' => 30,

--- a/src/bp-core/classes/class-bp-component.php
+++ b/src/bp-core/classes/class-bp-component.php
@@ -29,7 +29,12 @@ class BP_Component {
 	/** Variables *************************************************************/
 
 	/**
-	 * Translatable name for the component.
+	 * Raw name for the component.
+	 *
+	 * Do not use translatable strings here as this part is set before WP's `init` hook.
+	 *
+	 * @since 1.5.0
+	 * @since 14.3.0 Changed the variable inline documentation summary and added a description.
 	 *
 	 * @internal
 	 *
@@ -244,9 +249,10 @@ class BP_Component {
 	 * @since 1.9.0 Added $params as a parameter.
 	 * @since 2.3.0 Added $params['features'] as a configurable value.
 	 * @since 2.4.0 Added $params['search_query_arg'] as a configurable value.
+	 * @since 14.3.0 Changed the `$name` parameter's description.
 	 *
 	 * @param string $id   Unique ID. Letters, numbers, and underscores only.
-	 * @param string $name Unique name. This should be a translatable name, e.g. __( 'Groups', 'buddypress' ).
+	 * @param string $name Unique raw name for the component (do not use translatable strings).
 	 * @param string $path The file path for the component's files. Used by {@link BP_Component::includes()}.
 	 * @param array  $params {
 	 *     Additional parameters used by the component.

--- a/src/bp-core/classes/class-bp-core.php
+++ b/src/bp-core/classes/class-bp-core.php
@@ -28,7 +28,7 @@ class BP_Core extends BP_Component {
 	public function __construct() {
 		parent::start(
 			'core',
-			__( 'BuddyPress Core', 'buddypress' ),
+			'BuddyPress Core',
 			buddypress()->plugin_dir
 		);
 

--- a/src/bp-core/classes/class-bp-theme-compat.php
+++ b/src/bp-core/classes/class-bp-theme-compat.php
@@ -18,6 +18,7 @@ defined( 'ABSPATH' ) || exit;
  * extending this class.
  *
  * @since 1.7.0
+ * @since 14.3.0 Changed the `$name` property's description.
  *
  * @todo We should probably do something similar to BP_Component::start().
  * @todo If this is only intended to be extended, it should be abstract.
@@ -25,7 +26,7 @@ defined( 'ABSPATH' ) || exit;
  * @param array $properties {
  *     An array of properties describing the theme compat package.
  *     @type string $id      ID of the package. Must be unique.
- *     @type string $name    Name of the theme. This should match the name given
+ *     @type string $name    Raw name for the theme. This should match the name given
  *                           in style.css.
  *     @type string $version Theme version. Used for busting script and style
  *                           browser caches.

--- a/src/bp-friends/classes/class-bp-friends-component.php
+++ b/src/bp-friends/classes/class-bp-friends-component.php
@@ -28,7 +28,7 @@ class BP_Friends_Component extends BP_Component {
 	public function __construct() {
 		parent::start(
 			'friends',
-			_x( 'Friend Connections', 'Friends screen page <title>', 'buddypress' ),
+			'Friend Connections',
 			buddypress()->plugin_dir,
 			array(
 				'adminbar_myaccount_order' => 60,

--- a/src/bp-groups/classes/class-bp-groups-component.php
+++ b/src/bp-groups/classes/class-bp-groups-component.php
@@ -117,7 +117,7 @@ class BP_Groups_Component extends BP_Component {
 
 		parent::start(
 			'groups',
-			_x( 'User Groups', 'Group screen page <title>', 'buddypress' ),
+			'User Groups',
 			buddypress()->plugin_dir,
 			array(
 				'adminbar_myaccount_order' => 70,

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -75,7 +75,7 @@ class BP_Members_Component extends BP_Component {
 	public function __construct() {
 		parent::start(
 			'members',
-			__( 'Members', 'buddypress' ),
+			'Members',
 			buddypress()->plugin_dir,
 			array(
 				'adminbar_myaccount_order' => 20,

--- a/src/bp-members/classes/class-bp-members-invitations-component.php
+++ b/src/bp-members/classes/class-bp-members-invitations-component.php
@@ -30,7 +30,7 @@ class BP_Members_Invitations_Component extends BP_Component {
 	public function __construct() {
 		parent::start(
 			'members_invitations',
-			__( 'Members Invitations', 'buddypress' ),
+			'Members Invitations',
 			'',
 			array()
 		);

--- a/src/bp-messages/classes/class-bp-messages-component.php
+++ b/src/bp-messages/classes/class-bp-messages-component.php
@@ -37,7 +37,7 @@ class BP_Messages_Component extends BP_Component {
 	public function __construct() {
 		parent::start(
 			'messages',
-			__( 'Private Messages', 'buddypress' ),
+			'Private Messages',
 			buddypress()->plugin_dir,
 			array(
 				'adminbar_myaccount_order' => 50,

--- a/src/bp-notifications/classes/class-bp-notifications-component.php
+++ b/src/bp-notifications/classes/class-bp-notifications-component.php
@@ -28,7 +28,7 @@ class BP_Notifications_Component extends BP_Component {
 	public function __construct() {
 		parent::start(
 			'notifications',
-			_x( 'Notifications', 'Page <title>', 'buddypress' ),
+			'Notifications',
 			buddypress()->plugin_dir,
 			array(
 				'adminbar_myaccount_order' => 30,

--- a/src/bp-settings/classes/class-bp-settings-component.php
+++ b/src/bp-settings/classes/class-bp-settings-component.php
@@ -26,7 +26,7 @@ class BP_Settings_Component extends BP_Component {
 	public function __construct() {
 		parent::start(
 			'settings',
-			__( 'Settings', 'buddypress' ),
+			'Settings',
 			buddypress()->plugin_dir,
 			array(
 				'adminbar_myaccount_order' => 100,

--- a/src/bp-templates/bp-legacy/buddypress-functions.php
+++ b/src/bp-templates/bp-legacy/buddypress-functions.php
@@ -6,7 +6,7 @@
  *
  * @package BuddyPress
  * @subpackage BP_Theme_Compat
- * @version 14.0.0
+ * @version 14.3.0
  */
 
 // Exit if accessed directly.
@@ -58,7 +58,7 @@ class BP_Legacy extends BP_Theme_Compat {
 	protected function setup_globals() {
 		$bp            = buddypress();
 		$this->id      = 'legacy';
-		$this->name    = __( 'BuddyPress Legacy', 'buddypress' );
+		$this->name    = 'BP Legacy';
 		$this->version = bp_get_version();
 		$this->dir     = trailingslashit( $bp->themes_dir . '/bp-legacy' );
 		$this->url     = trailingslashit( $bp->themes_url . '/bp-legacy' );

--- a/src/bp-xprofile/classes/class-bp-xprofile-component.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-component.php
@@ -47,7 +47,7 @@ class BP_XProfile_Component extends BP_Component {
 	public function __construct() {
 		parent::start(
 			'xprofile',
-			_x( 'Extended Profiles', 'Component page <title>', 'buddypress' ),
+			'Extended Profiles',
 			buddypress()->plugin_dir,
 			array(
 				'adminbar_myaccount_order' => 20,

--- a/src/class-buddypress.php
+++ b/src/class-buddypress.php
@@ -896,7 +896,7 @@ class BuddyPress {
 		bp_register_theme_package(
 			array(
 				'id'      => 'legacy',
-				'name'    => __( 'BuddyPress Legacy', 'buddypress' ),
+				'name'    => 'BP Legacy',
 				'version' => bp_get_version(),
 				'dir'     => trailingslashit( $this->themes_dir . '/bp-legacy' ),
 				'url'     => trailingslashit( $this->themes_url . '/bp-legacy' ),
@@ -906,7 +906,7 @@ class BuddyPress {
 		bp_register_theme_package(
 			array(
 				'id'      => 'nouveau',
-				'name'    => __( 'BuddyPress Nouveau', 'buddypress' ),
+				'name'    => 'BP Nouveau',
 				'version' => bp_get_version(),
 				'dir'     => trailingslashit( $this->themes_dir . '/bp-nouveau' ),
 				'url'     => trailingslashit( $this->themes_url . '/bp-nouveau' ),


### PR DESCRIPTION
Use "raw" name instead of "translatable" name for the `BP_Component`'s & `BP_Theme_Compat` name properties.  

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9247

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
