### PR TITLE
Update a test about `bp_attachments_get_allowed_types()`

### DIFF
--- a/tests/phpunit/testcases/core/functions.php
+++ b/tests/phpunit/testcases/core/functions.php
@@ -777,15 +777,15 @@ class BP_Tests_Core_Functions extends BP_UnitTestCase {
 		$cover_image = bp_attachments_get_allowed_types( 'cover_image' );
 		$this->assertSame( $supported, $cover_image );
 
-		$images = bp_attachments_get_allowed_types( 'image/' );
+		$documents = bp_attachments_get_allowed_types( 'document' );
 
-		foreach ( $images as $image ) {
-			if ( 'image' !== wp_ext2type( $image ) ) {
-				$not_image = $image;
+		foreach ( $documents as $document ) {
+			if ( 'document' !== wp_ext2type( $document ) ) {
+				$not_document = $document;
 			}
 		}
 
-		$this->assertTrue( empty( $not_image ) );
+		$this->assertTrue( empty( $not_document ) );
 	}
 
 	public function test_emails_should_have_correct_link_color() {


### PR DESCRIPTION
Test `document` types instead of `image` ones as BP image supported types are not the same than WordPress.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9251

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
