### PR TITLE
Fix: Only show unsubscribe link in emails if both Settings and Notifi…

### DIFF
--- a/src/bp-core/bp-core-filters.php
+++ b/src/bp-core/bp-core-filters.php
@@ -1257,7 +1257,8 @@ function bp_email_set_default_tokens( $tokens, $property_name, $transform, $emai
 		if ( $user_obj ) {
 			$tokens['recipient.username'] = $user_obj->user_login;
 
-			if ( bp_is_active( 'settings' ) && empty( $tokens['unsubscribe'] ) ) {
+			// Only set unsubscribe link if both 'settings' and 'notifications' components are active.
+			if ( bp_is_active( 'settings' ) && bp_is_active( 'notifications' ) && empty( $tokens['unsubscribe'] ) ) {
 				$tokens['unsubscribe'] = esc_url(
 					bp_members_get_user_url(
 						$user_obj->ID,


### PR DESCRIPTION
Fixes an issue where BuddyPress would display an unsubscribe link and "change your email preferences" text in private message emails even when users could not actually manage their notification preferences (i.e., if the Settings or Notifications component was disabled).


Fixes: https://buddypress.trac.wordpress.org/ticket/9073