### PR TITLE
Add filter to members component for filtering the profile URI

### DIFF
--- a/src/bp-members/classes/class-bp-members-component.php
+++ b/src/bp-members/classes/class-bp-members-component.php
@@ -773,10 +773,12 @@ class BP_Members_Component extends BP_Component {
 			return parent::parse_query( $query );
 		}
 
+		$request = apply_filters('bp_members_parse_query_request',  $GLOBALS['wp']->request);
+
 		// Init the current member and member type.
 		$member      = false;
 		$member_type = false;
-		$member_data = bp_rewrites_get_member_data();
+		$member_data = bp_rewrites_get_member_data($request);
 
 		if ( isset( $member_data['object'] ) && $member_data['object'] ) {
 			bp_reset_query( trailingslashit( $this->root_slug ) . $GLOBALS['wp']->request, $query );


### PR DESCRIPTION
Adds a filter to the BP_Members_Component->parse_query method, that allows for the request object to be filtered, right before it get's passed to "bp_rewrites_get_member_data".

If member profiles are not used with the default URI, for example when using language subdirectories, BuddyPress will throw a 404. This filter allows for the requested URI to be manipulated such that "bp_rewrites_get_member_data" knows where to look for the username in the URI.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9235

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
