### PR TITLE
Docs: Add guide on how to override BuddyPress styles (#297)

### DIFF
--- a/docs/user/getting-started/how-to-override-bp-styles.md
+++ b/docs/user/getting-started/how-to-override-bp-styles.md
@@ -1,0 +1,45 @@
+To override BuddyPress styles, you can use one of four primary methods, listed from most to least recommended for general use. The best practice is to never edit the BuddyPress core files, as any changes will be lost during updates.
+
+1. Use Your Theme’s style.css
+The most straightforward way to override BuddyPress's default styles is to add your custom CSS directly to your active theme's style.css file. Since your theme's stylesheet loads after BuddyPress's, your rules will take precedence.
+
+-Open your theme’s style.css file.
+-Add your custom CSS rules. For example, to change the background and text color of BuddyPress buttons, you would add:
+
+
+.bp-button {
+  background-color: #0073aa;
+  color: #ffffff;
+}
+
+2. Use a Child Theme 👨‍👦
+For long-term solutions, a child theme is the safest method. It protects your customizations from being overwritten when the parent theme is updated. Simply add your CSS overrides to the style.css file within your child theme's folder.
+
+3. Use a Custom Stylesheet (bp-custom.css)
+For better organization, you can create a separate stylesheet specifically for BuddyPress. This keeps your BuddyPress-related styles distinct from your general theme styles.
+
+Enqueue the stylesheet: Add the following code to your theme’s functions.php file (or a child theme's functions.php):
+
+
+function my_bp_custom_styles() {
+    wp_enqueue_style(
+        'my-bp-styles',
+        get_stylesheet_directory_uri() . '/bp-custom.css'
+    );
+}
+add_action( 'wp_enqueue_scripts', 'my_bp_custom_styles' );
+
+Create the file: Create a file named bp-custom.css in your theme's root directory and add your CSS overrides there.
+
+4. Use WordPress Customizer (Quick Changes) 🎨
+For quick tests or small tweaks, the WordPress Customizer is a convenient option. This method stores the CSS directly in the database.
+
+-Navigate to Appearance > Customize in your WordPress dashboard.
+-Click on Additional CSS.
+-Paste your BuddyPress CSS overrides into the provided text box.
+
+# Best Practices
+-Never edit BuddyPress core files.
+-Prefer child themes or custom stylesheets for permanent changes.
+-Organize your CSS by grouping BuddyPress rules together.
+-Test your changes across different browsers and screen sizes.


### PR DESCRIPTION
## Summary
This PR adds a new documentation page explaining how to override BuddyPress styles.

## Changes made
- Added `docs/user/getting-started/how-to-override-bp-styles.md`
- Documented four safe ways to override BuddyPress CSS:
  1. Theme’s `style.css`
  2. Child theme
  3. Custom stylesheet (`bp-custom.css`)
  4. WordPress Customizer

## References
- Trac ticket #297

---
**Note:** This PR is for documentation update and code review only. Please keep all further discussion on the Trac ticket.
