### PR TITLE
Signup: deprecate `bp_signup_allowed` function

### DIFF
--- a/src/bp-core/deprecated/1.1.php
+++ b/src/bp-core/deprecated/1.1.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Deprecated Functions
+ *
+ * @package BuddyPress
+ * @deprecated 1.1.0
+ */
+
+/**
+ * Output whether signup is allowed.
+ *
+ * @since 1.1.0
+ * @deprecated 15.0.0
+ */
+function bp_signup_allowed() {
+	// phpcs:ignore WordPress.Security.EscapeOutput
+	_deprecated_function( __FUNCTION__, '15.0.0', 'bp_get_signup_allowed()' );
+
+	echo bp_get_signup_allowed();
+}

--- a/src/bp-core/deprecated/1.2.php
+++ b/src/bp-core/deprecated/1.2.php
@@ -3,7 +3,7 @@
  * Deprecated Functions
  *
  * @package BuddyPress
- * @subpackage Core
+ * @deprecated 1.2.0
  */
 
 /**

--- a/src/bp-core/deprecated/1.5.php
+++ b/src/bp-core/deprecated/1.5.php
@@ -3,8 +3,7 @@
  * Deprecated Functions
  *
  * @package BuddyPress
- * @subpackage Core
- * @deprecated Since 1.5.0
+ * @deprecated 1.5.0
  */
 
 // Exit if accessed directly.

--- a/src/bp-core/deprecated/1.6.php
+++ b/src/bp-core/deprecated/1.6.php
@@ -3,7 +3,6 @@
  * Deprecated Functions
  *
  * @package BuddyPress
- * @subpackage Core
  * @deprecated 1.6.0
  */
 

--- a/src/bp-core/deprecated/1.7.php
+++ b/src/bp-core/deprecated/1.7.php
@@ -3,8 +3,7 @@
  * Deprecated Functions
  *
  * @package BuddyPress
- * @subpackage Core
- * @deprecated Since 1.7.0
+ * @deprecated 1.7.0
  */
 
 // Exit if accessed directly.

--- a/src/bp-core/deprecated/1.9.php
+++ b/src/bp-core/deprecated/1.9.php
@@ -6,7 +6,7 @@
  * Use bp-notifications instead.
  *
  * @package BuddyPress
- * @subpackage MembersNotifications
+ * @deprecated 1.9.0
  */
 
 // Exit if accessed directly.

--- a/src/bp-core/deprecated/2.0.php
+++ b/src/bp-core/deprecated/2.0.php
@@ -3,7 +3,6 @@
  * Deprecated Functions
  *
  * @package BuddyPress
- * @subpackage Core
  * @deprecated 2.0.0
  */
 

--- a/src/bp-core/deprecated/2.1.php
+++ b/src/bp-core/deprecated/2.1.php
@@ -3,7 +3,6 @@
  * Deprecated functions
  *
  * @package BuddyPress
- * @subpackage Core
  * @deprecated 2.1.0
  */
 

--- a/src/bp-core/deprecated/2.2.php
+++ b/src/bp-core/deprecated/2.2.php
@@ -3,7 +3,6 @@
  * Deprecated functions
  *
  * @package BuddyPress
- * @subpackage Core
  * @deprecated 2.2.0
  */
 

--- a/src/bp-core/deprecated/2.3.php
+++ b/src/bp-core/deprecated/2.3.php
@@ -2,6 +2,7 @@
 /**
  * Deprecated functions.
  *
+ * @package BuddyPress
  * @deprecated 2.3.0
  */
 

--- a/src/bp-core/deprecated/2.4.php
+++ b/src/bp-core/deprecated/2.4.php
@@ -2,6 +2,7 @@
 /**
  * Deprecated functions.
  *
+ * @package BuddyPress
  * @deprecated 2.4.0
  */
 

--- a/src/bp-core/deprecated/2.5.php
+++ b/src/bp-core/deprecated/2.5.php
@@ -2,6 +2,7 @@
 /**
  * Deprecated functions.
  *
+ * @package BuddyPress
  * @deprecated 2.5.0
  */
 

--- a/src/bp-core/deprecated/2.6.php
+++ b/src/bp-core/deprecated/2.6.php
@@ -2,6 +2,7 @@
 /**
  * Deprecated functions.
  *
+ * @package BuddyPress
  * @deprecated 2.6.0
  */
 

--- a/src/bp-core/deprecated/2.7.php
+++ b/src/bp-core/deprecated/2.7.php
@@ -2,6 +2,7 @@
 /**
  * Deprecated functions.
  *
+ * @package BuddyPress
  * @deprecated 2.7.0
  */
 

--- a/src/bp-core/deprecated/2.8.php
+++ b/src/bp-core/deprecated/2.8.php
@@ -2,6 +2,7 @@
 /**
  * Deprecated functions.
  *
+ * @package BuddyPress
  * @deprecated 2.8.0
  */
 

--- a/src/bp-core/deprecated/2.9.php
+++ b/src/bp-core/deprecated/2.9.php
@@ -2,6 +2,7 @@
 /**
  * Deprecated functions.
  *
+ * @package BuddyPress
  * @deprecated 2.9.0
  */
 

--- a/src/bp-core/deprecated/3.0.php
+++ b/src/bp-core/deprecated/3.0.php
@@ -2,6 +2,7 @@
 /**
  * Deprecated functions.
  *
+ * @package BuddyPress
  * @deprecated 3.0.0
  */
 

--- a/src/bp-core/deprecated/4.0.php
+++ b/src/bp-core/deprecated/4.0.php
@@ -2,6 +2,7 @@
 /**
  * Deprecated functions.
  *
+ * @package BuddyPress
  * @deprecated 4.0.0
  */
 

--- a/src/bp-core/deprecated/6.0.php
+++ b/src/bp-core/deprecated/6.0.php
@@ -2,6 +2,7 @@
 /**
  * Deprecated functions.
  *
+ * @package BuddyPress
  * @deprecated 6.0.0
  */
 

--- a/src/bp-core/deprecated/7.0.php
+++ b/src/bp-core/deprecated/7.0.php
@@ -3,6 +3,7 @@
 /**
  * Deprecated functions.
  *
+ * @package BuddyPress
  * @deprecated 7.0.0
  */
 

--- a/src/bp-core/deprecated/8.0.php
+++ b/src/bp-core/deprecated/8.0.php
@@ -3,6 +3,7 @@
 /**
  * Deprecated functions.
  *
+ * @package BuddyPress
  * @deprecated 8.0.0
  */
 

--- a/src/bp-members/bp-members-template.php
+++ b/src/bp-members/bp-members-template.php
@@ -3045,34 +3045,23 @@ function bp_signup_avatar( $args = '' ) {
 	}
 
 /**
- * Output whether signup is allowed.
+ * Is user signup allowed?
  *
  * @since 1.1.0
  *
- * @todo Remove this function. Echoing a bool is pointless.
+ * @return bool
  */
-function bp_signup_allowed() {
-	// phpcs:ignore WordPress.Security.EscapeOutput
-	echo bp_get_signup_allowed();
-}
-	/**
-	 * Is user signup allowed?
-	 *
-	 * @since 1.1.0
-	 *
-	 * @return bool
-	 */
-	function bp_get_signup_allowed() {
+function bp_get_signup_allowed() {
 
-		/**
-		 * Filters whether or not new signups are allowed.
-		 *
-		 * @since 1.5.0
-		 *
-		 * @param bool $signup_allowed Whether or not new signups are allowed.
-		 */
-		return apply_filters( 'bp_get_signup_allowed', (bool) bp_get_option( 'users_can_register' ) );
-	}
+	/**
+	 * Filters whether new signups are allowed.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param bool $signup_allowed Whether or not new signups are allowed.
+	 */
+	return apply_filters( 'bp_get_signup_allowed', (bool) bp_get_option( 'users_can_register' ) );
+}
 
 /**
  * Are users allowed to invite users to join this site?


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9250

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
