### PR TITLE
Start using `BP_Component_Feature` to organize the Members Invitations feature

### DIFF
--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -4987,6 +4987,7 @@ function bp_get_deprecated_functions_versions() {
 		11.0,
 		12.0,
 		14.0,
+		15.0,
 	);
 
 	/*

--- a/src/bp-core/classes/class-bp-component-feature.php
+++ b/src/bp-core/classes/class-bp-component-feature.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * BuddyPress Component's feature Class.
+ *
+ * @package BuddyPress
+ * @subpackage Core
+ * @since 15.0.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * BuddyPress Component Feature API.
+ *
+ * @since 15.0.0
+ */
+class BP_Component_Feature extends BP_Component {
+
+	/**
+	 * Unique ID for the feature.
+	 *
+	 * @since 15.0.0
+	 *
+	 * @var string
+	 */
+	public $id = '';
+
+	/**
+	 * Unique Slug for the feature.
+	 *
+	 * @since 15.0.0
+	 *
+	 * @var string
+	 */
+	public $slug = '';
+
+	/**
+	 * Unique ID for the feature's component.
+	 *
+	 * @since 15.0.0
+	 *
+	 * @var string
+	 */
+	public $component_id = '';
+
+	/**
+	 * This is a component's feature.
+	 *
+	 * @since 15.0.0
+	 *
+	 * @var boolean
+	 */
+	public $is_feature = true;
+
+	/**
+	 * Disable the `BP_Component()` starting method.
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param string $id     Unique ID. Letters, numbers, and underscores only.
+	 * @param string $name   Unique raw name for the component (do not use translatable strings).
+	 * @param string $path   The file path for the component's files. Used by {@link BP_Component::includes()}.
+	 * @param array  $params {
+	 *     Additional parameters used by the component.
+	 *
+	 *     @see BP_Component::start() for a description of parameters.
+	 * }
+	 */
+	public function start( $id = '', $name = '', $path = '', $params = array() ) {
+		_doing_it_wrong(
+			__CLASS__ . '::' . __METHOD__,
+			esc_html__( 'This method is not implemented. Use the `init` method to initialize this feature instead.', 'buddypress' ),
+			'15.0.0'
+		);
+	}
+
+	/**
+	 * Feature's initialization.
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param string $id           A unique string to use as the feature's ID.
+	 * @param string $component_id The unique string used as the component's ID the feature applies to.
+	 * @param array  $params {
+	 *     Additional parameters used by the component's feature.
+	 *
+	 *     @type int $adminbar_myaccount_order Set the position for our menu under the WP Toolbar's "My Account menu".
+	 * }
+	 */
+	public function init( $id, $component_id, $params = array() ) {
+		$this->id   = $id;
+		$this->slug = $id;
+
+		if ( ! bp_is_active( $component_id ) ) {
+			_doing_it_wrong(
+				__CLASS__ . '::' . __METHOD__,
+				sprintf(
+					/* Translators: %s is the component ID. */
+					esc_html__( 'This feature needs the %s component to be active.', 'buddypress' ),
+					esc_html( $component_id )
+				),
+				'15.0.0'
+			);
+		} else {
+			$this->component_id             = $component_id;
+			$this->path                     = trailingslashit( buddypress()->{$this->component_id}->path ) . 'bp-' . $this->component_id;
+
+			// Sets the position for our menu under the WP Toolbar's "My Account" menu.
+			if ( ! empty( $params['adminbar_myaccount_order'] ) ) {
+				$this->adminbar_myaccount_order = (int) $params['adminbar_myaccount_order'];
+			}
+
+			// Do some clean-up.
+			foreach ( array_keys( get_class_vars( 'BP_Component' ) ) as $key ) {
+				if ( in_array( $key, array( 'id', 'component_id', 'slug', 'main_nav', 'sub_nav', 'path', 'adminbar_myaccount_order' ), true ) ) {
+					continue;
+				}
+
+				unset( $this->{$key} );
+			}
+
+			// Move on to the next step.
+			$this->setup_actions();
+		}
+	}
+
+	/**
+	 * Set up component’s feature global variables.
+	 *
+	 * @since 15.0.0
+	 */
+	public function globals() {
+		/**
+		 * Fires at the end of the `globals` method.
+		 *
+		 * This is a dynamic hook that is based on the component & feature string IDs.
+		 *
+		 * @since 15.0.0
+		 */
+		do_action( 'bp_' . $this->component_id . '_' . $this->id . '_globals' );
+	}
+
+	/**
+	 * Include required files.
+	 *
+	 * @since 15.0.0
+	 *
+	 * @param array $includes An array of file names.
+	 */
+	public function includes( $includes = array() ) {
+		$slashed_path = trailingslashit( $this->path );
+
+		// Loop through files to be included.
+		foreach ( (array) $includes as $file ) {
+			$php_file = $slashed_path . rtrim( $file, '.php' ) . '.php';
+
+			if ( ! file_exists( $php_file ) ) {
+				continue;
+			}
+
+			require_once $php_file;
+		}
+
+		/**
+		 * Fires at the end of the `includes` method.
+		 *
+		 * This is a dynamic hook that is based on the component & feature string IDs.
+		 *
+		 * @since 15.0.0
+		 */
+		do_action( 'bp_' . $this->component_id . '_' . $this->id . '_includes' );
+	}
+
+	/**
+	 * Set up action hooks for the Feature.
+	 *
+	 * @since 15.0.0
+	 */
+	public function setup_actions() {
+		// Setup globals.
+		add_action( 'bp_' . $this->component_id . '_setup_globals', array( $this, 'globals' ) );
+
+		// Include required files.
+		add_action( 'bp_' . $this->component_id . '_includes', array( $this, 'includes' ) );
+
+		// Load files conditionally, based on certain pages.
+		add_action( 'bp_late_include', array( $this, 'late_includes' ), 11 );
+
+		// Register feature's navigation.
+		add_action( 'bp_register_nav', array( $this, 'register_nav' ) );
+
+		// Setup feature's navigation.
+		add_action( 'bp_setup_nav', array( $this, 'setup_nav' ) );
+
+		// Setup WP Toolbar menus.
+		add_action( 'bp_setup_admin_bar', array( $this, 'setup_admin_bar' ), $this->adminbar_myaccount_order );
+
+		// Setup cache groups.
+		add_action( 'bp_setup_cache_groups', array( $this, 'setup_cache_groups' ) );
+
+		// Register BP REST Endpoints.
+		if ( bp_rest_in_buddypress() && bp_rest_api_is_available() ) {
+			add_action( 'bp_rest_api_init', array( $this, 'rest_api_init' ) );
+		}
+
+		// Register BP Blocks.
+		if ( bp_support_blocks() ) {
+			add_action( 'bp_blocks_init', array( $this, 'blocks_init' ) );
+		}
+
+		/**
+		 * Fires at the end of the `setup_actions` method.
+		 *
+		 * This is a dynamic hook that is based on the component & feature string IDs.
+		 *
+		 * @since 15.0.0
+		 *
+		 * @param BP_Component_Feature $feature_object The Feature object.
+		 */
+		do_action( 'bp_' . $this->component_id . '_' . $this->id . '_setup_actions', $this );
+	}
+}

--- a/src/bp-core/classes/class-bp-component-feature.php
+++ b/src/bp-core/classes/class-bp-component-feature.php
@@ -103,8 +103,8 @@ class BP_Component_Feature extends BP_Component {
 				'15.0.0'
 			);
 		} else {
-			$this->component_id             = $component_id;
-			$this->path                     = trailingslashit( buddypress()->{$this->component_id}->path ) . 'bp-' . $this->component_id;
+			$this->component_id = $component_id;
+			$this->path         = trailingslashit( buddypress()->{$this->component_id}->path ) . 'bp-' . $this->component_id;
 
 			// Sets the position for our menu under the WP Toolbar's "My Account" menu.
 			if ( ! empty( $params['adminbar_myaccount_order'] ) ) {

--- a/src/bp-core/classes/class-bp-component.php
+++ b/src/bp-core/classes/class-bp-component.php
@@ -214,6 +214,15 @@ class BP_Component {
 	public $features = array();
 
 	/**
+	 * The array of active feature objects.
+	 *
+	 * @since 15.0.0
+	 *
+	 * @var object[]
+	 */
+	public $active_features = array();
+
+	/**
 	 * Component's directory title.
 	 *
 	 * @since 2.0.0
@@ -543,6 +552,21 @@ class BP_Component {
 			}
 		}
 
+		// Include potential features.
+		foreach ( $this->features as $feature ) {
+			if ( ! bp_is_active( $this->id, $feature ) ) {
+				continue;
+			}
+
+			$feature_class = 'BP_' . ucfirst( $this->id ) . '_' . ucfirst( $feature ) . '_Feature';
+
+			if ( class_exists( $feature_class, true ) ) {
+				$this->active_features[ $feature ] = new $feature_class;
+			} else {
+				$this->active_features[ $feature ] = null;
+			}
+		}
+
 		/**
 		 * Fires at the end of the includes method inside BP_Component.
 		 *
@@ -806,14 +830,19 @@ class BP_Component {
 			}
 		}
 
+		$action = 'bp_' . $this->id . '_setup_nav';
+		if ( isset( $this->is_feature, $this->component_id ) ) {
+			$action = 'bp_' . $this->component_id . '_' . $this->id . '_setup_nav';
+		}
+
 		/**
 		 * Fires at the end of the setup_nav method inside BP_Component.
 		 *
-		 * This is a dynamic hook that is based on the component string ID.
+		 * This is a dynamic hook that is based on the component/feature string IDs.
 		 *
 		 * @since 1.5.0
 		 */
-		do_action( 'bp_' . $this->id . '_setup_nav' );
+		do_action( $action );
 	}
 
 	/**
@@ -884,6 +913,11 @@ class BP_Component {
 			}
 		}
 
+		$action = 'bp_' . $this->id . '_setup_admin_bar';
+		if ( isset( $this->is_feature, $this->component_id ) ) {
+			$action = 'bp_' . $this->component_id . '_' . $this->id . '_setup_admin_bar';
+		}
+
 		/**
 		 * Fires at the end of the setup_admin_bar method inside BP_Component.
 		 *
@@ -891,7 +925,7 @@ class BP_Component {
 		 *
 		 * @since 1.5.0
 		 */
-		do_action( 'bp_' . $this->id . '_setup_admin_bar' );
+		do_action( $action );
 	}
 
 	/**

--- a/src/bp-core/deprecated/15.0.php
+++ b/src/bp-core/deprecated/15.0.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Deprecated functions.
+ *
+ * @package BuddyPress
+ * @deprecated 15.0.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Set up the bp-members-invitations component.
+ *
+ * @since 12.0.0
+ * @deprecated 15.0.0
+ */
+function bp_setup_members_invitations() {
+	_deprecated_function( __FUNCTION__, '15.0.0' );
+}

--- a/src/bp-members/bp-members-invitations.php
+++ b/src/bp-members/bp-members-invitations.php
@@ -175,7 +175,7 @@ add_filter( 'bp_members_membership_requests_bypass_manual_approval_multisite', '
 
 /**
  * Whether a user can access invitations screens.
- * Referred to by BP_Members_Invitations_Component::register_nav().
+ * Referred to by BP_Members_Invitations_Feature::register_nav().
  *
  * @since 12.0.0
  *
@@ -187,7 +187,7 @@ function bp_members_invitations_user_can_view_screens() {
 
 /**
  * Whether a user can access the send invitations member screen.
- * Referred to by BP_Members_Invitations_Component::register_nav().
+ * Referred to by BP_Members_Invitations_Feature::register_nav().
  *
  * @since 12.0.0
  *

--- a/src/bp-members/bp-members-loader.php
+++ b/src/bp-members/bp-members-loader.php
@@ -19,13 +19,3 @@ function bp_setup_members() {
 	buddypress()->members = new BP_Members_Component();
 }
 add_action( 'bp_setup_components', 'bp_setup_members', 1 );
-
-/**
- * Set up the bp-members-invitations component.
- *
- * @since 12.0.0
- */
-function bp_setup_members_invitations() {
-	buddypress()->members_invitations = new BP_Members_Invitations_Component();
-}
-add_action( 'bp_setup_components', 'bp_setup_members_invitations', 1 );

--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -105,7 +105,6 @@ class BP_Members_Component extends BP_Component {
 			'functions',
 			'blocks',
 			'cache',
-			'invitations',
 			'notifications',
 		);
 
@@ -193,17 +192,6 @@ class BP_Members_Component extends BP_Component {
 			// Theme compatibility.
 			new BP_Registration_Theme_Compat();
 		}
-
-		// Invitations.
-		if ( is_user_logged_in() && bp_is_user_members_invitations() ) {
-			// Actions.
-			if ( isset( $_POST['members_invitations'] ) ) {
-				require_once $this->path . 'bp-members/actions/invitations-bulk-manage.php';
-			}
-
-			// Screens.
-			require_once $this->path . 'bp-members/screens/invitations.php';
-		}
 	}
 
 	/**
@@ -290,11 +278,6 @@ class BP_Members_Component extends BP_Component {
 			$bp->profile->slug = 'profile';
 			$bp->profile->id   = 'profile';
 		}
-
-		/** Network Invitations **************************************************
-		 */
-
-		$bp->members->invitations = new stdClass();
 	}
 
 	/**

--- a/src/bp-members/classes/class-bp-members-invitations-component.php
+++ b/src/bp-members/classes/class-bp-members-invitations-component.php
@@ -5,149 +5,15 @@
  * @package BuddyPress
  *
  * @since 12.0.0
+ * @deprecated 15.0.0
  */
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
-/**
- * BuddyPress Invitations Component Class.
- *
- * Invitations are actually a deactivable feature of the Members component. To make sure this feature
- * page slugs can be customized using the BP Rewrites API, it was decided to extend the `BP_Component`
- * class to benefit from the improvements added to it during 12.0.0 into the "rewrite" area.
- * @see `BP_Component::register_nav()`.
- *
- * @since 12.0.0
- */
-class BP_Members_Invitations_Component extends BP_Component {
-
-	/**
-	 * Start the invitations feature creation process.
-	 *
-	 * @since 12.0.0
-	 */
-	public function __construct() {
-		parent::start(
-			'members_invitations',
-			'Members Invitations',
-			'',
-			array()
-		);
-	}
-
-	/**
-	 * Register component navigation.
-	 *
-	 * @since 12.0.0
-	 *
-	 * @see `BP_Component::register_nav()` for a description of arguments.
-	 *
-	 * @param array $main_nav Optional. See `BP_Component::register_nav()` for
-	 *                        description.
-	 * @param array $sub_nav  Optional. See `BP_Component::register_nav()` for
-	 *                        description.
-	 */
-	public function register_nav( $main_nav = array(), $sub_nav = array() ) {
-		if ( ! bp_get_members_invitations_allowed() ) {
-			return;
-		}
-
-		/* Add 'Invitations' to the main user profile navigation */
-		$main_nav = array(
-			'name'                     => __( 'Invitations', 'buddypress' ),
-			'slug'                     => bp_get_members_invitations_slug(),
-			'position'                 => 80,
-			'screen_function'          => 'members_screen_send_invites',
-			'default_subnav_slug'      => 'list-invites',
-			'show_for_displayed_user'  => false, // Non-admin users should only see their own invites.
-			'user_has_access_callback' => 'bp_members_invitations_user_can_view_screens',
-		);
-
-		/* Create two subnav items for community invitations. */
-		$sub_nav[] = array(
-			'name'                     => __( 'Send Invites', 'buddypress' ),
-			'slug'                     => 'send-invites',
-			'parent_slug'              => bp_get_members_invitations_slug(),
-			'screen_function'          => 'members_screen_send_invites',
-			'position'                 => 10,
-			'user_has_access'          => false,
-			'user_has_access_callback' => 'bp_members_invitations_user_can_view_send_screen',
-		);
-
-		$sub_nav[] = array(
-			'name'                     => __( 'Pending Invites', 'buddypress' ),
-			'slug'                     => 'list-invites',
-			'parent_slug'              => bp_get_members_invitations_slug(),
-			'screen_function'          => 'members_screen_list_sent_invites',
-			'position'                 => 20,
-			'user_has_access'          => false,
-			'user_has_access_callback' => 'bp_members_invitations_user_can_view_screens',
-		);
-
-		parent::register_nav( $main_nav, $sub_nav );
-	}
-
-	/**
-	 * Set up component navigation.
-	 *
-	 * @since 12.0.0 Used to customize the default subnavigation slug.
-	 *
-	 * @see `BP_Component::setup_nav()` for a description of arguments.
-	 *
-	 * @param array $main_nav Optional. See `BP_Component::setup_nav()` for
-	 *                        description.
-	 * @param array $sub_nav  Optional. See `BP_Component::setup_nav()` for
-	 *                        description.
-	 */
-	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
-		if ( bp_is_my_profile() && bp_user_can( bp_displayed_user_id(), 'bp_members_invitations_view_send_screen' ) ) {
-			$this->main_nav['default_subnav_slug'] = 'send-invites';
-		}
-
-		parent::setup_nav( $main_nav, $sub_nav );
-	}
-
-	/**
-	 * Set up the component entries in the WordPress Admin Bar.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @see BP_Component::setup_admin_bar() for a description of arguments.
-	 *
-	 * @param array $wp_admin_nav See BP_Component::setup_admin_bar()
-	 *                            for description.
-	 */
-	public function setup_admin_bar( $wp_admin_nav = array() ) {
-		if ( bp_current_user_can( 'bp_members_invitations_view_screens' ) ) {
-			$bp             = buddypress();
-			$invite_slug    = bp_get_members_invitations_slug();
-			$invite_menu_id = $bp->my_account_menu_id . '-invitations';
-
-			$wp_admin_nav[] = array(
-				'id'     => $invite_menu_id,
-				'parent' => $bp->my_account_menu_id,
-				'title'  => __( 'Invitations', 'buddypress' ),
-				'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $invite_slug ) ) ),
-			);
-
-			if ( bp_current_user_can( 'bp_members_invitations_view_send_screen' ) ) {
-				$wp_admin_nav[] = array(
-					'id'     => $bp->my_account_menu_id . '-invitations-send',
-					'parent' => $invite_menu_id,
-					'title'  => __( 'Send Invites', 'buddypress' ),
-					'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $invite_slug, 'send-invites' ) ) ),
-				);
-			}
-
-			$wp_admin_nav[] = array(
-				'id'     => $bp->my_account_menu_id . '-invitations-list',
-				'parent' => $invite_menu_id,
-				'title'  => __( 'Pending Invites', 'buddypress' ),
-				'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $invite_slug, 'list-invites' ) ) ),
-			);
-		}
-
-		parent::setup_admin_bar( $wp_admin_nav );
-	}
-}
+_deprecated_file(
+	basename( __FILE__ ),
+	'15.0.0',
+	'',
+	esc_html__( 'The Members component Invitations feature is now using the BP Component Feature API.', 'buddypress' )
+);

--- a/src/bp-members/classes/class-bp-members-invitations-feature.php
+++ b/src/bp-members/classes/class-bp-members-invitations-feature.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * BuddyPress Members Invitations feature Class.
+ *
+ * @package BuddyPress
+ * @subpackage Members
+ * @since 15.0.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * The BP Members Invitations feature is optional.
+ *
+ * If you want to disable it, you can use:
+ * `add_filter( 'bp_is_members_invitations_active', '__return_false' );`
+ *
+ * @since 15.0.0
+ */
+class BP_Members_Invitations_Feature extends BP_Component_Feature {
+
+	/**
+	 * Invitations Feature initialization.
+	 *
+	 * @since 15.0.0
+	 */
+	public function __construct() {
+		parent::init( 'invitations', 'members' );
+	}
+
+	/**
+	 * Set up Signups feature global variables.
+	 *
+	 * @since 15.0.0
+	 */
+	public function globals() {
+		buddypress()->members->invitations = new stdClass();
+
+		parent::globals();
+	}
+
+	/**
+	 * Include Invitations feature files.
+	 *
+	 * @since 15.0.0
+	 *
+	 * @see `BP_Component_Feature::includes()` for description of parameters.
+	 *
+	 * @param array $includes See {@link BP_Component_Feature::includes()}.
+	 */
+	public function includes( $includes = array() ) {
+		parent::includes( array( 'bp-members-invitations' ) );
+	}
+
+	/**
+	 * Include screen/action files later & when on specific pages.
+	 *
+	 * @since 15.0.0
+	 */
+	public function late_includes() {
+		// Invitations.
+		if ( is_user_logged_in() && bp_is_user_members_invitations() ) {
+			$bp = buddypress();
+
+			// Actions.
+			if ( isset( $_POST['members_invitations'] ) ) {
+				require_once $bp->members->path . 'bp-members/actions/invitations-bulk-manage.php';
+			}
+
+			// Screens.
+			require_once $bp->members->path . 'bp-members/screens/invitations.php';
+		}
+	}
+
+	/**
+	 * Register Invitations feature navigation.
+	 *
+	 * @since 15.0.0
+	 *
+	 * @see `BP_Component::register_nav()` for a description of arguments.
+	 *
+	 * @param array $main_nav Optional. See `BP_Component::register_nav()` for
+	 *                        description.
+	 * @param array $sub_nav  Optional. See `BP_Component::register_nav()` for
+	 *                        description.
+	 */
+	public function register_nav( $main_nav = array(), $sub_nav = array() ) {
+		if ( bp_get_members_invitations_allowed() ) {
+			// Add 'Invitations' to the main user profile navigation.
+			$main_nav = array(
+				'name'                     => __( 'Invitations', 'buddypress' ),
+				'slug'                     => bp_get_members_invitations_slug(),
+				'position'                 => 80,
+				'screen_function'          => 'members_screen_send_invites',
+				'default_subnav_slug'      => 'list-invites',
+				'show_for_displayed_user'  => false, // Non-admin users should only see their own invites.
+				'user_has_access_callback' => 'bp_members_invitations_user_can_view_screens',
+			);
+
+			// Create two subnav items for community invitations.
+			$sub_nav[] = array(
+				'name'                     => __( 'Send Invites', 'buddypress' ),
+				'slug'                     => 'send-invites',
+				'parent_slug'              => bp_get_members_invitations_slug(),
+				'screen_function'          => 'members_screen_send_invites',
+				'position'                 => 10,
+				'user_has_access'          => false,
+				'user_has_access_callback' => 'bp_members_invitations_user_can_view_send_screen',
+			);
+
+			$sub_nav[] = array(
+				'name'                     => __( 'Pending Invites', 'buddypress' ),
+				'slug'                     => 'list-invites',
+				'parent_slug'              => bp_get_members_invitations_slug(),
+				'screen_function'          => 'members_screen_list_sent_invites',
+				'position'                 => 20,
+				'user_has_access'          => false,
+				'user_has_access_callback' => 'bp_members_invitations_user_can_view_screens',
+			);
+		}
+
+		parent::register_nav( $main_nav, $sub_nav );
+	}
+
+	/**
+	 * Set up Invitations feature navigation.
+	 *
+	 * @since 15.0.0 Used to customize the default subnavigation slug.
+	 *
+	 * @see `BP_Component::setup_nav()` for a description of arguments.
+	 *
+	 * @param array $main_nav Optional. See `BP_Component::setup_nav()` for
+	 *                        description.
+	 * @param array $sub_nav  Optional. See `BP_Component::setup_nav()` for
+	 *                        description.
+	 */
+	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
+		if ( bp_is_my_profile() && bp_user_can( bp_displayed_user_id(), 'bp_members_invitations_view_send_screen' ) ) {
+			$this->main_nav['default_subnav_slug'] = 'send-invites';
+		}
+
+		parent::setup_nav( $main_nav, $sub_nav );
+	}
+
+	/**
+	 * Set up the Invitations feature entries in the WordPress Admin Bar.
+	 *
+	 * @since 15.0.0
+	 *
+	 * @see BP_Component::setup_admin_bar() for a description of arguments.
+	 *
+	 * @param array $wp_admin_nav See BP_Component::setup_admin_bar()
+	 *                            for description.
+	 */
+	public function setup_admin_bar( $wp_admin_nav = array() ) {
+		if ( bp_current_user_can( 'bp_members_invitations_view_screens' ) ) {
+			$bp             = buddypress();
+			$invite_slug    = bp_get_members_invitations_slug();
+			$invite_menu_id = $bp->my_account_menu_id . '-invitations';
+
+			$wp_admin_nav[] = array(
+				'id'     => $invite_menu_id,
+				'parent' => $bp->my_account_menu_id,
+				'title'  => __( 'Invitations', 'buddypress' ),
+				'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $invite_slug ) ) ),
+			);
+
+			if ( bp_current_user_can( 'bp_members_invitations_view_send_screen' ) ) {
+				$wp_admin_nav[] = array(
+					'id'     => $bp->my_account_menu_id . '-invitations-send',
+					'parent' => $invite_menu_id,
+					'title'  => __( 'Send Invites', 'buddypress' ),
+					'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $invite_slug, 'send-invites' ) ) ),
+				);
+			}
+
+			$wp_admin_nav[] = array(
+				'id'     => $bp->my_account_menu_id . '-invitations-list',
+				'parent' => $invite_menu_id,
+				'title'  => __( 'Pending Invites', 'buddypress' ),
+				'href'   => bp_loggedin_user_url( bp_members_get_path_chunks( array( $invite_slug, 'list-invites' ) ) ),
+			);
+		}
+
+		parent::setup_admin_bar( $wp_admin_nav );
+	}
+}

--- a/src/class-buddypress.php
+++ b/src/class-buddypress.php
@@ -705,6 +705,7 @@ class BuddyPress {
 			'BP_Button'                        => 'core',
 			'BP_Block'                         => 'core',
 			'BP_Component'                     => 'core',
+			'BP_Component_Feature'             => 'core',
 			'BP_Customizer_Control_Range'      => 'core',
 			'BP_Date_Query'                    => 'core',
 			'BP_Email_Delivery'                => 'core',
@@ -736,7 +737,6 @@ class BuddyPress {
 			'BP_Signup'                        => 'members',
 			'BP_Members_Invitation_Manager'    => 'members',
 			'BP_Members_Invitations_Template'  => 'members',
-			'BP_Members_Invitations_Component' => 'members',
 		);
 
 		$component = null;


### PR DESCRIPTION
Stop using `BP_Component` in favor of `BP_Component_Feature` to avoid messing with BuddyPress component globals and "faking" a component to register the feature navigation.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9254

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
