### PR TITLE
Fix ATOM feed href value and avoid PHP Deprecated

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-feed.php
+++ b/src/bp-activity/classes/class-bp-activity-feed.php
@@ -441,7 +441,7 @@ class BP_Activity_Feed {
 <channel>
 	<title><?php echo esc_html( $this->title ); ?></title>
 	<link><?php echo esc_url( $this->link ); ?></link>
-	<atom:link href="<?php esc_url( self_link() ); ?>" rel="self" type="application/rss+xml" />
+	<atom:link href="<?php self_link(); ?>" rel="self" type="application/rss+xml" />
 	<description><?php echo esc_html( $this->description ); ?></description>
 	<lastBuildDate><?php echo esc_html( mysql2date( 'D, d M Y H:i:s O', bp_activity_get_last_updated(), false ) ); ?></lastBuildDate>
 	<generator>https://buddypress.org/?v=<?php esc_html( bp_get_version() ); ?></generator>


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Avoids PHP Deprecated noise in logs and fixes the ATOM feed URL for Activities.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9298

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
