### PR TITLE
Add first-class per-item privacy support

### DIFF
--- a/src/bp-activity/bp-activity-functions.php
+++ b/src/bp-activity/bp-activity-functions.php
@@ -2057,6 +2057,7 @@ function bp_activity_get_specific( $args = '' ) {
  *     @type bool     $hide_sitewide     Should the item be hidden on sitewide streams?
  *                                       Default: false.
  *     @type bool     $is_spam           Should the item be marked as spam? Default: false.
+ *     @type string   $privacy           The activity privacy value. Default: 'public'.
  *     @type string   $error_type        Optional. Error type. Either 'bool' or 'wp_error'. Default: 'bool'.
  * }
  * @return WP_Error|bool|int The ID of the activity on success. False on error.
@@ -2078,6 +2079,7 @@ function bp_activity_add( $args = '' ) {
 			'recorded_time'     => bp_core_current_time(), // The GMT time that this activity was recorded.
 			'hide_sitewide'     => false,                  // Should this be hidden on the sitewide activity stream?
 			'is_spam'           => false,                  // Is this activity item to be marked as spam?
+			'privacy'           => 'public',               // Activity privacy value.
 			'error_type'        => 'bool',
 		),
 		'activity_add'
@@ -2104,6 +2106,7 @@ function bp_activity_add( $args = '' ) {
 	$activity->date_recorded     = $r['recorded_time'];
 	$activity->hide_sitewide     = $r['hide_sitewide'];
 	$activity->is_spam           = $r['is_spam'];
+	$activity->privacy           = $r['privacy'];
 	$activity->error_type        = $r['error_type'];
 	$activity->action            = ! empty( $r['action'] )
 						? $r['action']
@@ -2150,6 +2153,7 @@ function bp_activity_add( $args = '' ) {
  *     An array of arguments.
  *     @type string $content    The content of the activity update.
  *     @type int    $user_id    Optional. Defaults to the logged-in user.
+ *     @type string $privacy    Optional. Activity privacy value. Default: 'public'.
  *     @type string $error_type Optional. Error type to return. Either 'bool' or 'wp_error'. Defaults to
  *                              'bool' for boolean. 'wp_error' will return a WP_Error object.
  * }
@@ -2163,6 +2167,7 @@ function bp_activity_post_update( $args = '' ) {
 		array(
 			'content'    => false,
 			'user_id'    => bp_loggedin_user_id(),
+			'privacy'    => 'public',
 			'error_type' => 'bool',
 		),
 		'activity_post_update'
@@ -2213,6 +2218,7 @@ function bp_activity_post_update( $args = '' ) {
 		'primary_link' => $add_primary_link,
 		'component'    => buddypress()->activity->id,
 		'type'         => 'activity_update',
+		'privacy'      => $r['privacy'],
 		'error_type'   => $r['error_type']
 	) );
 

--- a/src/bp-activity/classes/class-bp-activity-activity.php
+++ b/src/bp-activity/classes/class-bp-activity-activity.php
@@ -135,6 +135,14 @@ class BP_Activity_Activity {
 	var $is_spam;
 
 	/**
+	 * The privacy level of the activity item.
+	 *
+	 * @since 15.1.0
+	 * @var string
+	 */
+	var $privacy = 'public';
+
+	/**
 	 * Error holder.
 	 *
 	 * @since 2.6.0
@@ -207,6 +215,7 @@ class BP_Activity_Activity {
 		$this->mptt_left         = (int) $row->mptt_left;
 		$this->mptt_right        = (int) $row->mptt_right;
 		$this->is_spam           = (int) $row->is_spam;
+		$this->privacy           = isset( $row->privacy ) ? (string) $row->privacy : 'public';
 
 		// Generate dynamic 'action' when possible.
 		$action = bp_activity_generate_action_string( $this );
@@ -252,6 +261,7 @@ class BP_Activity_Activity {
 		$this->mptt_left         = apply_filters_ref_array( 'bp_activity_mptt_left_before_save', array( $this->mptt_left, &$this ) );
 		$this->mptt_right        = apply_filters_ref_array( 'bp_activity_mptt_right_before_save', array( $this->mptt_right, &$this ) );
 		$this->is_spam           = apply_filters_ref_array( 'bp_activity_is_spam_before_save', array( $this->is_spam, &$this ) );
+		$this->privacy           = apply_filters_ref_array( 'bp_activity_privacy_before_save', array( $this->privacy, &$this ) );
 
 		/**
 		 * Fires before the current activity item gets saved.
@@ -308,9 +318,9 @@ class BP_Activity_Activity {
 
 		// If we have an existing ID, update the activity item, otherwise insert it.
 		if ( ! empty( $this->id ) ) {
-			$q = $wpdb->prepare( "UPDATE {$bp->activity->table_name} SET user_id = %d, component = %s, type = %s, action = %s, content = %s, primary_link = %s, date_recorded = %s, item_id = %d, secondary_item_id = %d, hide_sitewide = %d, is_spam = %d WHERE id = %d", $this->user_id, $this->component, $this->type, $this->action, $this->content, $this->primary_link, $this->date_recorded, $this->item_id, $this->secondary_item_id, $this->hide_sitewide, $this->is_spam, $this->id );
+			$q = $wpdb->prepare( "UPDATE {$bp->activity->table_name} SET user_id = %d, component = %s, type = %s, action = %s, content = %s, primary_link = %s, date_recorded = %s, item_id = %d, secondary_item_id = %d, hide_sitewide = %d, is_spam = %d, privacy = %s WHERE id = %d", $this->user_id, $this->component, $this->type, $this->action, $this->content, $this->primary_link, $this->date_recorded, $this->item_id, $this->secondary_item_id, $this->hide_sitewide, $this->is_spam, $this->privacy, $this->id );
 		} else {
-			$q = $wpdb->prepare( "INSERT INTO {$bp->activity->table_name} ( user_id, component, type, action, content, primary_link, date_recorded, item_id, secondary_item_id, hide_sitewide, is_spam ) VALUES ( %d, %s, %s, %s, %s, %s, %s, %d, %d, %d, %d )", $this->user_id, $this->component, $this->type, $this->action, $this->content, $this->primary_link, $this->date_recorded, $this->item_id, $this->secondary_item_id, $this->hide_sitewide, $this->is_spam );
+			$q = $wpdb->prepare( "INSERT INTO {$bp->activity->table_name} ( user_id, component, type, action, content, primary_link, date_recorded, item_id, secondary_item_id, hide_sitewide, is_spam, privacy ) VALUES ( %d, %s, %s, %s, %s, %s, %s, %d, %d, %d, %d, %s )", $this->user_id, $this->component, $this->type, $this->action, $this->content, $this->primary_link, $this->date_recorded, $this->item_id, $this->secondary_item_id, $this->hide_sitewide, $this->is_spam, $this->privacy );
 		}
 
 		if ( false === $wpdb->query( $q ) ) {
@@ -382,6 +392,7 @@ class BP_Activity_Activity {
 	 *     @type bool         $display_comments  Whether to include activity comments. Default: false.
 	 *     @type bool         $show_hidden       Whether to show items marked hide_sitewide. Default: false.
 	 *     @type string       $spam              Spam status. Default: 'ham_only'.
+	 *     @type string|array $privacy           Activity privacy value(s) to include. Default: false.
 	 *     @type bool         $cache_results     Optional. Whether to cache activity information. Default true.
 	 *     @type bool         $update_meta_cache Whether to pre-fetch metadata for queried activity items. Default: true.
 	 *     @type string|bool  $count_total       If true, an additional DB query is run to count the total activity items
@@ -451,6 +462,7 @@ class BP_Activity_Activity {
 				'display_comments'  => false,           // Whether to include activity comments.
 				'show_hidden'       => false,           // Show items marked hide_sitewide.
 				'spam'              => 'ham_only',      // Spam status.
+				'privacy'           => false,           // Filter by activity privacy value(s).
 				'cache_results'     => true,            // Whether to cache activity information.
 				'update_meta_cache' => true,            // Whether to update meta cache.
 				'count_total'       => false,           // Whether to use count_total.
@@ -550,6 +562,13 @@ class BP_Activity_Activity {
 			$where_conditions['spam_sql'] = 'a.is_spam = 1';
 		}
 
+		if ( ! empty( $r['privacy'] ) ) {
+			$privacy_sql = self::get_in_operator_sql( 'a.privacy', $r['privacy'] );
+			if ( $privacy_sql ) {
+				$where_conditions['privacy_sql'] = $privacy_sql;
+			}
+		}
+
 		// Searching.
 		if ( $r['search_terms'] ) {
 			$search_terms_like              = '%' . bp_esc_like( $r['search_terms'] ) . '%';
@@ -592,6 +611,7 @@ class BP_Activity_Activity {
 			case 'mptt_left':
 			case 'mptt_right':
 			case 'is_spam':
+			case 'privacy':
 				break;
 
 			default:
@@ -933,6 +953,7 @@ class BP_Activity_Activity {
 					$activity->mptt_left         = (int) $activity->mptt_left;
 					$activity->mptt_right        = (int) $activity->mptt_right;
 					$activity->is_spam           = (int) $activity->is_spam;
+					$activity->privacy           = isset( $activity->privacy ) ? (string) $activity->privacy : 'public';
 				}
 
 				$activities[] = $activity;
@@ -954,6 +975,7 @@ class BP_Activity_Activity {
 				$activity->mptt_left         = (int) $activity->mptt_left;
 				$activity->mptt_right        = (int) $activity->mptt_right;
 				$activity->is_spam           = (int) $activity->is_spam;
+				$activity->privacy           = isset( $activity->privacy ) ? (string) $activity->privacy : 'public';
 
 				$activities[] = $activity;
 			}

--- a/src/bp-activity/classes/class-bp-activity-query.php
+++ b/src/bp-activity/classes/class-bp-activity-query.php
@@ -47,7 +47,7 @@ class BP_Activity_Query extends BP_Recursive_Query {
 	 */
 	public $db_columns = array(
 		'id', 'user_id', 'component', 'type', 'action', 'content', 'primary_link',
-		'item_id', 'secondary_item_id', 'hide_sitewide', 'is_spam',
+		'item_id', 'secondary_item_id', 'hide_sitewide', 'is_spam', 'privacy',
 	);
 
 	/**

--- a/src/bp-activity/classes/class-bp-activity-rest-controller.php
+++ b/src/bp-activity/classes/class-bp-activity-rest-controller.php
@@ -895,6 +895,7 @@ class BP_Activity_REST_Controller extends WP_REST_Controller {
 			'status'            => $activity->is_spam ? 'spam' : 'published',
 			'title'             => $activity->action,
 			'type'              => $activity->type,
+			'privacy'           => isset( $activity->privacy ) ? (string) $activity->privacy : 'public',
 			'hidden'            => (bool) $activity->hide_sitewide,
 			'favorited'         => in_array( $activity->id, $this->get_user_favorites(), true ),
 		);
@@ -1069,6 +1070,17 @@ class BP_Activity_REST_Controller extends WP_REST_Controller {
 			}
 
 			$prepared_activity->hide_sitewide = $is_hidden;
+		}
+
+		// Activity privacy.
+		if ( ! empty( $schema['properties']['privacy'] ) ) {
+			$privacy = $request->get_param( 'privacy' );
+
+			if ( ! is_null( $privacy ) ) {
+				$prepared_activity->privacy = $privacy;
+			} elseif ( isset( $activity->privacy ) ) {
+				$prepared_activity->privacy = $activity->privacy;
+			}
 		}
 
 		/**
@@ -1417,6 +1429,14 @@ class BP_Activity_REST_Controller extends WP_REST_Controller {
 						'context'     => array( 'edit', 'embed' ),
 						'description' => __( 'Whether the activity object should be sitewide hidden or not.', 'buddypress' ),
 						'type'        => 'boolean',
+					),
+					'privacy'           => array(
+						'context'     => array( 'view', 'edit', 'embed' ),
+						'description' => __( 'The privacy level of the activity object.', 'buddypress' ),
+						'type'        => 'string',
+						'arg_options' => array(
+							'sanitize_callback' => 'sanitize_text_field',
+						),
 					),
 					'favorited'         => array(
 						'context'     => array( 'view', 'edit', 'embed' ),

--- a/src/bp-core/admin/bp-core-admin-schema.php
+++ b/src/bp-core/admin/bp-core-admin-schema.php
@@ -138,6 +138,7 @@ function bp_core_install_activity_streams() {
 				mptt_left int(11) NOT NULL DEFAULT 0,
 				mptt_right int(11) NOT NULL DEFAULT 0,
 				is_spam tinyint(1) NOT NULL DEFAULT 0,
+				privacy varchar(75) NOT NULL DEFAULT 'public',
 				KEY date_recorded (date_recorded),
 				KEY user_id (user_id),
 				KEY item_id (item_id),
@@ -147,7 +148,8 @@ function bp_core_install_activity_streams() {
 				KEY mptt_left (mptt_left),
 				KEY mptt_right (mptt_right),
 				KEY hide_sitewide (hide_sitewide),
-				KEY is_spam (is_spam)
+				KEY is_spam (is_spam),
+				KEY privacy (privacy)
 			) {$charset_collate};";
 
 	$sql[] = "CREATE TABLE {$bp_prefix}bp_activity_meta (

--- a/src/bp-groups/bp-groups-activity.php
+++ b/src/bp-groups/bp-groups-activity.php
@@ -529,6 +529,7 @@ function groups_record_activity( $args = '' ) {
 			'secondary_item_id' => false,
 			'recorded_time'     => bp_core_current_time(),
 			'hide_sitewide'     => $hide_sitewide,
+			'privacy'           => 'public',
 			'error_type'        => 'bool',
 		),
 		'groups_record_activity'
@@ -550,6 +551,7 @@ function groups_record_activity( $args = '' ) {
  *                            ID of the logged-in user.
  *     @type int    $group_id Optional. ID of the group to be affiliated with the
  *                            update. Default: ID of the current group.
+ *     @type string $privacy  Optional. Activity privacy value. Default: 'public'.
  * }
  * @return WP_Error|bool|int Returns the ID of the new activity item on success, or false on failure.
  */
@@ -562,6 +564,7 @@ function groups_post_update( $args = '' ) {
 			'content'    => false,
 			'user_id'    => bp_loggedin_user_id(),
 			'group_id'   => 0,
+			'privacy'    => 'public',
 			'error_type' => 'bool',
 		),
 		'groups_post_update'
@@ -610,6 +613,7 @@ function groups_post_update( $args = '' ) {
 		'content'    => $content_filtered,
 		'type'       => 'activity_update',
 		'item_id'    => $group_id,
+		'privacy'    => $r['privacy'],
 		'error_type' => $r['error_type'],
 	) );
 

--- a/src/class-buddypress.php
+++ b/src/class-buddypress.php
@@ -461,7 +461,7 @@ class BuddyPress {
 		/** Versions */
 
 		$this->version    = '15.0.0-alpha';
-		$this->db_version = 13906;
+		$this->db_version = 13907;
 
 		/** Loading */
 


### PR DESCRIPTION
Add `privacy` as a core activity field across schema, model persistence, query APIs, helper write paths, and REST serialization/input handling, so addons can rely on a single native storage/query contract instead of post-save double writes.

Trac ticket: https://buddypress.trac.wordpress.org/ticket/9327

Schema + upgrade gating:
- `bp_core_install_activity_streams()` now defines:
  - `privacy varchar(75) NOT NULL DEFAULT 'public'`
  - `KEY privacy (privacy)`
- Bump BuddyPress DB version in `class-buddypress.php` (`13906` -> `13907`) so schema upgrades run through normal update flow.

Activity model (`BP_Activity_Activity`):
- Add class property default: `privacy = 'public'`.
- Hydrate `privacy` in `populate()` and both `get_activity_data()` paths (cached + uncached) to keep object shape consistent.
- Add save-time filter hook:
  - `bp_activity_privacy_before_save`
- Persist `privacy` in both SQL branches:
  - UPDATE includes `privacy = %s`
  - INSERT includes `privacy` column/value
- Extend `get()`:
  - new arg default: `'privacy' => false`
  - optional WHERE constraint via `a.privacy IN (...)`
  - allow ordering by `privacy` in `order_by` whitelist.

Write-path parity (`bp_activity_add` + helpers):
- `bp_activity_add()`:
  - add parsed arg default `'privacy' => 'public'`
  - assign `$activity->privacy` before save
  - docblock updated
- `bp_activity_post_update()`:
  - accept/pass `privacy` through helper payload to `bp_activity_add()`
  - docblock updated
- Groups helper path:
  - `groups_record_activity()` default includes `privacy`
  - `groups_post_update()` accepts/passes `privacy`
  - docblock updated

Query allowlist:
- Add `'privacy'` to `BP_Activity_Query::$db_columns` so `filter_query` clauses using `column => 'privacy'` are validated and applied.

REST activity endpoint:
- `prepare_item_for_response()` now includes `privacy` in response data.
- `prepare_item_for_database()` accepts/propagates request `privacy` (with fallback to existing activity value on updates).
- `get_item_schema()` adds `privacy` property (string) with contexts and sanitize callback (`sanitize_text_field`).

Verification performed:
- `php -l` passed for all touched PHP files.
- Local site runtime checks confirmed:
  - direct `bp_activity_add()` persists privacy
  - helper branches (`bp_activity_post_update`, groups update flow) persist privacy
  - `BP_Activity_Activity::get( [ 'privacy' => ... ] )` filters correctly
  - `filter_query` with `column => privacy` works
  - REST create/update branches persist + return `privacy`
- Note: local environment had downgraded DB-version state during testing; runtime behavior checks still passed after schema parity adjustments.