### PR TITLE
Add PHP 8 compatibility and improve type safety

### DIFF
--- a/src/bp-activity/classes/class-bp-activity-template.php
+++ b/src/bp-activity/classes/class-bp-activity-template.php
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0
  */
+#[AllowDynamicProperties]
 class BP_Activity_Template {
 
 	/**

--- a/src/bp-blogs/classes/class-bp-blogs-template.php
+++ b/src/bp-blogs/classes/class-bp-blogs-template.php
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * Responsible for loading a group of blogs into a loop for display.
  */
+#[AllowDynamicProperties]
 class BP_Blogs_Template {
 
 	/**

--- a/src/bp-core/bp-core-filters.php
+++ b/src/bp-core/bp-core-filters.php
@@ -1113,6 +1113,10 @@ function bp_core_filter_edit_post_link( $edit_link = '', $post_id = 0 ) {
  * @return string
  */
 function bp_core_add_loading_lazy_attribute( $content = '' ) {
+	if ( ! is_string( $content ) || '' === $content ) {
+		return $content;
+	}
+
 	if ( false === strpos( $content, '<img ' ) && false === strpos( $content, '<iframe ' ) ) {
 		return $content;
 	}

--- a/src/bp-core/bp-core-functions.php
+++ b/src/bp-core/bp-core-functions.php
@@ -466,7 +466,7 @@ function bp_sanitize_pagination_arg( $page_arg = '', $page = 1 ) {
  * @return string The sanitized value 'DESC' or 'ASC'.
  */
 function bp_esc_sql_order( $order = '' ) {
-	$order = strtoupper( trim( $order ) );
+	$order = strtoupper( trim( (string) $order ) );
 	return 'DESC' === $order ? 'DESC' : 'ASC';
 }
 

--- a/src/bp-core/bp-core-rewrites.php
+++ b/src/bp-core/bp-core-rewrites.php
@@ -339,7 +339,7 @@ function bp_rewrites_get_member_data( $request = '' ) {
 			$request = $GLOBALS['wp']->request;
 		}
 
-		$request_chunks = explode( '/', ltrim( $request, '/' ) );
+		$request_chunks = explode( '/', ltrim( (string) $request, '/' ) );
 		$member_chunk   = reset( $request_chunks );
 
 		// Try to get an existing member to eventually reset the WP Query.

--- a/src/bp-core/classes/class-bp-button.php
+++ b/src/bp-core/classes/class-bp-button.php
@@ -45,6 +45,7 @@ defined( 'ABSPATH' ) || exit;
  *     @type string      $link_title        Deprecated. Use $button_attr and set 'title' as array key.
  * }
  */
+#[AllowDynamicProperties]
 class BP_Button {
 
 	/** Button properties *****************************************************/

--- a/src/bp-core/classes/class-bp-core-nav.php
+++ b/src/bp-core/classes/class-bp-core-nav.php
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 2.6.0
  */
+#[AllowDynamicProperties]
 class BP_Core_Nav {
 
 	/**

--- a/src/bp-core/classes/class-bp-core-user.php
+++ b/src/bp-core/classes/class-bp-core-user.php
@@ -23,6 +23,7 @@ defined( 'ABSPATH' ) || exit;
  *    $user_status = $user->status;
  *    etc.
  */
+#[AllowDynamicProperties]
 class BP_Core_User {
 
 	/**

--- a/src/bp-core/classes/class-bp-theme-compat.php
+++ b/src/bp-core/classes/class-bp-theme-compat.php
@@ -34,6 +34,7 @@ defined( 'ABSPATH' ) || exit;
  *     @type string $url     Base URL of the theme.
  * }
  */
+#[AllowDynamicProperties]
 class BP_Theme_Compat {
 
 	/**

--- a/src/bp-core/classes/class-bp-user-query.php
+++ b/src/bp-core/classes/class-bp-user-query.php
@@ -63,6 +63,7 @@ defined( 'ABSPATH' ) || exit;
  *                                                  count query.
  * }
  */
+#[AllowDynamicProperties]
 class BP_User_Query {
 
 	/** Variables *************************************************************/

--- a/src/bp-groups/classes/class-bp-group-extension.php
+++ b/src/bp-groups/classes/class-bp-group-extension.php
@@ -90,6 +90,7 @@ if ( class_exists( 'BP_Group_Extension', false ) ) {
  *
  * @since 1.1.0
  */
+#[AllowDynamicProperties]
 class BP_Group_Extension {
 
 	/** Public ************************************************************/

--- a/src/bp-groups/classes/class-bp-groups-group-members-template.php
+++ b/src/bp-groups/classes/class-bp-groups-group-members-template.php
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0
  */
+#[AllowDynamicProperties]
 class BP_Groups_Group_Members_Template {
 
 	/**

--- a/src/bp-groups/classes/class-bp-groups-template.php
+++ b/src/bp-groups/classes/class-bp-groups-template.php
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.2.0
  */
+#[AllowDynamicProperties]
 class BP_Groups_Template {
 
 	/**

--- a/src/bp-members/classes/class-bp-core-members-template.php
+++ b/src/bp-members/classes/class-bp-core-members-template.php
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0
  */
+#[AllowDynamicProperties]
 class BP_Core_Members_Template {
 
 	/**

--- a/src/bp-notifications/classes/class-bp-notifications-template.php
+++ b/src/bp-notifications/classes/class-bp-notifications-template.php
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.9.0
  */
+#[AllowDynamicProperties]
 class BP_Notifications_Template {
 
 	/**

--- a/src/bp-templates/bp-legacy/buddypress/assets/_attachments/avatars/crop.php
+++ b/src/bp-templates/bp-legacy/buddypress/assets/_attachments/avatars/crop.php
@@ -14,11 +14,11 @@
 ?>
 <script id="tmpl-bp-avatar-item" type="text/html">
 	<div id="avatar-to-crop">
-		<img src="{{{data.url}}}"/>
+		<img src="{{{data.url}}}" alt="<?php esc_attr_e( 'Avatar preview', 'buddypress' ); ?>"/>
 	</div>
 	<div class="avatar-crop-management">
 		<div id="avatar-crop-pane" class="avatar" style="width:{{data.full_w}}px; height:{{data.full_h}}px">
-			<img src="{{{data.url}}}" id="avatar-crop-preview"/>
+			<img src="{{{data.url}}}" id="avatar-crop-preview" alt="<?php esc_attr_e( 'Avatar crop preview', 'buddypress' ); ?>"/>
 		</div>
 		<div id="avatar-crop-actions">
 			<a class="button avatar-crop-submit" href="#"><?php esc_html_e( 'Crop Image', 'buddypress' ); ?></a>

--- a/src/bp-templates/bp-legacy/buddypress/assets/_attachments/avatars/recycle.php
+++ b/src/bp-templates/bp-legacy/buddypress/assets/_attachments/avatars/recycle.php
@@ -37,7 +37,7 @@
 	<td>
 		<label for="avatar_{{data.id}}">
 			<input type="radio" name="avatar_id" value="{{data.id}}" id="avatar_{{data.id}}" class="<?php echo esc_attr( is_admin() && ! wp_doing_ajax() ? 'screen-reader-text' : 'bp-screen-reader-text' ); ?>"/>
-			<img src="{{{data.url}}}" id="{{data.id}}" class="avatar" width="<?php echo esc_attr( bp_core_avatar_thumb_width() ); ?>" height="<?php echo esc_attr( bp_core_avatar_thumb_height() ); ?>"/>
+			<img src="{{{data.url}}}" id="{{data.id}}" class="avatar" width="<?php echo esc_attr( bp_core_avatar_thumb_width() ); ?>" height="<?php echo esc_attr( bp_core_avatar_thumb_height() ); ?>" alt="<?php esc_attr_e( 'Recycled avatar preview', 'buddypress' ); ?>"/>
 		</label>
 	</td>
 	<td>

--- a/src/bp-templates/bp-nouveau/buddypress/assets/_attachments/avatars/crop.php
+++ b/src/bp-templates/bp-nouveau/buddypress/assets/_attachments/avatars/crop.php
@@ -11,11 +11,11 @@
 ?>
 <script id="tmpl-bp-avatar-item" type="text/html">
 	<div id="avatar-to-crop">
-		<img src="{{{data.url}}}"/>
+		<img src="{{{data.url}}}" alt="<?php esc_attr_e( 'Avatar preview', 'buddypress' ); ?>"/>
 	</div>
 	<div class="avatar-crop-management">
 		<div id="avatar-crop-pane" class="avatar" style="width:{{data.full_w}}px; height:{{data.full_h}}px">
-			<img src="{{{data.url}}}" id="avatar-crop-preview"/>
+			<img src="{{{data.url}}}" id="avatar-crop-preview" alt="<?php esc_attr_e( 'Avatar crop preview', 'buddypress' ); ?>"/>
 		</div>
 		<div id="avatar-crop-actions">
 			<button type="button" class="button avatar-crop-submit"><?php echo esc_html_x( 'Crop Image', 'button', 'buddypress' ); ?></button>

--- a/src/bp-templates/bp-nouveau/buddypress/assets/_attachments/avatars/recycle.php
+++ b/src/bp-templates/bp-nouveau/buddypress/assets/_attachments/avatars/recycle.php
@@ -37,7 +37,7 @@
 	<td>
 		<label for="avatar_{{data.id}}">
 			<input type="radio" name="avatar_id" value="{{data.id}}" id="avatar_{{data.id}}" class="<?php echo esc_attr( is_admin() && ! wp_doing_ajax() ? 'screen-reader-text' : 'bp-screen-reader-text' ); ?>"/>
-			<img src="{{{data.url}}}" id="{{data.id}}" class="avatar" width="<?php echo esc_attr( bp_core_avatar_thumb_width() ); ?>" height="<?php echo esc_attr( bp_core_avatar_thumb_height() ); ?>"/>
+			<img src="{{{data.url}}}" id="{{data.id}}" class="avatar" width="<?php echo esc_attr( bp_core_avatar_thumb_width() ); ?>" height="<?php echo esc_attr( bp_core_avatar_thumb_height() ); ?>" alt="<?php esc_attr_e( 'Recycled avatar preview', 'buddypress' ); ?>"/>
 		</label>
 	</td>
 	<td>

--- a/src/bp-xprofile/bp-xprofile-filters.php
+++ b/src/bp-xprofile/bp-xprofile-filters.php
@@ -752,11 +752,12 @@ function _bp_xprofile_signup_do_backcompat( $args = array() ) {
  * @param string $template_name The needed template name.
  */
 function _bp_xprofile_signup_check_backcompat( $template = '', $template_name = '' ) {
-	if ( 'members/register.php' !== $template_name ) {
+	if ( 'members/register.php' !== $template_name || empty( $template ) || ! is_string( $template ) ) {
 		return;
 	}
 
-	if ( 0 !== strpos( $template, buddypress()->theme_compat->theme->dir ) ) {
+	$theme_dir = isset( buddypress()->theme_compat->theme->dir ) ? buddypress()->theme_compat->theme->dir : '';
+	if ( $theme_dir && 0 !== strpos( $template, $theme_dir ) ) {
 		add_filter( 'bp_after_has_profile_parse_args', '_bp_xprofile_signup_do_backcompat', 100 );
 	}
 }

--- a/src/bp-xprofile/classes/class-bp-xprofile-field-type-url.php
+++ b/src/bp-xprofile/classes/class-bp-xprofile-field-type-url.php
@@ -187,9 +187,10 @@ class BP_XProfile_Field_Type_URL extends BP_XProfile_Field_Type {
 	 * @return string URL converted to a link.
 	 */
 	public static function display_filter( $field_value, $field_id = '' ) {
-		$link      = wp_strip_all_tags( $field_value );
-		$no_scheme = preg_replace( '#^https?://#', '', rtrim( $link, '/' ) );
-		$url_text  = str_replace( $link, $no_scheme, $field_value );
+		$field_value = (string) $field_value;
+		$link        = wp_strip_all_tags( $field_value );
+		$no_scheme   = preg_replace( '#^https?://#', '', rtrim( $link, '/' ) );
+		$url_text    = str_replace( $link, $no_scheme, $field_value );
 		return '<a href="' . esc_url( $field_value ) . '" rel="nofollow">' . esc_html( $url_text ) . '</a>';
 	}
 }


### PR DESCRIPTION
Apply #[AllowDynamicProperties] attribute to classes using dynamic properties for PHP 8.2+ compatibility. Add type casting and validation for string parameters to prevent type-related warnings. Add missing alt attributes to avatar images for improved accessibility.

<!--
Hi there! Thanks for contributing to BuddyPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the BuddyPress Core Trac instance (https://buddypress.trac.wordpress.org/), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://codex.buddypress.org/participate-and-contribute/contribute-with-code/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

### Description of Changes

This Pull Request addresses PHP 8+ compatibility issues and improves accessibility across the BuddyPress plugin:

1. **PHP 8.2+ Dynamic Properties Compatibility**:
   Added `#[AllowDynamicProperties]` attribute to core base classes, query classes, and template loops to prevent runtime `Creation of dynamic property is deprecated` notices in PHP 8.2+:
   - `BP_Activity_Template` (`src/bp-activity/classes/class-bp-activity-template.php`)
   - `BP_Groups_Template` (`src/bp-groups/classes/class-bp-groups-template.php`)
   - `BP_Core_Members_Template` (`src/bp-members/classes/class-bp-core-members-template.php`)
   - `BP_Groups_Group_Members_Template` (`src/bp-groups/classes/class-bp-groups-group-members-template.php`)
   - `BP_Blogs_Template` (`src/bp-blogs/classes/class-bp-blogs-template.php`)
   - `BP_Notifications_Template` (`src/bp-notifications/classes/class-bp-notifications-template.php`)
   - `BP_Core_User` (`src/bp-core/classes/class-bp-core-user.php`)
   - `BP_Button` (`src/bp-core/classes/class-bp-button.php`)
   - `BP_Theme_Compat` (`src/bp-core/classes/class-bp-theme-compat.php`)
   - `BP_Core_Nav` (`src/bp-core/classes/class-bp-core-nav.php`)
   - `BP_Group_Extension` (`src/bp-groups/classes/class-bp-group-extension.php`)
   - `BP_User_Query` (`src/bp-core/classes/class-bp-user-query.php`)

2. **PHP 8.1+ Type Safety & Null Parameter Handling**:
   Added explicit type casting and null checks for parameters before passing them to built-in string functions (`trim()`, `ltrim()`, `strpos()`, `wp_strip_all_tags()`) to prevent PHP 8.1+ deprecation warnings when parameters are empty or null:
   - `bp_esc_sql_order()` (`src/bp-core/bp-core-functions.php`)
   - `bp_core_add_loading_lazy_attribute()` (`src/bp-core/bp-core-filters.php`)
   - `_bp_xprofile_signup_check_backcompat()` (`src/bp-xprofile/bp-xprofile-filters.php`)
   - `BP_XProfile_Field_Type_Url::display_filter()` (`src/bp-xprofile/classes/class-bp-xprofile-field-type-url.php`)
   - `bp_rewrites_get_member_data()` (`src/bp-core/bp-core-rewrites.php`)

3. **Accessibility (a11y) Enhancements**:
   Added missing localized `alt` attributes to avatar crop and recycle image elements in both BP Nouveau and BP Legacy template packs to ensure full screen-reader accessibility:
   - `src/bp-templates/bp-nouveau/buddypress/assets/_attachments/avatars/crop.php`
   - `src/bp-templates/bp-nouveau/buddypress/assets/_attachments/avatars/recycle.php`
   - `src/bp-templates/bp-legacy/buddypress/assets/_attachments/avatars/crop.php`
   - `src/bp-templates/bp-legacy/buddypress/assets/_attachments/avatars/recycle.php`

Trac ticket: https://buddypress.trac.wordpress.org/

---
**This Pull Request is for code review only. Please keep all other discussion in the BuddyPress Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the WordPress Core Handbook for more details.**
