### PR TITLE
Update class-bp-activity-activity.php

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-activity.php
+++ b/src/bp-activity/classes/class-bp-activity-activity.php
@@ -1666,7 +1666,12 @@ class BP_Activity_Activity {
 		// We store the string 'none' to cache the fact that the
 		// activity item has no comments.
 		if ( 'none' === $comments_cache ) {
-			return false;
+			/*
+			When the activity item was cached and has no comments, we still need to return an empty array, just
+			like how the rest of the function returns an empty array when there are no comments. Other functions depend on this being the case.
+			For example, line 2618 in bp-activity-template.php in the function bp_activity_get_comment_depth will throw an error if this is not the case.
+			*/
+			return $comments;
 
 			// A true cache miss.
 		} elseif ( empty( $comments_cache ) ) {


### PR DESCRIPTION

https://buddypress.trac.wordpress.org/ticket/9270#ticket

<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
When the activity item was cached and has no comments, we still need to return an empty array, just like how the rest of the function returns an empty array when there are no comments. Other functions depend on this being the case. For example, line 2618 in bp-activity-template.php in the function bp_activity_get_comment_depth will throw an error if this is not the case. We could also set bp_activity_get_comment_depth to check if $comments returned is false in that function and set it to an empty array.

But in this version, we return $comments (which is an empty array) instead of false on line 1649 (I believe) of class-bp-activity-activity.php in the public static function get_activity_comments.

Trac ticket: <!-- insert a link to the BuddyPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
