### PR TITLE
Delete orphaned cover images when a user is deleted

### DIFF
--- a/src/bp-members/bp-members-functions.php
+++ b/src/bp-members/bp-members-functions.php
@@ -1377,6 +1377,41 @@ function bp_core_delete_avatar_on_delete_user( $user_id ) {
 add_action( 'delete_user', 'bp_core_delete_avatar_on_delete_user' );
 
 /**
+ * Delete a user's cover image when the user is deleted.
+ *
+ * @since 1.9.0
+ *
+ * @param int $user_id ID of the user who is about to be deleted.
+ * @return bool
+ */
+function bp_core_delete_cover_image_on_user_delete( $user_id ) {
+	return bp_attachments_delete_file(
+		array(
+			'item_id'    => $user_id,
+			'object_dir' => 'members',
+			'type'       => 'cover-image',
+		)
+	);
+}
+add_action( 'wpmu_delete_user', 'bp_core_delete_cover_image_on_user_delete' );
+
+/**
+ * Deletes cover image data on the 'delete_user' hook.
+ *
+ * @since 6.0.0
+ *
+ * @param int $user_id The ID of the deleted user.
+ */
+function bp_core_delete_cover_image_on_delete_user( $user_id ) {
+	if ( ! bp_remove_user_data_on_delete_user_hook( 'cover_image', $user_id ) ) {
+		return;
+	}
+
+	bp_core_delete_cover_image_on_user_delete( $user_id );
+}
+add_action( 'delete_user', 'bp_core_delete_cover_image_on_delete_user' );
+
+/**
  * Multibyte-safe ucfirst() support.
  *
  * Uses multibyte functions when available on the PHP build.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
- Added functions to delete the user’s cover image and related folder during user deletion.
- Ensure cover images are properly removed when a user is deleted by hooking into `delete_user` and `wpmu_delete_user`. 
- This prevents orphaned cover image files in `/uploads/buddypress/members/<user_id>`.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/7636

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
