### PR TITLE
Trac Ticket-9287 : Add hook before and after activity content 

### DIFF
--- a/src/bp-templates/bp-nouveau/buddypress/activity/entry.php
+++ b/src/bp-templates/bp-nouveau/buddypress/activity/entry.php
@@ -31,6 +31,8 @@ bp_nouveau_activity_hook( 'before', 'entry' ); ?>
 
 		</div>
 
+		<?php bp_nouveau_activity_hook( 'before', 'content' ); ?>
+
 		<?php if ( bp_nouveau_activity_has_content() ) : ?>
 
 			<div class="activity-inner">
@@ -40,6 +42,8 @@ bp_nouveau_activity_hook( 'before', 'entry' ); ?>
 			</div>
 
 		<?php endif; ?>
+
+		<?php bp_nouveau_activity_hook( 'after', 'content' ); ?>
 
 		<?php bp_nouveau_activity_entry_buttons(); ?>
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Added hooks for before and after activity content. So that we can extend any functionality from plugins.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9287

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
