### PR TITLE
Blogs: Respect custom alt text when using site icon avatars

### DIFF
--- a/src/bp-blogs/bp-blogs-template.php
+++ b/src/bp-blogs/bp-blogs-template.php
@@ -466,7 +466,7 @@ function bp_blog_avatar( $args = '' ) {
 					esc_url( $site_icon ),
 					esc_attr( "{$r['class']} avatar-{$size}" ),
 					esc_attr( $size ),
-					esc_attr( $alt_attribute )
+					esc_attr( $r['alt'] )
 				);
 			}
 		}

--- a/tests/phpunit/testcases/blogs/template.php
+++ b/tests/phpunit/testcases/blogs/template.php
@@ -407,6 +407,7 @@ class BP_Tests_Blogs_Template extends BP_UnitTestCase {
 		$blogs_template = $reset_blogs_template;
 
 		$this->assertTrue( false !== strpos( $avatar, BP_TESTS_DIR . 'assets/upside-down.jpg' ) );
+		$this->assertTrue( false !== strpos( $avatar, 'alt="test"' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes [](https://buddypress.trac.wordpress.org/ticket/9331)

When a blog has a site icon, `bp_get_blog_avatar()` generated the `<img>` alt attribute from `$alt_attribute` instead of parsed args (`$r['alt']`), so custom alt text passed by callers was ignored in the site-icon path.

This change switches the site-icon markup to use `$r['alt']`. Default behavior is unchanged because `$r['alt']` already defaults to `$alt_attribute`.

Tests:
- Extend `BP_Tests_Blogs_Template::test_bp_get_blog_avatar_has_site_icon()` to assert `alt="test"` is present.
