### PR TITLE
Docs: Clarify return types in template helpers

### DIFF
--- a/src/bp-activity/bp-activity-template.php
+++ b/src/bp-activity/bp-activity-template.php
@@ -1908,7 +1908,7 @@ function bp_activity_parent_content( $args = '' ) {
 	 * @global BP_Activity_Template $activities_template The main activity template loop class.
 	 *
 	 * @param string $args Unused. Left over from an earlier implementation.
-	 * @return mixed False on failure, otherwise the activity parent content.
+	 * @return string|false False on failure, otherwise the activity parent content.
 	 */
 	function bp_get_activity_parent_content( $args = '' ) {
 		global $activities_template;

--- a/src/bp-core/bp-core-template.php
+++ b/src/bp-core/bp-core-template.php
@@ -291,7 +291,7 @@ function bp_site_name() {
  *                                 to return month, day, and time. Default: false.
  * @param bool       $gmt          Optional. True to display in local time, false to
  *                                  leave in GMT. Default: true.
- * @return mixed A string representation of $time, in the format
+ * @return string|false A string representation of $time, in the format
  *               "March 18, 2014 at 2:00 pm" (or whatever your
  *               'date_format' and 'time_format' settings are
  *               on your root blog). False on failure.


### PR DESCRIPTION
This PR updates a couple of PHPDoc `@return` annotations that currently use
`mixed`, even though the functions return well-defined values.

The changes clarify the return types based on the existing behavior:

- `bp_format_time()` returns a formatted string on success or `false` on failure.
- `bp_get_activity_parent_content()` returns a string or `false` when no parent
  content is available.

This is a documentation-only change and does not affect runtime behavior.

This PR addresses Trac ticket #9319:
https://buddypress.trac.wordpress.org/ticket/9319
